### PR TITLE
Implement LogWaitStrategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Ordinarily Testcontainers will wait for up to 60 seconds for the container's map
 If the default 60s timeout is not sufficient, it can be altered with the `withStartupTimeout()` method:
 
 ```javascript
-import { Duration, TemporalUnit } from 'node-duration';
+const { Duration, TemporalUnit } = require("node-duration");
 
 const container = await new GenericContainer("redis")
     .withExposedPorts(6379)
@@ -65,6 +65,8 @@ In some situations a container's log output is a simple way to determine if it i
 wait for a `Ready` message in the container's logs as follows:
 
 ```javascript
+const { GenericContainer, Wait } = require("testcontainers");
+
 const container = await new GenericContainer("redis")
     .withExposedPorts(6379)
     .withWaitStrategy(Wait.forLogMessage("Ready to accept connections"))

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ const { GenericContainer } = require("testcontainers");
 
 (async () => {
   const container = await new GenericContainer("redis")
-    .withEnv("KEY", "VALUE")
-    .withExposedPorts(6379)
-    .start();
+      .withEnv("KEY", "VALUE")
+      .withExposedPorts(6379)
+      .start();
 
   const redisClient = redis.createClient(
       container.getMappedPort(6379),
@@ -43,4 +43,30 @@ const { GenericContainer } = require("testcontainers");
 
   await container.stop();
 })();
+```
+
+## Wait Strategies
+
+Ordinarily Testcontainers will wait for up to 60 seconds for the container's mapped network ports to start listening. 
+If the default 60s timeout is not sufficient, it can be altered with the `withStartupTimeout()` method:
+
+```javascript
+import { Duration, TemporalUnit } from 'node-duration';
+
+const container = await new GenericContainer("redis")
+    .withExposedPorts(6379)
+    .withStartupTimeout(new Duration(100, TemporalUnit.SECONDS))
+    .start();
+```
+
+### Log output Wait Strategy
+
+In some situations a container's log output is a simple way to determine if it is ready or not. For example, we can 
+wait for a `Ready' message in the container's logs as follows:
+
+```javascript
+const container = await new GenericContainer("redis")
+    .withExposedPorts(6379)
+    .withWaitStrategy(Wait.forLogMessage("Ready to accept connections"))
+    .start();
 ```

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ const container = await new GenericContainer("redis")
 ### Log output Wait Strategy
 
 In some situations a container's log output is a simple way to determine if it is ready or not. For example, we can 
-wait for a `Ready' message in the container's logs as follows:
+wait for a `Ready` message in the container's logs as follows:
 
 ```javascript
 const container = await new GenericContainer("redis")

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,15 @@
         }
       }
     },
+    "@types/byline": {
+      "version": "4.2.31",
+      "resolved": "https://registry.npmjs.org/@types/byline/-/byline-4.2.31.tgz",
+      "integrity": "sha1-DmH8ucA+BH0hxEllVMcRYperYM0=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/debug": {
       "version": "0.0.31",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.31.tgz",
@@ -1090,6 +1099,11 @@
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
+    },
+    "byline": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+      "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
     },
     "cache-base": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "format": "prettier --write package.json testcontainer.Dockerfile.js src/**/*.ts"
   },
   "dependencies": {
+    "byline": "^5.0.0",
     "debug": "^4.1.1",
     "dockerode": "^2.5.8",
     "get-port": "^4.1.0",
@@ -37,6 +38,7 @@
     "stream-to-array": "^2.3.0"
   },
   "devDependencies": {
+    "@types/byline": "^4.2.31",
     "@types/debug": "0.0.31",
     "@types/dockerode": "^2.5.10",
     "@types/get-port": "^4.0.1",

--- a/src/container.ts
+++ b/src/container.ts
@@ -30,6 +30,7 @@ export interface Container {
   stop(): Promise<void>;
   remove(): Promise<void>;
   exec(options: ExecOptions): Promise<Exec>;
+  logs(): Promise<NodeJS.ReadableStream>;
   inspect(): Promise<InspectResult>;
 }
 
@@ -60,6 +61,24 @@ export class DockerodeContainer implements Container {
         AttachStderr: options.attachStderr
       })
     );
