### PR TITLE
Adding rimraf instead of rm -rf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -245,6 +245,17 @@
         "realpath-native": "^1.1.0",
         "rimraf": "^2.5.4",
         "strip-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "@jest/environment": {
@@ -441,7 +452,6 @@
       "version": "2.5.24",
       "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-2.5.24.tgz",
       "integrity": "sha512-2iwkmqjc6viw40KnAcyLW1sp9mptb6CPARvpRQDAzKsf0y6dphK0qzgouLiI2gaoNB0iiumZGd2nduGypKk9Aw==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -480,8 +490,7 @@
     "@types/node": {
       "version": "10.12.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
-      "dev": true
+      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
     },
     "@types/node-fetch": {
       "version": "2.3.4",
@@ -2991,6 +3000,17 @@
         "make-dir": "^2.1.0",
         "rimraf": "^2.6.3",
         "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "istanbul-reports": {
@@ -4471,9 +4491,9 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "prepublish": "npm run build",
     "build": "npm run clean && tsc",
-    "clean": "rm -rf dist",
+    "clean": "rimraf dist",
     "test": "jest",
     "lint": "tslint --fix src/**/*.ts",
     "format": "prettier --write package.json docker/index.js docker-with-buildargs/index.js src/**/*.ts"
@@ -52,6 +52,7 @@
     "jest": "^24.8.0",
     "node-fetch": "^2.6.0",
     "prettier": "^1.17.1",
+    "rimraf": "^3.0.2",
     "ts-jest": "^24.0.2",
     "ts-node": "^7.0.1",
     "tslint": "^5.17.0",


### PR DESCRIPTION
The rm -rf  is a unix style command that windows users wont be able to use.
 If we switch to the rimraf the clean command will work.