### PR TITLE
Enable users to set NetworkMode for containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,16 @@ const container = await new GenericContainer("alpine")
   .start();
 ```
 
+Creating a container that connects to a specific network:
+
+```javascript
+const { GenericContainer } = require("testcontainers");
+
+const container = await new GenericContainer("alpine")
+  .withNetworkMode("network_name")
+  .start();
+```
+
 Testcontainers will wait 10 seconds for a container to stop, to override:
 
 ```javascript

--- a/src/docker-client.ts
+++ b/src/docker-client.ts
@@ -10,6 +10,7 @@ import { RepoTag } from "./repo-tag";
 
 export type Command = string;
 export type ContainerName = string;
+export type NetworkMode = string;
 export type ExitCode = number;
 
 export type EnvKey = string;
@@ -44,6 +45,7 @@ type CreateOptions = {
   tmpFs: TmpFs;
   boundPorts: BoundPorts;
   name?: ContainerName;
+  networkMode?: NetworkMode;
 };
 
 export interface DockerClient {
@@ -75,6 +77,7 @@ export class DockerodeClient implements DockerClient {
       ExposedPorts: this.getExposedPorts(options.boundPorts),
       Cmd: options.cmd,
       HostConfig: {
+        NetworkMode: options.networkMode,
         PortBindings: this.getPortBindings(options.boundPorts),
         Binds: this.getBindMounts(options.bindMounts),
         Tmpfs: options.tmpFs

--- a/src/generic-container.test.ts
+++ b/src/generic-container.test.ts
@@ -36,25 +36,14 @@ describe("GenericContainer", () => {
 
   it("should set network mode", async () => {
     const container = await new GenericContainer("cristianrgreco/testcontainer", "1.1.11")
-      .withName("special-test-container")
       .withNetworkMode("host")
       .start();
 
     const dockerodeClient = new Dockerode();
-    const listedContainers = await dockerodeClient.listContainers();
 
-    let containerInfo: undefined | Dockerode.ContainerInfo;
-    for (const listedContainer of listedContainers) {
-      if (listedContainer.Names.includes("/special-test-container")) {
-        containerInfo = listedContainer;
-        break;
-      }
-    }
-    if (containerInfo) {
-      expect(containerInfo.HostConfig.NetworkMode).toBe("host");
-    } else {
-      fail("This branch should be unreachable");
-    }
+    const dockerContainer = dockerodeClient.getContainer(container.getId());
+    const containerInfo = await dockerContainer.inspect();
+    expect(containerInfo.HostConfig.NetworkMode).toBe("host");
 
     await container.stop();
   });

--- a/src/generic-container.ts
+++ b/src/generic-container.ts
@@ -15,6 +15,7 @@ import {
   EnvKey,
   EnvValue,
   ExecResult,
+  NetworkMode,
   TmpFs
 } from "./docker-client";
 import { DockerClientFactory, DockerodeClientFactory, Host } from "./docker-client-factory";
@@ -73,6 +74,7 @@ export class GenericContainer implements TestContainer {
   private readonly dockerClient: DockerClient;
 
   private env: Env = {};
+  private networkMode?: NetworkMode;
   private ports: Port[] = [];
   private cmd: Command[] = [];
   private bindMounts: BindMount[] = [];
@@ -103,7 +105,8 @@ export class GenericContainer implements TestContainer {
       bindMounts: this.bindMounts,
       tmpFs: this.tmpFs,
       boundPorts,
-      name: this.name
+      name: this.name,
+      networkMode: this.networkMode
     });
     await this.dockerClient.start(container);
     const inspectResult = await container.inspect();
@@ -136,6 +139,11 @@ export class GenericContainer implements TestContainer {
 
   public withTmpFs(tmpFs: TmpFs) {
     this.tmpFs = tmpFs;
+    return this;
+  }
+
+  public withNetworkMode(networkMode: NetworkMode): TestContainer {
+    this.networkMode = networkMode;
     return this;
   }
 

--- a/src/test-container.ts
+++ b/src/test-container.ts
@@ -3,6 +3,7 @@ import { BindMode, Command, ContainerName, Dir, EnvKey, EnvValue, ExecResult, Tm
 import { Host } from "./docker-client-factory";
 import { Port } from "./port";
 import { WaitStrategy } from "./wait-strategy";
+import { Id as ContainerId } from "./container";
 
 export interface TestContainer {
   start(): Promise<StartedTestContainer>;
@@ -35,6 +36,7 @@ export interface StartedTestContainer {
   getContainerIpAddress(): Host;
   getMappedPort(port: Port): Port;
   getName(): ContainerName;
+  getId(): ContainerId;
   exec(command: Command[]): Promise<ExecResult>;
 }
 

--- a/src/test-container.ts
+++ b/src/test-container.ts
@@ -1,9 +1,9 @@
 import { Duration, TemporalUnit } from "node-duration";
+import { Id as ContainerId } from "./container";
 import { BindMode, Command, ContainerName, Dir, EnvKey, EnvValue, ExecResult, TmpFs } from "./docker-client";
 import { Host } from "./docker-client-factory";
 import { Port } from "./port";
 import { WaitStrategy } from "./wait-strategy";
-import { Id as ContainerId } from "./container";
 
 export interface TestContainer {
   start(): Promise<StartedTestContainer>;


### PR DESCRIPTION
This PR enables users to configure containers to run in specific networks. This is quite useful in complex CI setups with microservices.