### PR TITLE
Change type of logs to Readable

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -1,9 +1,9 @@
-import byline from "byline";
 import dockerode, { ContainerInspectInfo } from "dockerode";
 import { log } from "./logger";
 import { Duration, TemporalUnit } from "node-duration";
 import { Command, ContainerName, ExitCode } from "./docker-client";
 import { Port } from "./port";
+import { Readable } from "stream";
 
 export type Id = string;
 
@@ -45,7 +45,7 @@ export interface Container {
   stop(options: StopOptions): Promise<void>;
   remove(options: RemoveOptions): Promise<void>;
   exec(options: ExecOptions): Promise<Exec>;
-  logs(): Promise<NodeJS.ReadableStream>;
+  logs(): Promise<Readable>;
   inspect(): Promise<InspectResult>;
 }
 
@@ -91,13 +91,13 @@ export class DockerodeContainer implements Container {
     );
   }
 
-  public async logs(): Promise<NodeJS.ReadableStream> {
+  public async logs(): Promise<Readable> {
     const options = {
       follow: true,
       stdout: true,
       stderr: true,
     };
-    return (await this.container.logs(options)).setEncoding("utf-8");
+    return (await this.container.logs(options)).setEncoding("utf-8") as Readable;
   }
 
   public async inspect(): Promise<InspectResult> {

--- a/src/generic-container.test.ts
+++ b/src/generic-container.test.ts
@@ -5,6 +5,7 @@ import path from "path";
 import { GenericContainer } from "./generic-container";
 import { AlwaysPullPolicy } from "./pull-policy";
 import { Wait } from "./wait";
+import { Readable } from "stream";
 
 describe("GenericContainer", () => {
   jest.setTimeout(180_000);
@@ -194,8 +195,7 @@ describe("GenericContainer", () => {
       .withExposedPorts(8080)
       .start();
 
-    const events = await dockerodeClient.getEvents();
-    events.setEncoding("utf-8");
+    const events = (await dockerodeClient.getEvents()).setEncoding("utf-8") as Readable;
 
     const container2 = await new GenericContainer("cristianrgreco/testcontainer", "1.1.12")
       .withPullPolicy(new AlwaysPullPolicy())
@@ -215,7 +215,6 @@ describe("GenericContainer", () => {
 
     expect(statuses).toContain("pull");
 
-    // @ts-ignore
     events.destroy();
     await container1.stop();
     await container2.stop();

--- a/src/generic-container.ts
+++ b/src/generic-container.ts
@@ -37,6 +37,7 @@ import {
 import { RandomUuid, Uuid } from "./uuid";
 import { HostPortWaitStrategy, WaitStrategy } from "./wait-strategy";
 import { Reaper } from "./reaper";
+import { Readable } from "stream";
 
 export class GenericContainerBuilder {
   private buildArgs: BuildArgs = {};
@@ -289,7 +290,7 @@ export class StartedGenericContainer implements StartedTestContainer {
     return this.dockerClient.exec(this.container, command);
   }
 
-  public logs(): Promise<NodeJS.ReadableStream> {
+  public logs(): Promise<Readable> {
     return this.container.logs();
   }
 }

--- a/src/modules/abstract-started-container.ts
+++ b/src/modules/abstract-started-container.ts
@@ -3,6 +3,7 @@ import { Host } from "../docker-client-factory";
 import { Port } from "../port";
 import { Command, ContainerName, ExecResult } from "../docker-client";
 import { Id as ContainerId } from "../container";
+import { Readable } from "stream";
 
 export class AbstractStartedContainer {
   constructor(protected readonly startedTestContainer: StartedTestContainer) {}
@@ -31,7 +32,7 @@ export class AbstractStartedContainer {
     return this.startedTestContainer.exec(command);
   }
 
-  public logs(): Promise<NodeJS.ReadableStream> {
+  public logs(): Promise<Readable> {
     return this.startedTestContainer.logs();
   }
 }

--- a/src/modules/arangodb/arangodb-container.ts
+++ b/src/modules/arangodb/arangodb-container.ts
@@ -36,7 +36,7 @@ export class StartedArangoContainer extends AbstractStartedContainer {
 
   constructor(
     startedTestContainer: StartedTestContainer,
-    private port: Port,
+    private readonly port: Port,
     private readonly username: string,
     private readonly password: string
   ) {

--- a/src/test-container.ts
+++ b/src/test-container.ts
@@ -16,6 +16,7 @@ import { Host } from "./docker-client-factory";
 import { Port } from "./port";
 import { PullPolicy } from "./pull-policy";
 import { WaitStrategy } from "./wait-strategy";
+import { Readable } from "stream";
 
 export interface TestContainer {
   start(): Promise<StartedTestContainer>;
@@ -50,7 +51,7 @@ export interface StartedTestContainer {
   getName(): ContainerName;
   getId(): ContainerId;
   exec(command: Command[]): Promise<ExecResult>;
-  logs(): Promise<NodeJS.ReadableStream>;
+  logs(): Promise<Readable>;
 }
 
 export interface StoppedTestContainer {}

--- a/src/wait-strategy.ts
+++ b/src/wait-strategy.ts
@@ -89,26 +89,21 @@ export class LogWaitStrategy extends AbstractWaitStrategy {
       stream
         .on("data", (line) => {
           if (line.includes(this.message)) {
-            this.destroyStream(stream);
+            stream.destroy();
             resolve();
           }
         })
         .on("err", (line) => {
           if (line.includes(this.message)) {
-            this.destroyStream(stream);
+            stream.destroy();
             resolve();
           }
         })
         .on("end", () => {
-          this.destroyStream(stream);
+          stream.destroy();
           reject();
         });
     });
-  }
-
-  private destroyStream(stream: NodeJS.ReadableStream) {
-    // @ts-ignore
-    stream.destroy();
   }
 }
 


### PR DESCRIPTION
The response from docker logs is actually an `IncomingMessage`, which is a HTTP server response. 
It extends `Readable` so let's use that instead for a nice streaming interface.