### PR TITLE
Fix: error occured when stop a stopped container.

### DIFF
--- a/fixtures/docker-exit-immediately/Dockerfile
+++ b/fixtures/docker-exit-immediately/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.10
+
+MAINTAINER Cristian Greco
+
+ENTRYPOINT ["echo", "This container will exit immediately."]

--- a/src/generic-container.test.ts
+++ b/src/generic-container.test.ts
@@ -317,5 +317,16 @@ describe("GenericContainer", () => {
 
       expect(response.status).toBe(200);
     });
+
+    it("should exit immediately and stop without exception", async () => {
+      const message = "This container will exit immediately.";
+      const context = path.resolve(fixtures, "docker-exit-immediately");
+      const container = await GenericContainer.fromDockerfile(context).build();
+      const startedContainer = await container.withWaitStrategy(Wait.forLogMessage(message)).start();
+
+      await new Promise((res) => setTimeout(res, 1000));
+
+      await startedContainer.stop();
+    });
   });
 });


### PR DESCRIPTION
When ``GenericContainer`` stop a container, if the container already stopped or exited.
The following code will raise a exception indicated that ``(HTTP code 304) container already stopped`` at line 248.
https://github.com/testcontainers/testcontainers-node/blob/0578b08c1350f8396ccbaefedb2a411f926a62ff/src/generic-container.ts#L246-L251

This could exit the function without remove the container. I have check the [implementation](https://github.com/testcontainers/testcontainers-java/blob/c3f53b3a63e6b0bc800a7f0fbce91ce95a8986b3/core/src/main/java/org/testcontainers/utility/ResourceReaper.java#L246) of testcontainers-java. Seems that they use ``try { ... } catch { ... }`` to bypass this issue. 

This PR implement a test and fix for this issue.

---

I discover this issue when I try to run flyway as a container to do the migration for database. Flyway it self serve as a tool instead of a service. So it exited when it done its work. Which trigger this issue when I try to call ``stop`` to remove it.