### PR TITLE
Add support for stopping a docker-compose environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,6 @@ describe("DockerComposeEnvironment", () => {
     expect(await redisClient.get("key")).toBe("val");
   });
 });
-
 ```
 
 Create the containers with their own wait strategies:
@@ -382,6 +381,16 @@ const environment = await new DockerComposeEnvironment(composeFilePath, composeF
 
 const container = environment.getContainer("alpine_1");
 const { output, exitCode } = await container.exec(["echo", "hello", "world"]);
+```
+
+If you have multiple docker-compose environments which share dependencies such as networks, you can stop the environment instead of downing it:
+
+```javascript
+const { DockerComposeEnvironment } = require("testcontainers");
+
+const environment = await new DockerComposeEnvironment(composeFilePath, composeFile).up();
+
+await environment.stop();
 ```
 
 By default docker-compose does not re-build Dockerfiles, but you can override this behaviour:

--- a/fixtures/docker-compose/docker-compose-with-network.yml
+++ b/fixtures/docker-compose/docker-compose-with-network.yml
@@ -1,0 +1,13 @@
+version: "3"
+
+services:
+  container:
+    image: cristianrgreco/testcontainer:1.1.12
+    ports:
+      - 8080
+    networks:
+      - shared-network
+
+networks:
+  shared-network:
+    name: test-network

--- a/src/docker-compose-environment.test.ts
+++ b/src/docker-compose-environment.test.ts
@@ -55,6 +55,16 @@ describe("DockerComposeEnvironment", () => {
     await startedEnvironment.down();
   });
 
+  it("should stop a docker-compose environment", async () => {
+    const environment1 = await new DockerComposeEnvironment(fixtures, "docker-compose-with-network.yml").up();
+    const environment2 = await new DockerComposeEnvironment(fixtures, "docker-compose-with-network.yml").up();
+
+    const stoppedEnvironment = await environment2.stop();
+    await environment1.down();
+
+    await stoppedEnvironment.down();
+  });
+
   it("should re-build the Dockerfiles", async () => {
     const startedEnvironment = await new DockerComposeEnvironment(fixtures, "docker-compose.yml").withBuild().up();
 

--- a/src/docker-compose-environment.ts
+++ b/src/docker-compose-environment.ts
@@ -174,13 +174,24 @@ export class StartedDockerComposeEnvironment {
     private readonly startedGenericContainers: { [containerName: string]: StartedGenericContainer }
   ) {}
 
-  public async down(): Promise<StoppedDockerComposeEnvironment> {
+  public async stop(): Promise<StoppedDockerComposeEnvironment> {
     log.info(`Stopping DockerCompose environment`);
     try {
-      await dockerCompose.down(defaultDockerComposeOptions(this.composeFilePath, this.composeFile, this.projectName));
-      return new StoppedDockerComposeEnvironment();
+      await dockerCompose.stop(defaultDockerComposeOptions(this.composeFilePath, this.composeFile, this.projectName));
+      return new StoppedDockerComposeEnvironment(this.composeFilePath, this.composeFile, this.projectName);
     } catch ({ err }) {
       log.error(`Failed to stop DockerCompose environment: ${err}`);
+      throw new Error(err.trim());
+    }
+  }
+
+  public async down(): Promise<DownedDockerComposeEnvironment> {
+    log.info(`Downing DockerCompose environment`);
+    try {
+      await dockerCompose.down(defaultDockerComposeOptions(this.composeFilePath, this.composeFile, this.projectName));
+      return new DownedDockerComposeEnvironment();
+    } catch ({ err }) {
+      log.error(`Failed to down DockerCompose environment: ${err}`);
       throw new Error(err.trim());
     }
   }
@@ -196,4 +207,23 @@ export class StartedDockerComposeEnvironment {
   }
 }
 
-export class StoppedDockerComposeEnvironment {}
+export class StoppedDockerComposeEnvironment {
+  constructor(
+    private readonly composeFilePath: string,
+    private readonly composeFile: string,
+    private readonly projectName: string
+  ) {}
+
+  public async down(): Promise<DownedDockerComposeEnvironment> {
+    log.info(`Downing DockerCompose environment`);
+    try {
+      await dockerCompose.down(defaultDockerComposeOptions(this.composeFilePath, this.composeFile, this.projectName));
+      return new DownedDockerComposeEnvironment();
+    } catch ({ err }) {
+      log.error(`Failed to down DockerCompose environment: ${err}`);
+      throw new Error(err.trim());
+    }
+  }
+}
+
+export class DownedDockerComposeEnvironment {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,18 @@
-export { GenericContainer, GenericContainerBuilder } from "./generic-container";
 export { TestContainer, StartedTestContainer, StoppedTestContainer } from "./test-container";
-export { Network, StartedNetwork, StoppedNetwork } from "./network";
+export { GenericContainer, GenericContainerBuilder } from "./generic-container";
+
 export {
   DockerComposeEnvironment,
   StartedDockerComposeEnvironment,
   StoppedDockerComposeEnvironment,
+  DownedDockerComposeEnvironment,
 } from "./docker-compose-environment";
+
+export { Network, StartedNetwork, StoppedNetwork } from "./network";
+
 export { Wait } from "./wait";
 export { PullPolicy, DefaultPullPolicy, AlwaysPullPolicy } from "./pull-policy";
+
 export { KafkaContainer, StartedKafkaContainer } from "./modules/kafka/kafka-container";
 export { Neo4jContainer, StartedNeo4jContainer } from "./modules/neo4j/neo4j-container";
 export { ArangoDBContainer, StartedArangoContainer } from "./modules/arangodb/arangodb-container";


### PR DESCRIPTION
Addresses #133 

Supports stopping a docker-compose environment. Calling `stop` returns a `StoppedDockerComposeEnvironment` which can also be `down`'d which returns a `DownedDockerComposeEnvironment`.