### PR TITLE
fix: delegate startup timeout setting to wait strategy

### DIFF
--- a/src/generic-container.ts
+++ b/src/generic-container.ts
@@ -61,7 +61,7 @@ export class GenericContainer implements TestContainer {
     const hostPortCheck = new HostPortCheck();
     const internalPortCheck = new InternalPortCheck(container, this.dockerClient);
     const waitStrategy = new HostPortWaitStrategy(this.dockerClient, hostPortCheck, internalPortCheck);
-    await waitStrategy.waitUntilReady(containerState);
+    await waitStrategy.withStartupTimeout(this.startupTimeout).waitUntilReady(containerState);
   }
 }
 


### PR DESCRIPTION
I have problem with an image inside a Gitlab CI that requires more than 10 seconds (default `startupTimeout`) to start.

Even though `GenericContainer` exposes a method `withStartupTimeout`, it is not delegated to the `WaitStrategy`(HostPortWaitStrategy) and thus ignored.

  This MR adds a simple fix for that.