### PR TITLE
Add isCreating method to generic container

### DIFF
--- a/src/generic-container.ts
+++ b/src/generic-container.ts
@@ -98,12 +98,20 @@ export class GenericContainer implements TestContainer {
     this.dockerClient = dockerClientFactory.getClient();
   }
 
+
+  // An interceptor method for any routine which needs to be performed
+  // after everything is prepared and a step before container is created
+  protected isCreating?(boundPorts: BoundPorts): void;
+
   public async start(): Promise<StartedTestContainer> {
     if (!(await this.hasRepoTagLocally())) {
       await this.dockerClient.pull(this.repoTag, this.authConfig);
     }
 
     const boundPorts = await new PortBinder().bind(this.ports);
+    if (this.isCreating) {
+      this.isCreating(boundPorts);
+    }
     const container = await this.dockerClient.create({
       repoTag: this.repoTag,
       env: this.env,


### PR DESCRIPTION
Hi!

Looks like currently there is no option to create working Kafka container using testcontainers. The reason is that randomly mapped ports are available only after container is started. But mapped port is needed to set advertised listeners to environment and configure Kafka.

These are the changes which provide possibility to pass mapped ports to environment variables, for example. And possibly for other needs. Thus, one can extend GenericContainer class and provide their own implementation of isCreating method. I tested this change for Kafka container.

If there are any suggestions or other ideas, I'll be glad to discuss it.

Example of usage:
```
class KafkaTestContainer extends GenericContainer {

  protected isCreating(boundPorts: BoundPorts): void {
    // set bound port to env here
    this.withEnv(...);
  }
}
```

