### PR TITLE
Add ID getter to GenericContainer

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -4,7 +4,7 @@ import { Duration, TemporalUnit } from "node-duration";
 import { Command, ContainerName, ExitCode } from "./docker-client";
 import { Port } from "./port";
 
-type Id = string;
+export type Id = string;
 
 export type InspectResult = {
   internalPorts: Port[];

--- a/src/generic-container.ts
+++ b/src/generic-container.ts
@@ -210,7 +210,7 @@ class StartedGenericContainer implements StartedTestContainer {
   }
 
   public getId(): ContainerId {
-    return this.container.getId()
+    return this.container.getId();
   }
 
   public getName(): ContainerName {

--- a/src/generic-container.ts
+++ b/src/generic-container.ts
@@ -1,6 +1,6 @@
 import { Duration, TemporalUnit } from "node-duration";
 import { BoundPorts } from "./bound-ports";
-import { Container } from "./container";
+import { Container, Id as ContainerId } from "./container";
 import { ContainerState } from "./container-state";
 import {
   BindMode,
@@ -207,6 +207,10 @@ class StartedGenericContainer implements StartedTestContainer {
 
   public getMappedPort(port: Port): Port {
     return this.boundPorts.getBinding(port);
+  }
+
+  public getId(): ContainerId {
+    return this.container.getId()
   }
 
   public getName(): ContainerName {


### PR DESCRIPTION
This minor change allows for better interoperability with `dockerode`, as this library mainly relies on the container ID to instantiate "Container" objects.