### PR TITLE
Add optional name parameter for container creation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,12 @@ const { GenericContainer } = require("testcontainers");
 Running commands inside running container
 
 ```javascript
-const { GenericContainer } = require("testcontainers");
+const { GenericContainer, Wait } = require("testcontainers");
 
 (async () => {
   const container = await new GenericContainer("mysql")
       .withEnv("MYSQL_ALLOW_EMPTY_PASSWORD", "true")
+      .withWaitStrategy(Wait.forLogMessage("ready for connections"))
       .start();
 
   const { output, exitCode } = await container.exec(["mysql", "--execute", "show databases"]);

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,6 +1,6 @@
 import byline from "byline";
 import dockerode, { ContainerInspectInfo } from "dockerode";
-import { Command, ExitCode } from "./docker-client";
+import { Command, ContainerName, ExitCode } from "./docker-client";
 import { Port } from "./port";
 
 type Id = string;
@@ -8,6 +8,7 @@ type Id = string;
 export type InspectResult = {
   internalPorts: Port[];
   hostPorts: Port[];
+  name: ContainerName;
 };
 
 type ExecOptions = {
@@ -90,8 +91,13 @@ export class DockerodeContainer implements Container {
     const inspectResult = await this.container.inspect();
     return {
       hostPorts: this.getHostPorts(inspectResult),
-      internalPorts: this.getInternalPorts(inspectResult)
+      internalPorts: this.getInternalPorts(inspectResult),
+      name: this.getName(inspectResult)
     };
+  }
+
+  private getName(inspectInfo: ContainerInspectInfo): ContainerName {
+    return inspectInfo.Name;
   }
 
   private getInternalPorts(inspectInfo: ContainerInspectInfo): Port[] {

--- a/src/docker-client.ts
+++ b/src/docker-client.ts
@@ -56,8 +56,8 @@ export class DockerodeClient implements DockerClient {
   public async create(options: CreateOptions): Promise<Container> {
     log.info(`Creating container for image: ${options.repoTag}`);
 
-    const containerNameOption = options.name !== undefined ? { name: options.name } : {};
     const dockerodeContainer = await this.dockerode.createContainer({
+      name: options.name,
       Image: options.repoTag.toString(),
       Env: this.getEnv(options.env),
       ExposedPorts: this.getExposedPorts(options.boundPorts),
@@ -65,8 +65,7 @@ export class DockerodeClient implements DockerClient {
       HostConfig: {
         PortBindings: this.getPortBindings(options.boundPorts),
         Tmpfs: options.tmpFs
-      },
-      ...containerNameOption
+      }
     });
 
     return new DockerodeContainer(dockerodeContainer);

--- a/src/generic-container.test.ts
+++ b/src/generic-container.test.ts
@@ -61,6 +61,17 @@ describe("GenericContainer", () => {
     await container.stop();
   });
 
+  it("should set name", async () => {
+    const containerName = "special-test-container";
+    const expectedContainerName = "/special-test-container";
+    const container = await new GenericContainer("cristianrgreco/testcontainer", "1.1.11")
+      .withName(containerName)
+      .start();
+
+    expect(container.getName()).toEqual(expectedContainerName);
+    await container.stop();
+  });
+
   it("should build and start from a Dockerfile", async () => {
     const context = path.resolve(__dirname, "..", "docker");
     const container = await GenericContainer.fromDockerfile(context);

--- a/src/test-container.ts
+++ b/src/test-container.ts
@@ -1,5 +1,5 @@
 import { Duration } from "node-duration";
-import { Command, EnvKey, EnvValue, ExecResult } from "./docker-client";
+import { Command, ContainerName, EnvKey, EnvValue, ExecResult } from "./docker-client";
 import { Host } from "./docker-client-factory";
 import { Port } from "./port";
 import { WaitStrategy } from "./wait-strategy";
@@ -16,6 +16,7 @@ export interface StartedTestContainer {
   stop(): Promise<StoppedTestContainer>;
   getContainerIpAddress(): Host;
   getMappedPort(port: Port): Port;
+  getName(): ContainerName;
   exec(command: Command[]): Promise<ExecResult>;
 }
 


### PR DESCRIPTION
In certain test environments, it may be possible that the `container.stop` may not be called. This could cause zombie containers. So it is nice to somehow keep track of containers created by testcontainers-node. Easiest way could be giving the option of setting container names. 

This PR adds that feature, so when you are running a container, you can set a name. I've tried to stay close to your coding standards, as much as possible. Please do comment if there are any discrepancies.