+  }
+
+  public logs(): Promise<NodeJS.ReadableStream> {
+    return new Promise((resolve, reject) => {
+      const options = {
+        follow: true,
+        stdout: true,
+        stderr: true
+      };
+
+      this.container.logs(options, (err, stream) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(stream);
+        }
+      });
+    });
   }
 
   public async inspect(): Promise<InspectResult> {

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,3 +1,4 @@
+import byline from 'byline';
 import dockerode, { ContainerInspectInfo } from "dockerode";
 import { Command, ExitCode } from "./docker-client";
 import { Port } from "./port";
@@ -75,7 +76,11 @@ export class DockerodeContainer implements Container {
         if (err) {
           reject(err);
         } else {
-          resolve(stream);
+          if (!stream) {
+            reject(new Error('Log stream is undefined'));
+          } else {
+            resolve(byline(stream));
+          }
         }
       });
     });

--- a/src/generic-container.test.ts
+++ b/src/generic-container.test.ts
@@ -1,12 +1,27 @@
 import fetch from "node-fetch";
 import { GenericContainer } from "./generic-container";
+import { Wait } from "./wait";
 
 describe("GenericContainer", () => {
   jest.setTimeout(45000);
 
-  it("should wait until container is ready", async () => {
+  it("should wait for port", async () => {
     const container = await new GenericContainer("cristianrgreco/testcontainer", "1.1.7")
       .withExposedPorts(8080)
+      .start();
+
+    const url = `http://${container.getContainerIpAddress()}:${container.getMappedPort(8080)}`;
+    const response = await fetch(`${url}/hello-world`);
+    expect(response.status).toBe(200);
+
+    await container.stop();
+    await expect(fetch(url)).rejects.toThrowError();
+  });
+
+  it("should wait for log", async () => {
+    const container = await new GenericContainer("cristianrgreco/testcontainer", "1.1.7")
+      .withExposedPorts(8080)
+      .withWaitStrategy(Wait.forLogMessage("Listening on port 8080"))
       .start();
 
     const url = `http://${container.getContainerIpAddress()}:${container.getMappedPort(8080)}`;

--- a/src/generic-container.ts
+++ b/src/generic-container.ts
@@ -10,7 +10,8 @@ import { PortBinder } from "./port-binder";
 import { HostPortCheck, InternalPortCheck } from "./port-check";
 import { Image, RepoTag, Tag } from "./repo-tag";
 import { StartedTestContainer, StoppedTestContainer, TestContainer } from "./test-container";
-import { HostPortWaitStrategy } from "./wait-strategy";
+import { Wait } from "./wait";
+import { HostPortWaitStrategy, WaitStrategy } from "./wait-strategy";
 
 export class GenericContainer implements TestContainer {
   private readonly repoTag: RepoTag;
@@ -18,7 +19,8 @@ export class GenericContainer implements TestContainer {
 
   private env: Env = {};
   private ports: Port[] = [];
-  private startupTimeout: Duration = new Duration(30_000, TemporalUnit.MILLISECONDS);
+  private waitStrategy?: WaitStrategy;
+  private startupTimeout: Duration = new Duration(60_000, TemporalUnit.MILLISECONDS);
 
   constructor(
     readonly image: Image,
@@ -59,6 +61,11 @@ export class GenericContainer implements TestContainer {
     return this;
   }
 
+  public withWaitStrategy(waitStrategy: WaitStrategy): TestContainer {
+    this.waitStrategy = waitStrategy;
+    return this;
+  }
+
   private async hasRepoTagLocally(): Promise<boolean> {
     const repoTags = await this.dockerClient.fetchRepoTags();
     return repoTags.some(repoTag => repoTag.equals(this.repoTag));
@@ -70,11 +77,18 @@ export class GenericContainer implements TestContainer {
     boundPorts: BoundPorts
   ): Promise<void> {
     log.debug("Starting container health checks");
+    const waitStrategy = this.getWaitStrategy(container);
+    await waitStrategy.withStartupTimeout(this.startupTimeout).waitUntilReady(container, containerState, boundPorts);
+    log.debug("Container health checks complete");
+  }
+
+  private getWaitStrategy(container: Container): WaitStrategy {
+    if (this.waitStrategy) {
+      return this.waitStrategy;
+    }
     const hostPortCheck = new HostPortCheck(this.dockerClient.getHost());
     const internalPortCheck = new InternalPortCheck(container, this.dockerClient);
-    const waitStrategy = new HostPortWaitStrategy(this.dockerClient, hostPortCheck, internalPortCheck);
-    await waitStrategy.withStartupTimeout(this.startupTimeout).waitUntilReady(containerState, boundPorts);
-    log.debug("Container health checks complete");
+    return new HostPortWaitStrategy(this.dockerClient, hostPortCheck, internalPortCheck);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { GenericContainer } from "./generic-container";
+export { Wait } from "./wait";

--- a/src/test-container.ts
+++ b/src/test-container.ts
@@ -2,11 +2,13 @@ import { Duration } from "node-duration";
 import { EnvKey, EnvValue } from "./docker-client";
 import { Host } from "./docker-client-factory";
 import { Port } from "./port";
+import { WaitStrategy } from "./wait-strategy";
 
 export interface TestContainer {
   start(): Promise<StartedTestContainer>;
   withEnv(key: EnvKey, value: EnvValue): TestContainer;
   withExposedPorts(...ports: Port[]): TestContainer;
+  withWaitStrategy(waitStrategy: WaitStrategy): TestContainer;
   withStartupTimeout(startupTimeout: Duration): TestContainer;
 }
 

--- a/src/wait-strategy.ts
+++ b/src/wait-strategy.ts
@@ -85,13 +85,13 @@ export class LogWaitStrategy extends AbstractWaitStrategy {
     return new Promise(async (resolve, reject) => {
       const stream = await container.logs();
       stream
-        .on("data", chunk => {
-          if (chunk.toString().includes(this.message)) {
+        .on("data", line => {
+          if (line.toString().includes(this.message)) {
             resolve();
           }
         })
-        .on("err", chunk => {
-          if (chunk.toString().includes(this.message)) {
+        .on("err", line => {
+          if (line.toString().includes(this.message)) {
             resolve();
           }
         })

--- a/src/wait-strategy.ts
+++ b/src/wait-strategy.ts
@@ -81,11 +81,7 @@ export class LogWaitStrategy extends AbstractWaitStrategy {
     super();
   }
 
-  public async waitUntilReady(
-    container: Container,
-    containerState: ContainerState,
-    boundPorts: BoundPorts
-  ): Promise<void> {
+  public async waitUntilReady(container: Container): Promise<void> {
     return new Promise(async (resolve, reject) => {
       const stream = await container.logs();
       stream

--- a/src/wait-strategy.ts
+++ b/src/wait-strategy.ts
@@ -100,7 +100,7 @@ export class LogWaitStrategy extends AbstractWaitStrategy {
           }
         })
         .on("end", () => {
-          reject("stream is at an end");
+          reject();
         });
     });
   }

--- a/src/wait.ts
+++ b/src/wait.ts
@@ -1,0 +1,7 @@
+import { Log, LogWaitStrategy, WaitStrategy } from "./wait-strategy";
+
+export class Wait {
+  public static forLogMessage(message: Log): WaitStrategy {
+    return new LogWaitStrategy(message);
+  }
+}


### PR DESCRIPTION
Addresses #9. Example usage:

```javascript
const container = await new GenericContainer("redis")
    .withExposedPorts(6379)
    .withWaitStrategy(Wait.forLogMessage("Ready to accept connections"))
    .start();
```