### PR TITLE
Remove volumes when container is stopped

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -51,7 +51,7 @@ export class DockerodeContainer implements Container {
   }
 
   public remove(): Promise<void> {
-    return this.container.remove();
+    return this.container.remove({ v: true });
   }
 
   public async exec(options: ExecOptions): Promise<Exec> {


### PR DESCRIPTION
Addresses #29 by telling Docker to remove volumes associated with the container by default when the container is stopped: https://docs.docker.com/engine/api/v1.37/#operation/ContainerDelete