### PR TITLE
Option to provide additional host configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,20 @@ const container = await new GenericContainer("alpine")
   .start();
 ```
 
+You can override the logging driver used by docker to be the default one (json-file).
+This might be necessary when the driver of your docker host does not support reading logs
+and you want to use the `Wait.forLogMessage` wait strategy.
+
+This is the same as [--log-driver json-file on docker run](https://docs.docker.com/config/containers/logging/configure/#configure-the-logging-driver-for-a-container).
+
+```javascript
+const { GenericContainer } = require("testcontainers");
+
+const container = await new GenericContainer("redis")
+  .withDefaultLogDriver()
+  .start();
+```
+
 Testcontainers will wait 10 seconds for a container to stop, to override:
 
 ```javascript

--- a/src/generic-container.test.ts
+++ b/src/generic-container.test.ts
@@ -160,6 +160,23 @@ describe("GenericContainer", () => {
     await container.stop();
   });
 
+  it("should set default log driver", async () => {
+    const container = await new GenericContainer("cristianrgreco/testcontainer", "1.1.12")
+      .withDefaultLogDriver()
+      .start();
+
+    const dockerodeClient = new Dockerode();
+
+    const dockerContainer = dockerodeClient.getContainer(container.getId());
+    const containerInfo = await dockerContainer.inspect();
+    expect(containerInfo.HostConfig.LogConfig).toEqual({
+      Type: "json-file",
+      Config: {}
+    });
+
+    await container.stop();
+  });
+
   it("should execute a command on a running container", async () => {
     const container = await new GenericContainer("cristianrgreco/testcontainer", "1.1.12")
       .withExposedPorts(8080)

--- a/src/generic-container.ts
+++ b/src/generic-container.ts
@@ -1,3 +1,4 @@
+import { HostConfig } from "dockerode";
 import { Duration, TemporalUnit } from "node-duration";
 import { BoundPorts } from "./bound-ports";
 import { Container, Id as ContainerId } from "./container";
@@ -16,6 +17,7 @@ import {
   EnvValue,
   ExecResult,
   HealthCheck,
+  LogConfig,
   NetworkMode,
   TmpFs
 } from "./docker-client";
@@ -84,6 +86,7 @@ export class GenericContainer implements TestContainer {
   private healthCheck?: HealthCheck;
   private waitStrategy?: WaitStrategy;
   private startupTimeout: Duration = new Duration(60_000, TemporalUnit.MILLISECONDS);
+  private useDefaultLogDriver: boolean = false;
 
   constructor(
     readonly image: Image,
@@ -109,7 +112,8 @@ export class GenericContainer implements TestContainer {
       boundPorts,
       name: this.name,
       networkMode: this.networkMode,
-      healthCheck: this.healthCheck
+      healthCheck: this.healthCheck,
+      useDefaultLogDriver: this.useDefaultLogDriver
     });
     await this.dockerClient.start(container);
     const inspectResult = await container.inspect();
@@ -172,6 +176,11 @@ export class GenericContainer implements TestContainer {
 
   public withWaitStrategy(waitStrategy: WaitStrategy): this {
     this.waitStrategy = waitStrategy;
+    return this;
+  }
+
+  public withDefaultLogDriver(): this {
+    this.useDefaultLogDriver = true;
     return this;
   }
 

--- a/src/test-container.ts
+++ b/src/test-container.ts
@@ -25,6 +25,7 @@ export interface TestContainer {
   withWaitStrategy(waitStrategy: WaitStrategy): this;
   withStartupTimeout(startupTimeout: Duration): this;
   withNetworkMode(networkMode: NetworkMode): this;
+  withDefaultLogDriver(): this;
 }
 
 export interface OptionalStopOptions {


### PR DESCRIPTION
In the Java implementation, it is possible to modify the `docker run` command before it is being executed with `withCreateContainerCmdModifier`. So far there is no similar option in testcontainers-node.

This PR adds an option to add additional host parameters, exposing the underlying dockerode API. This is very similar to how the Java implementation with the above mentioned `withCreateContainerCmdModifier` exposes the underlying docker-java API. (See [here](https://github.com/testcontainers/testcontainers-java/blob/6622578bed5e66bfb979b9bfeeb0e22321e21266/core/src/main/java/org/testcontainers/containers/GenericContainer.java#L1351))

The specific reason why we would need this feature, is that we want to run a test using testcontainers on a docker host with splunk set as the log driver. But Splunk is a write-only log driver, which leads to errors when waiting for a log line in testcontainers. With this PR, we could set the log-driver for the test explicitly to json-file.