### PR TITLE
Fix Windows

### DIFF
--- a/fixtures/docker-compose/docker-compose-with-healthcheck.yml
+++ b/fixtures/docker-compose/docker-compose-with-healthcheck.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.5"
 
 services:
   container:

--- a/fixtures/docker-compose/docker-compose-with-name.yml
+++ b/fixtures/docker-compose/docker-compose-with-name.yml
@@ -1,4 +1,5 @@
-version: "3"
+version: "3.5"
+
 services:
   db:
     container_name: custom_container_name

--- a/fixtures/docker-compose/docker-compose-with-network.yml
+++ b/fixtures/docker-compose/docker-compose-with-network.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.5"
 
 services:
   container:

--- a/fixtures/docker-compose/docker-compose-with-volume.yml
+++ b/fixtures/docker-compose/docker-compose-with-volume.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.5"
 
 services:
   container:

--- a/fixtures/docker-compose/docker-compose.yml
+++ b/fixtures/docker-compose/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.5"
 
 services:
   container:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6644,8 +6644,7 @@
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
     },
     "slice-ansi": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "get-port": "^5.1.1",
     "glob": "^7.1.6",
     "node-duration": "^1.0.4",
+    "slash": "^3.0.0",
     "stream-to-array": "^2.3.0",
     "tar-fs": "^2.1.0"
   },

--- a/src/container.ts
+++ b/src/container.ts
@@ -151,6 +151,6 @@ class DockerodeExec implements Exec {
 
   public async inspect(): Promise<ExecInspectResult> {
     const inspectResult = await this.exec.inspect();
-    return { exitCode: inspectResult.ExitCode === null ? -1 : inspectResult.ExitCode };
+    return { exitCode: inspectResult.ExitCode === null ? 0 : inspectResult.ExitCode };
   }
 }

