### PR TITLE
GenericContainer: add withExposedPort as a way to set pre-defined mapped port

### DIFF
--- a/src/bound-ports.ts
+++ b/src/bound-ports.ts
@@ -13,8 +13,9 @@ export class BoundPorts {
     return binding;
   }
 
-  public setBinding(key: Port, value: Port): void {
+  public setBinding(key: Port, value: Port): BoundPorts {
     this.ports.set(key, value);
+    return this;
   }
 
   public iterator(): Iterable<[Port, Port]> {

--- a/src/test-container.ts
+++ b/src/test-container.ts
@@ -21,6 +21,7 @@ export interface TestContainer {
   withEnv(key: EnvKey, value: EnvValue): this;
   withCmd(cmd: Command[]): this;
   withTmpFs(tmpFs: TmpFs): this;
+  withExposedPort(port: Port, mappedPort?: Port): this;
   withExposedPorts(...ports: Port[]): this;
   withBindMount(source: Dir, target: Dir, bindMode: BindMode): this;
   withWaitStrategy(waitStrategy: WaitStrategy): this;


### PR DESCRIPTION
I think it makes a lot of sense to have this one. In fact we never use random ports on our test containers. It always something pre-defined in the ENV.