### PR TITLE
Add a command parameter to DockerClient.create()

### DIFF
--- a/src/docker-client.ts
+++ b/src/docker-client.ts
@@ -21,7 +21,7 @@ type DockerodeExposedPorts = { [port in PortString]: {} };
 
 export interface DockerClient {
   pull(repoTag: RepoTag): Promise<void>;
-  create(repoTag: RepoTag, env: Env, boundPorts: BoundPorts): Promise<Container>;
+  create(repoTag: RepoTag, env: Env, boundPorts: BoundPorts, cmd?: Command[]): Promise<Container>;
   start(container: Container): Promise<void>;
   exec(container: Container, command: Command[]): Promise<ExecResult>;
   fetchRepoTags(): Promise<RepoTag[]>;
@@ -37,13 +37,14 @@ export class DockerodeClient implements DockerClient {
     await streamToArray(stream);
   }
 
-  public async create(repoTag: RepoTag, env: Env, boundPorts: BoundPorts): Promise<Container> {
+  public async create(repoTag: RepoTag, env: Env, boundPorts: BoundPorts, cmd: Command[] = []): Promise<Container> {
     log.info(`Creating container for image: ${repoTag}`);
 
     const dockerodeContainer = await this.dockerode.createContainer({
       Image: repoTag.toString(),
       Env: this.getEnv(env),
       ExposedPorts: this.getExposedPorts(boundPorts),
+      Cmd: cmd,
       HostConfig: {
         PortBindings: this.getPortBindings(boundPorts)
       }

--- a/src/docker-client.ts
+++ b/src/docker-client.ts
@@ -21,7 +21,7 @@ type DockerodeExposedPorts = { [port in PortString]: {} };
 
 export interface DockerClient {
   pull(repoTag: RepoTag): Promise<void>;
-  create(repoTag: RepoTag, env: Env, boundPorts: BoundPorts, cmd?: Command[]): Promise<Container>;
+  create(repoTag: RepoTag, env: Env, boundPorts: BoundPorts, cmd: Command[]): Promise<Container>;
   start(container: Container): Promise<void>;
   exec(container: Container, command: Command[]): Promise<ExecResult>;
   fetchRepoTags(): Promise<RepoTag[]>;
@@ -37,7 +37,7 @@ export class DockerodeClient implements DockerClient {
     await streamToArray(stream);
   }
 
-  public async create(repoTag: RepoTag, env: Env, boundPorts: BoundPorts, cmd: Command[] = []): Promise<Container> {
+  public async create(repoTag: RepoTag, env: Env, boundPorts: BoundPorts, cmd: Command[]): Promise<Container> {
     log.info(`Creating container for image: ${repoTag}`);
 
     const dockerodeContainer = await this.dockerode.createContainer({

--- a/src/generic-container.test.ts
+++ b/src/generic-container.test.ts
@@ -45,4 +45,14 @@ describe("GenericContainer", () => {
 
     await container.stop();
   });
+
+  it("should allow passing in custom parameters for mysql", async () => {
+    const container = await new GenericContainer("mysql")
+      .withCmd(["--port=3307"])
+      .withEnv("MYSQL_ROOT_PASSWORD", "my-root-pw")
+      .withExposedPorts(3307)
+      .start();
+
+    await container.stop();
+  });
 });

--- a/src/generic-container.ts
+++ b/src/generic-container.ts
@@ -2,7 +2,7 @@ import { Duration, TemporalUnit } from "node-duration";
 import { BoundPorts } from "./bound-ports";
 import { Container } from "./container";
 import { ContainerState } from "./container-state";
-import { DockerClient, Env, EnvKey, EnvValue } from "./docker-client";
+import { Command, DockerClient, Env, EnvKey, EnvValue } from "./docker-client";
 import { DockerClientFactory, DockerodeClientFactory, Host } from "./docker-client-factory";
 import log from "./logger";
 import { Port } from "./port";
@@ -19,6 +19,7 @@ export class GenericContainer implements TestContainer {
   private env: Env = {};
   private ports: Port[] = [];
   private startupTimeout: Duration = new Duration(30_000, TemporalUnit.MILLISECONDS);
+  private cmd: Command[] = [];
 
   constructor(
     readonly image: Image,
@@ -35,13 +36,18 @@ export class GenericContainer implements TestContainer {
     }
 
     const boundPorts = await new PortBinder().bind(this.ports);
-    const container = await this.dockerClient.create(this.repoTag, this.env, boundPorts);
+    const container = await this.dockerClient.create(this.repoTag, this.env, boundPorts, this.cmd);
     await this.dockerClient.start(container);
     const inspectResult = await container.inspect();
     const containerState = new ContainerState(inspectResult);
     await this.waitForContainer(container, containerState, boundPorts);
 
     return new StartedGenericContainer(container, this.dockerClient.getHost(), boundPorts);
+  }
+
+  public withCmd(cmd: Command[]) {
+    this.cmd = cmd;
+    return this;
   }
 
   public withEnv(key: EnvKey, value: EnvValue): TestContainer {


### PR DESCRIPTION
Hi, 

In this little PR I've added the ability to provide a (optional) command when creating a new container. 
The reason is that sometimes you want to start the service inside a container with specific parameters. 

Changes in a nutshell: 
* `DockerCLient.create(repoTag: RepoTag, env: Env, boundPorts: BoundPorts, cmd: Command[] = []): Promise<Container>;` --> added new `cmd` parameter

Extending this function with the new parameter is not a breaking change as `cmd` is optional and defaults to an empty array. 

However, the default parameter might become a problem if more parameters are added: 
the underlying library (Dockerode) allows to pass in various options in `createContainer()`, i.e.:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/1957e4cb6a5ed54ca310f015e5a61411bb713da7/types/dockerode/index.d.ts#L836

In the future, if you would like to allow more (optional) parameters to be added, I would propose going for a different approach as described in here: https://www.csgpro.com/blog/2016/08/typescript-default-parameters-and-destructuring-as-a-substitute-for-named-parameters

Let me know if you have any suggestions for improvements.
Cheers