### PR TITLE
Add exec support to started containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,25 @@ const { GenericContainer } = require("testcontainers");
 })();
 ```
 
+Running commands inside running container
+
+```javascript
+const path = require('path');
+const { GenericContainer, Wait } = require("testcontainers");
+
+(async () => {
+  const container = await new GenericContainer("mysql")
+      .withEnv("MYSQL_ALLOW_EMPTY_PASSWORD", "true")
+      .withWaitStrategy(Wait.forLogMessage("ready for connections"))
+      .start();
+
+  const { output, exitCode } = await container.exec(["mysql", "--execute", "show databases"]);
+  console.log(output);
+
+  await container.stop();
+})();
+```
+
 ## Wait Strategies
 
 Ordinarily Testcontainers will wait for up to 60 seconds for the container's mapped network ports to start listening. 

--- a/src/docker-client.ts
+++ b/src/docker-client.ts
@@ -18,8 +18,8 @@ type DockerodeEnvironment = string[];
 
 export type BuildContext = string;
 
-type StreamOutput = string;
-type ExecResult = { output: StreamOutput; exitCode: ExitCode };
+export type StreamOutput = string;
+export type ExecResult = { output: StreamOutput; exitCode: ExitCode };
 type DockerodeExposedPorts = { [port in PortString]: {} };
 
 export interface DockerClient {

--- a/src/generic-container.test.ts
+++ b/src/generic-container.test.ts
@@ -83,6 +83,25 @@ describe("GenericContainer", () => {
     await container.stop();
   });
 
+  it("should allow for exec'ing in running container", async () => {
+    const container = await new GenericContainer("mysql")
+      .withEnv("MYSQL_ALLOW_EMPTY_PASSWORD", "true")
+      .withWaitStrategy(Wait.forLogMessage("ready for connections"))
+      .start();
+
+    const { output, exitCode } = await container.exec([
+      "mysql",
+      "-B",
+      "--disable-column-names",
+      "--execute",
+      "show databases"
+    ]);
+    expect(exitCode).toBe(0);
+    expect(output).toContain("performance_schema");
+
+    await container.stop();
+  });
+
   it("should work for couch db", async () => {
     const container = await new GenericContainer("couchdb").withExposedPorts(5984).start();
 

--- a/src/test-container.ts
+++ b/src/test-container.ts
@@ -1,5 +1,5 @@
 import { Duration } from "node-duration";
-import { EnvKey, EnvValue } from "./docker-client";
+import { Command, EnvKey, EnvValue, ExecResult } from "./docker-client";
 import { Host } from "./docker-client-factory";
 import { Port } from "./port";
 import { WaitStrategy } from "./wait-strategy";
@@ -16,6 +16,7 @@ export interface StartedTestContainer {
   stop(): Promise<StoppedTestContainer>;
   getContainerIpAddress(): Host;
   getMappedPort(port: Port): Port;
+  exec(command: Command[]): Promise<ExecResult>;
 }
 
 export interface StoppedTestContainer {}


### PR DESCRIPTION
When testing base images in my CI system, there are times in which I'd like to exec into a container to validate command output. This PR adds that functionality.