### PR TITLE
Log a warning when Docker's free space is less than 2GB

### DIFF
--- a/src/docker-client-factory.ts
+++ b/src/docker-client-factory.ts
@@ -13,10 +13,32 @@ export interface DockerClientFactory {
 }
 
 export class DockerodeClientFactory implements DockerClientFactory {
+  public static getInstance() {
+    if (!DockerodeClientFactory.instance) {
+      DockerodeClientFactory.instance = new DockerodeClientFactory();
+
+      DockerodeClientFactory.instance
+        .getClient()
+        .info()
+        .then(info => {
+          log.debug(`Docker version: ${info.version}`);
+
+          const availableGb = info.availableMb / 1000;
+          if (availableGb < 2) {
+            log.warn(`Docker environment should have more than 2GB free disk space`);
+          }
+        });
+    }
+
+    return DockerodeClientFactory.instance;
+  }
+
+  private static instance: DockerodeClientFactory;
+
   private readonly host: Host;
   private readonly client: DockerClient;
 
-  constructor() {
+  private constructor() {
     if (process.env.DOCKER_HOST) {
       const { host, client } = this.fromDockerHost(process.env.DOCKER_HOST);
       this.host = host;

--- a/src/docker-client.ts
+++ b/src/docker-client.ts
@@ -28,6 +28,11 @@ export type StreamOutput = string;
 export type ExecResult = { output: StreamOutput; exitCode: ExitCode };
 type DockerodeExposedPorts = { [port in PortString]: {} };
 
+export type DockerInfo = {
+  version: string;
+  availableMb: number;
+};
+
 export type BindMode = "rw" | "ro";
 export type BindMount = {
   source: Dir;
@@ -47,6 +52,7 @@ type CreateOptions = {
 };
 
 export interface DockerClient {
+  info(): Promise<DockerInfo>;
   pull(repoTag: RepoTag): Promise<void>;
   create(options: CreateOptions): Promise<Container>;
   start(container: Container): Promise<void>;
@@ -58,6 +64,16 @@ export interface DockerClient {
 
 export class DockerodeClient implements DockerClient {
   constructor(private readonly host: Host, private readonly dockerode: Dockerode) {}
+
+  public async info(): Promise<DockerInfo> {
+    const { Version: version } = await this.dockerode.version();
+    const { LayersSize: availableBytes } = await this.dockerode.df();
+
+    return {
+      version,
+      availableMb: availableBytes / 1e6
+    };
+  }
 
   public async pull(repoTag: RepoTag): Promise<void> {
     log.info(`Pulling image: ${repoTag}`);


### PR DESCRIPTION
Fetch remaining disk space available to Docker and log a warning if it's below 2GB.
This will help diagnose issues such as https://github.com/testcontainers/testcontainers-node/issues/41.

This has been done in the `DockerClientFactory`, as it should only be called once. To make this clear, the module has been made a singleton, which should also improve performance.

The implementation of the check is also non-blocking, so the check won't add to the build time.