--- a/src/container.ts
+++ b/src/container.ts
@@ -18,6 +18,9 @@ export type InspectResult = {
 
 type ExecInspectResult = {
   exitCode: ExitCode;
+  running: boolean;
+  entrypoint: string;
+  arguments: string[];
 };
 
 interface Exec {
@@ -151,6 +154,12 @@ class DockerodeExec implements Exec {
 
   public async inspect(): Promise<ExecInspectResult> {
     const inspectResult = await this.exec.inspect();
-    return { exitCode: inspectResult.ExitCode === null ? 0 : inspectResult.ExitCode };
+
+    return {
+      exitCode: inspectResult.ExitCode === null ? -1 : inspectResult.ExitCode,
+      running: inspectResult.Running,
+      entrypoint: inspectResult.ProcessConfig.entrypoint,
+      arguments: inspectResult.ProcessConfig.arguments,
+    };
   }
 }

--- a/src/docker-client.ts
+++ b/src/docker-client.ts
@@ -174,7 +174,6 @@ export class DockerodeClient implements DockerClient {
   }
 
   public start(container: Container): Promise<void> {
-    log.info(`Starting container with ID: ${container.getId()}`);
     return container.start();
   }
 

--- a/src/docker-client.ts
+++ b/src/docker-client.ts
@@ -1,3 +1,4 @@
+import byline from "byline";
 import Dockerode, { Network, PortMap as DockerodePortBindings } from "dockerode";
 import { Duration, TemporalUnit } from "node-duration";
 import streamToArray from "stream-to-array";
@@ -183,8 +184,12 @@ export class DockerodeClient implements DockerClient {
       attachStderr: true,
     });
 
-    const stream = await exec.start();
-    const output = Buffer.concat(await streamToArray(stream)).toString();
+    const stream = byline(await exec.start()).setEncoding("utf-8");
+
+    const output: string = await new Promise((resolve) => stream.on("data", (chunk) => resolve(chunk)));
+
+    stream.destroy();
+
     const { exitCode } = await exec.inspect();
 
     return { output, exitCode };

--- a/src/docker-client.ts
+++ b/src/docker-client.ts
@@ -2,6 +2,7 @@ import Dockerode, { Network, PortMap as DockerodePortBindings } from "dockerode"
 import { Duration, TemporalUnit } from "node-duration";
 import streamToArray from "stream-to-array";
 import tar from "tar-fs";
+import slash from "slash";
 import { BoundPorts } from "./bound-ports";
 import { Container, DockerodeContainer, Id } from "./container";
 import { Host } from "./docker-client-factory";
@@ -208,7 +209,7 @@ export class DockerodeClient implements DockerClient {
   ): Promise<void> {
     log.info(`Building image '${repoTag.toString()}' with context '${context}'`);
     const dockerIgnoreFiles = await findDockerIgnoreFiles(context);
-    const tarStream = tar.pack(context, { ignore: (name) => dockerIgnoreFiles.has(name) });
+    const tarStream = tar.pack(context, { ignore: (name) => dockerIgnoreFiles.has(slash(name)) });
     const stream = await this.dockerode.buildImage(tarStream, {
       dockerfile: dockerfileName,
       buildargs: buildArgs,

--- a/src/docker-client.ts
+++ b/src/docker-client.ts
@@ -186,9 +186,11 @@ export class DockerodeClient implements DockerClient {
 
     const stream = byline(await exec.start()).setEncoding("utf-8");
 
-    const output: string = await new Promise((resolve) => stream.on("data", (chunk) => resolve(chunk)));
-
-    stream.destroy();
+    const output: string = await new Promise((resolve) => {
+      const chunks: string[] = [];
+      stream.on("data", (chunk) => chunks.push(chunk));
+      stream.on("end", () => resolve(chunks.reduce((result, chunk) => result + chunk, "")));
+    });
 
     const { exitCode } = await exec.inspect();
 

--- a/src/docker-client.ts
+++ b/src/docker-client.ts
@@ -11,6 +11,7 @@ import { log } from "./logger";
 import { PortString } from "./port";
 import { RepoTag } from "./repo-tag";
 import { PullStreamParser } from "./pull-stream-parser";
+import { Readable } from "stream";
 
 export type Command = string;
 export type ContainerName = string;
@@ -184,7 +185,7 @@ export class DockerodeClient implements DockerClient {
       attachStderr: true,
     });
 
-    const stream = (await exec.start()).setEncoding("utf-8");
+    const stream = (await exec.start()).setEncoding("utf-8") as Readable;
 
     return await new Promise((resolve) => {
       let output = "";
@@ -195,6 +196,7 @@ export class DockerodeClient implements DockerClient {
 
         if (!running) {
           clearInterval(interval);
+          stream.destroy();
           resolve({ output, exitCode });
         }
       }, 100);

--- a/src/docker-compose-environment.test.ts
+++ b/src/docker-compose-environment.test.ts
@@ -12,7 +12,7 @@ describe("DockerComposeEnvironment", () => {
 
   it("should throw error when compose file is malformed", async () => {
     await expect(new DockerComposeEnvironment(fixtures, "docker-compose-malformed.yml").up()).rejects.toThrowError(
-      `Version in "./docker-compose-malformed.yml" is invalid - it should be a string.`
+      `Version in ".${path.sep}docker-compose-malformed.yml" is invalid - it should be a string.`
     );
   });
 

--- a/src/docker-ignore.ts
+++ b/src/docker-ignore.ts
@@ -1,4 +1,5 @@
 import { existsSync, promises as fs } from "fs";
+import os from "os";
 import glob from "glob";
 import path from "path";
 
@@ -12,7 +13,7 @@ export const findDockerIgnoreFiles = async (context: string): Promise<Set<string
 
   const dockerIgnorePatterns = (await fs.readFile(dockerIgnoreFilePath, { encoding: "utf-8" }))
     .toString()
-    .split("\n")
+    .split(os.EOL)
     .map((dockerIgnorePattern) => path.resolve(context, dockerIgnorePattern));
 
   const dockerIgnoreMatches: string[][] = await Promise.all(

--- a/src/generic-container.ts
+++ b/src/generic-container.ts
@@ -129,6 +129,7 @@ export class GenericContainer implements TestContainer {
       autoRemove: this.daemonMode,
     });
 
+    log.info(`Starting container ${this.repoTag} with ID: ${container.getId()}`);
     await dockerClient.start(container);
 
     if (!this.daemonMode) {
@@ -241,6 +242,13 @@ export class GenericContainer implements TestContainer {
       log.info("Container is ready");
     } catch (err) {
       log.error("Container failed to be ready");
+
+      if (this.daemonMode) {
+        (await container.logs())
+          .on("data", (data) => containerLog.trace(`${container.getId()}: ${data}`))
+          .on("err", (data) => containerLog.error(`${container.getId()}: ${data}`));
+      }
+
       try {
         await container.stop({ timeout: new Duration(0, TemporalUnit.MILLISECONDS) });
         await container.remove({ removeVolumes: true });

--- a/src/port-check.ts
+++ b/src/port-check.ts
@@ -36,22 +36,15 @@ export class InternalPortCheck implements PortCheck {
   constructor(private readonly container: Container, private readonly dockerClient: DockerClient) {}
 
   public async isBound(port: Port): Promise<boolean> {
-    return new Promise((resolve) => {
-      const timeout = setTimeout(() => resolve(false), 1000);
-      const portHex = port.toString(16).padStart(4, "0");
-      const commands = [
-        ["/bin/sh", "-c", `cat /proc/net/tcp* | awk '{print $2}' | grep -i :${portHex}`],
-        ["/bin/sh", "-c", `nc -vz -w 1 localhost ${port}`],
-        ["/bin/bash", "-c", `</dev/tcp/localhost/${port}`],
-      ];
-      commands.map((command) =>
-        this.dockerClient.exec(this.container, command).then((result) => {
-          if (result.exitCode === 0) {
-            clearTimeout(timeout);
-            resolve(true);
-          }
-        })
-      );
-    });
+    const portHex = port.toString(16).padStart(4, "0");
+    const commands = [
+      ["/bin/sh", "-c", `cat /proc/net/tcp* | awk '{print $2}' | grep -i :${portHex}`],
+      ["/bin/sh", "-c", `nc -vz -w 1 localhost ${port}`],
+      ["/bin/bash", "-c", `</dev/tcp/localhost/${port}`],
+    ];
+    const commandResults = await Promise.all(
+      commands.map((command) => this.dockerClient.exec(this.container, command))
+    );
+    return commandResults.some((result) => result.exitCode === 0);
   }
 }

--- a/src/reaper.ts
+++ b/src/reaper.ts
@@ -32,7 +32,7 @@ export class Reaper {
       .withName(`ryuk-${sessionId}`)
       .withExposedPorts(8080)
       .withWaitStrategy(Wait.forLogMessage("Started!"))
-      .withBindMount(dockerClient.getSocketPath() || "/var/run/docker.sock", "/var/run/docker.sock")
+      .withBindMount("/var/run/docker.sock", "/var/run/docker.sock")
       .withDaemonMode()
       .withPrivilegedMode()
       .start();


### PR DESCRIPTION
- Fix Reaper socket mount not working for Windows
- Output daemon container logs when they fail, to facilitate easier debugging https://github.com/testcontainers/testcontainers-node/issues/145.
- Docker exec does not work on Windows due to https://github.com/apocas/docker-modem/issues/83; this PR introduces a workaround which works cross-platform by polling Docker for the exec result.
- Resolve docker-compose version compatibility issues.
- Fix dockerignore path patterns not working with the Windows filesystem.