### PR TITLE
Expose host ports to container

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,13 +322,35 @@ Finding a container's IP address in a given network:
 const { GenericContainer, Network } = require("testcontainers");
 
 const network = await new Network()
-    .start();
+  .start();
 
 const container = await new GenericContainer("alpine")
   .withNetworkMode(network.getName())
   .start();
 
 const networkIpAddress = container.getIpAddress(network.getName());
+```
+
+[Exposing host ports to the container:](https://www.testcontainers.org/features/networking/#exposing-host-ports-to-the-container)
+
+```javascript
+const { GenericContainer, TestContainers } = require("testcontainers");
+const { createServer } = require("http");
+
+const server = createServer((req, res) => {
+  res.writeHead(200);
+  res.end("hello world");
+});
+server.listen(8000);
+
+await TestContainers.exposeHostPorts(8000);
+
+const container = await new GenericContainer("alpine")
+  .withCmd(["top"])
+  .start();
+
+const { output } = await container.exec(["curl", `http://host.testcontainers.internal:8000`]);
+assert(output === "hello world");
 ```
 
 ## Docker Compose

--- a/package-lock.json
+++ b/package-lock.json
@@ -1173,6 +1173,23 @@
       "integrity": "sha512-hiYA88aHiEIgDmeKlsyVsuQdcFn3Z2VuFd/Xm/HCnGnPD8UFU5BM128uzzRVVGEzKDKYUrRsRH9S2o+NUy/3IA==",
       "dev": true
     },
+    "@types/ssh2": {
+      "version": "0.5.45",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-0.5.45.tgz",
+      "integrity": "sha512-SAQITTyO/jOoskSAw2T/9sveX4lhTzx7zdeYR0t04RMhZQrEIzvrAoCStSxYwvwZ5ofek1JWeW9x2yOK3GOUlg==",
+      "requires": {
+        "@types/node": "*",
+        "@types/ssh2-streams": "*"
+      }
+    },
+    "@types/ssh2-streams": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@types/ssh2-streams/-/ssh2-streams-0.1.7.tgz",
+      "integrity": "sha512-cQNV72C+BOG7G8WNGarTQdB2Ii37cJlWatSpx5zTYxtI2ZvUt2lbq6Nc2XZ4kbge28V7Xe5KYYr82d96/rDMnQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@types/dockerode": "^2.5.34",
+    "@types/ssh2": "^0.5.45",
     "byline": "^5.0.0",
     "debug": "^4.1.1",
     "docker-compose": "^0.23.5",
@@ -39,6 +40,7 @@
     "get-port": "^5.1.1",
     "glob": "^7.1.6",
     "slash": "^3.0.0",
+    "ssh2": "^0.8.9",
     "stream-to-array": "^2.3.0",
     "tar-fs": "^2.1.0"
   },

--- a/src/container.ts
+++ b/src/container.ts
@@ -9,6 +9,7 @@ export type Id = string;
 export type HealthCheckStatus = "none" | "starting" | "unhealthy" | "healthy";
 
 export type NetworkSettings = {
+  networkId: string;
   ipAddress: string;
 };
 
@@ -145,6 +146,7 @@ export class DockerodeContainer implements Container {
     return Object.entries(inspectResult.NetworkSettings.Networks)
       .map(([networkName, network]) => ({
         [networkName]: {
+          networkId: network.NetworkID,
           ipAddress: network.IPAddress,
         },
       }))

--- a/src/docker-client-instance.ts
+++ b/src/docker-client-instance.ts
@@ -6,17 +6,17 @@ import { RandomUuid } from "./uuid";
 
 export type Host = string;
 
-export class DockerClientFactory {
-  private static client: Promise<DockerClient>;
+export class DockerClientInstance {
+  private static instance: Promise<DockerClient>;
 
-  public static async getClient(): Promise<DockerClient> {
-    if (!this.client) {
-      this.client = this.createClient();
+  public static async getInstance(): Promise<DockerClient> {
+    if (!this.instance) {
+      this.instance = this.createInstance();
     }
-    return this.client;
+    return this.instance;
   }
 
-  private static async createClient(): Promise<DockerClient> {
+  private static async createInstance(): Promise<DockerClient> {
     log.debug("Creating new DockerClient");
     const dockerode = new Dockerode();
     const host = await this.getHost(dockerode);

--- a/src/docker-compose-environment.ts
+++ b/src/docker-compose-environment.ts
@@ -4,7 +4,7 @@ import { BoundPorts } from "./bound-ports";
 import { Container } from "./container";
 import { ContainerState } from "./container-state";
 import { DockerClient } from "./docker-client";
-import { DockerClientFactory } from "./docker-client-factory";
+import { DockerClientInstance } from "./docker-client-instance";
 import { resolveDockerComposeContainerName } from "./docker-compose-container-name-resolver";
 import { StartedGenericContainer } from "./generic-container";
 import { containerLog, log } from "./logger";
@@ -46,9 +46,9 @@ export class DockerComposeEnvironment {
   public async up(): Promise<StartedDockerComposeEnvironment> {
     log.info(`Starting DockerCompose environment`);
 
-    const dockerClient = await DockerClientFactory.getClient();
+    const dockerClient = await DockerClientInstance.getInstance();
 
-    (await ReaperInstance.start(dockerClient)).addProject(this.projectName);
+    (await ReaperInstance.getInstance(dockerClient)).addProject(this.projectName);
 
     await upAll(this.composeFilePath, this.composeFiles, this.projectName, this.build);
     const startedContainers = (await dockerClient.listContainers()).filter(

--- a/src/generic-container.test.ts
+++ b/src/generic-container.test.ts
@@ -347,10 +347,8 @@ describe("GenericContainer", () => {
 
   it("should expose host ports to the container", async () => {
     const randomPort = await new RandomPortClient().getPort();
-
     const server: Server = await new Promise((resolve) => {
       const server = createServer((req, res) => {
-        console.log("server received request!");
         res.writeHead(200);
         res.end("hello world");
       });
@@ -362,28 +360,13 @@ describe("GenericContainer", () => {
 
     const container = await new GenericContainer("cristianrgreco/testcontainer", "1.1.12")
       .withExposedPorts(8080)
-      // .withCmd(["top"])
       .start();
 
-    // const response = await container.exec(["sh", "-c", `echo "hello world" | nc host.testcontainers.internal ${randomPort}`]);
-    const response = await container.exec(["curl", "-v", `http://host.testcontainers.internal:${randomPort}`]);
-    // const response = await container.exec(["echo", "hello"]);
-
-    console.log("response", response);
-    // const container = await new GenericContainer("cristianrgreco/testcontainer", "1.1.12")
-    // .withExposedPorts(8080)
-    // .withCmd(["sh", "-c", `echo "hello world" | nc host.testcontainers.internal ${randomPort}`])
-    // .start();
-
-    expect(response.output).toBe("hello world");
-    // await expect(socketReceivesDataPromise).resolves.toBe("hello world");
+    const { output } = await container.exec(["curl", "-v", `http://host.testcontainers.internal:${randomPort}`]);
+    expect(output).toBe("hello world");
 
     await server.close();
     await container.stop();
-    await (await PortForwarderInstance.getInstance(await DockerClientInstance.getInstance())).stop();
-    // await PortForwarderInstance.stop();
-    // todo shutdown server
-    // todo shutdown port forwarder to not interfere with other tests
   });
 
   describe("from Dockerfile", () => {

--- a/src/generic-container.test.ts
+++ b/src/generic-container.test.ts
@@ -354,8 +354,6 @@ describe("GenericContainer", () => {
       }).listen(randomPort, "localhost");
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-
     await TestContainers.exposeHostPorts(randomPort);
 
     const container = await new GenericContainer("cristianrgreco/testcontainer", "1.1.12")
@@ -365,6 +363,7 @@ describe("GenericContainer", () => {
     await expect(socketReceivesDataPromise).resolves.toBe("hello world");
 
     await container.stop();
+    // todo shutdown port forwarder to not interfere with other tests
   });
 
   describe("from Dockerfile", () => {

--- a/src/generic-container.test.ts
+++ b/src/generic-container.test.ts
@@ -352,17 +352,14 @@ describe("GenericContainer", () => {
         res.writeHead(200);
         res.end("hello world");
       });
-      server.on("connection", () => console.log("connection"));
-      server.listen(randomPort, "localhost", () => resolve(server));
+      server.listen(randomPort, () => resolve(server));
     });
 
     await TestContainers.exposeHostPorts(randomPort);
 
-    const container = await new GenericContainer("cristianrgreco/testcontainer", "1.1.12")
-      .withExposedPorts(8080)
-      .start();
+    const container = await new GenericContainer("cristianrgreco/testcontainer", "1.1.12").withCmd(["top"]).start();
 
-    const { output } = await container.exec(["curl", "-v", `http://host.testcontainers.internal:${randomPort}`]);
+    const { output } = await container.exec(["curl", `http://host.testcontainers.internal:${randomPort}`]);
     expect(output).toBe("hello world");
 
     await server.close();

--- a/src/generic-container.ts
+++ b/src/generic-container.ts
@@ -117,7 +117,7 @@ export class GenericContainer implements TestContainer {
       await this.preCreate(dockerClient, boundPorts);
     }
 
-    if (!this.repoTag.isReaper() && !this.repoTag.isPortForwarder() && PortForwarderInstance.isRunning()) {
+    if (!this.repoTag.isHelperContainer() && PortForwarderInstance.isRunning()) {
       const portForwarder = await PortForwarderInstance.getInstance(dockerClient);
       this.extraHosts.push({ host: "host.testcontainers.internal", ipAddress: portForwarder.getIpAddress() });
     }
@@ -138,13 +138,12 @@ export class GenericContainer implements TestContainer {
       extraHosts: this.extraHosts,
     });
 
-    if (!this.repoTag.isReaper() && !this.repoTag.isPortForwarder() && PortForwarderInstance.isRunning()) {
+    if (!this.repoTag.isHelperContainer() && PortForwarderInstance.isRunning()) {
       const portForwarder = await PortForwarderInstance.getInstance(dockerClient);
       const portForwarderNetworkId = portForwarder.getNetworkId();
       const excludedNetworks = [portForwarderNetworkId, "none", "host"];
 
       if (!this.networkMode || !excludedNetworks.includes(this.networkMode)) {
-        // this.networkMode = portForwarderNetworkId;
         await dockerClient.connectToNetwork(container.getId(), portForwarderNetworkId);
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { TestContainer, StartedTestContainer, StoppedTestContainer } from "./test-container";
 export { GenericContainer, GenericContainerBuilder } from "./generic-container";
+export { TestContainers } from "./test-containers";
 
 export {
   DockerComposeEnvironment,

--- a/src/modules/abstract-started-container.ts
+++ b/src/modules/abstract-started-container.ts
@@ -1,5 +1,5 @@
 import { StartedTestContainer, StopOptions, StoppedTestContainer } from "../test-container";
-import { Host } from "../docker-client-factory";
+import { Host } from "../docker-client-instance";
 import { Port } from "../port";
 import { Command, ContainerName, ExecResult } from "../docker-client";
 import { Id as ContainerId } from "../container";
@@ -26,6 +26,14 @@ export class AbstractStartedContainer {
 
   public getId(): ContainerId {
     return this.startedTestContainer.getId();
+  }
+
+  public getNetworkNames(): string[] {
+    return this.startedTestContainer.getNetworkNames();
+  }
+
+  public getNetworkId(networkName: string): string {
+    return this.startedTestContainer.getNetworkId(networkName);
   }
 
   public getIpAddress(networkName: string): string {

--- a/src/modules/arangodb/arangodb-container.ts
+++ b/src/modules/arangodb/arangodb-container.ts
@@ -1,6 +1,6 @@
 import { GenericContainer, Wait } from "../..";
 import { Image, Tag } from "../../repo-tag";
-import { Host } from "../../docker-client-factory";
+import { Host } from "../../docker-client-instance";
 import { StartedTestContainer } from "../../test-container";
 import { Port } from "../../port";
 import { RandomUuid } from "../../uuid";

--- a/src/modules/kafka/kafka-container.ts
+++ b/src/modules/kafka/kafka-container.ts
@@ -3,7 +3,7 @@ import { BoundPorts } from "../../bound-ports";
 import { DockerClient } from "../../docker-client";
 import { Image, Tag } from "../../repo-tag";
 import { Network, StartedNetwork } from "../../network";
-import { Host } from "../../docker-client-factory";
+import { Host } from "../../docker-client-instance";
 import { Port } from "../../port";
 import { PortClient, RandomPortClient } from "../../port-client";
 import { RandomUuid, Uuid } from "../../uuid";

--- a/src/modules/neo4j/neo4j-container.ts
+++ b/src/modules/neo4j/neo4j-container.ts
@@ -1,6 +1,6 @@
 import { GenericContainer, Wait } from "../..";
 import { Image, Tag } from "../../repo-tag";
-import { Host } from "../../docker-client-factory";
+import { Host } from "../../docker-client-instance";
 import { StartedTestContainer } from "../../test-container";
 import { Port } from "../../port";
 import { RandomUuid } from "../../uuid";

--- a/src/network.ts
+++ b/src/network.ts
@@ -1,5 +1,5 @@
 import { CreateNetworkOptions, DockerClient } from "./docker-client";
-import { DockerClientFactory } from "./docker-client-factory";
+import { DockerClientInstance } from "./docker-client-instance";
 import { RandomUuid, Uuid } from "./uuid";
 import { log } from "./logger";
 import { ReaperInstance } from "./reaper";
@@ -24,8 +24,8 @@ export class Network {
   }
 
   public async start(): Promise<StartedNetwork> {
-    const dockerClient = await DockerClientFactory.getClient();
-    await ReaperInstance.start(dockerClient);
+    const dockerClient = await DockerClientInstance.getInstance();
+    await ReaperInstance.getInstance(dockerClient);
 
     const id = await dockerClient.createNetwork(this.createNetworkOptions);
     log.info(`Started network with ID: ${id}`);

--- a/src/port-check.ts
+++ b/src/port-check.ts
@@ -1,7 +1,7 @@
 import { Socket } from "net";
 import { Container } from "./container";
 import { DockerClient } from "./docker-client";
-import { Host } from "./docker-client-factory";
+import { Host } from "./docker-client-instance";
 import { Port } from "./port";
 
 export interface PortCheck {

--- a/src/port-forwarder.ts
+++ b/src/port-forwarder.ts
@@ -2,24 +2,106 @@ import { Client } from "ssh2";
 import { DockerClient } from "./docker-client";
 import { log } from "./logger";
 import { GenericContainer } from "./generic-container";
-import { RandomUuid } from "./uuid";
 import { Port } from "./port";
 import { StartedTestContainer } from "./test-container";
+import * as net from "net";
 
 export class PortForwarder {
-  constructor(private readonly client: Client, private readonly container: StartedTestContainer) {}
+  constructor(private client: Client, private readonly container: StartedTestContainer) {}
+
+  public async stop() {
+    this.client.destroy();
+    // await this.container.stop();
+  }
 
   public async exposeHostPort(port: Port): Promise<void> {
     log.debug(`Exposing host port ${port}`);
 
-    await new Promise((resolve, reject) => {
-      this.client.forwardIn("localhost", port, (err) => {
-        if (err) {
-          return reject(err);
-        }
-        resolve();
-      });
+    return new Promise((resolve) => {
+      const conn = new Client();
+      this.client = conn;
+      conn
+        .on("ready", function () {
+          console.log("Client :: ready");
+          conn.forwardIn("127.0.0.1", port, function (err) {
+            if (err) throw err;
+            console.log(`Listening for connections on server on port ${port}!`);
+            resolve();
+          });
+        })
+        .on("tcp connection", function (info, accept, reject) {
+          console.log("TCP :: INCOMING CONNECTION:");
+          console.dir(info);
+
+          const stream = accept();
+
+          stream.on("data", function (data: any) {
+            console.log("TCP :: DATA: " + data);
+          });
+
+          stream.on("end", function () {
+            console.log("TCP :: EOF");
+            socket.destroy();
+          });
+
+          stream.on("error", function (err: any) {
+            console.log("TCP :: ERROR: " + err);
+          });
+
+          stream.on("close", function (had_err: any) {
+            console.log("TCP :: CLOSED", had_err ? "had error" : "");
+          });
+
+          stream.pause();
+
+          const socket = net.connect(info.destPort, info.destIP, () => {
+            stream.pipe(socket);
+            socket.pipe(stream);
+            stream.resume();
+          });
+
+          /*        accept().on('close', function() {
+          console.log('TCP :: CLOSED');
+        }).on('data', function(data: any) {
+          console.log('TCP :: DATA: ' + data);
+          // const target = net.createConnection({
+          //   host: info.destIP,
+          //   port: info.destPort
+          // });
+          // target.push(data);
+        }).end([
+          'HTTP/1.1 404 Not Found',
+          'Date: Thu, 15 Nov 2012 02:07:58 GMT',
+          'Server: ForwardedConnection',
+          'Content-Length: 0',
+          'Connection: close',
+          '',
+          ''
+        ].join('\r\n'))*/
+        })
+        .connect({
+          host: this.container.getHost(),
+          port: this.container.getMappedPort(22),
+          username: "root",
+          password: "password",
+        });
     });
+
+    // await new Promise((resolve, reject) => {
+    //   this.client.on('tcp connection', (info, accept, reject) => {
+    //     console.log('TCP CONNECTION?', info);
+    //     accept()
+    //     // @ts-ignore
+    //       .on('data', data => console.log('tcp data', data))
+    //   });
+    //   this.client.forwardIn("127.0.0.1", port, (err) => {
+    //     if (err) {
+    //       return reject(err);
+    //     }
+    //     log.debug(`Listening for connections on server on port ${port}`);
+    //     resolve();
+    //   });
+    // });
   }
 
   public getNetworkId(): string {
@@ -55,10 +137,11 @@ export class PortForwarderInstance {
   private static async createInstance(dockerClient: DockerClient): Promise<PortForwarder> {
     log.debug(`Creating new Port Forwarder`);
 
-    const password = new RandomUuid().nextUuid();
+    const password = "password";
 
     const container = await new GenericContainer(this.IMAGE_NAME, this.IMAGE_VERSION)
       .withName(`testcontainers-port-forwarder-${dockerClient.getSessionId()}`)
+      .withDaemonMode()
       .withExposedPorts(22)
       .withEnv("PASSWORD", password)
       .withCmd([
@@ -73,12 +156,13 @@ export class PortForwarderInstance {
 
     log.debug(`Connecting to Port Forwarder on ${host}:${port}`);
 
-    const client: Client = await new Promise((resolve) => {
-      const client = new Client();
-      client.on("ready", () => resolve(client));
-      client.connect({ host, port, username: "root", password });
-    });
+    // const client: Client = await new Promise((resolve) => {
+    //   const client = new Client();
+    //   client.on("ready", () => resolve(client));
+    //   client.connect({ host, port, username: "root", password });
+    // });
 
-    return new PortForwarder(client, container);
+    // @ts-ignore
+    return new PortForwarder(null, container);
   }
 }

--- a/src/port-forwarder.ts
+++ b/src/port-forwarder.ts
@@ -1,0 +1,84 @@
+import { Client } from "ssh2";
+import { DockerClient } from "./docker-client";
+import { log } from "./logger";
+import { GenericContainer } from "./generic-container";
+import { RandomUuid } from "./uuid";
+import { Port } from "./port";
+import { StartedTestContainer } from "./test-container";
+
+export class PortForwarder {
+  constructor(private readonly client: Client, private readonly container: StartedTestContainer) {}
+
+  public async exposeHostPort(port: Port): Promise<void> {
+    log.debug(`Exposing host port ${port}`);
+
+    await new Promise((resolve, reject) => {
+      this.client.forwardIn("localhost", port, (err) => {
+        if (err) {
+          return reject(err);
+        }
+        resolve();
+      });
+    });
+  }
+
+  public getNetworkId(): string {
+    return this.container.getNetworkId(this.getNetworkName());
+  }
+
+  public getIpAddress(): string {
+    return this.container.getIpAddress(this.getNetworkName());
+  }
+
+  private getNetworkName(): string {
+    return this.container.getNetworkNames()[0];
+  }
+}
+
+export class PortForwarderInstance {
+  public static IMAGE_NAME = "testcontainers/sshd";
+  public static IMAGE_VERSION = "1.0.0";
+
+  private static instance: Promise<PortForwarder>;
+
+  public static isRunning(): boolean {
+    return this.instance !== undefined;
+  }
+
+  public static async getInstance(dockerClient: DockerClient): Promise<PortForwarder> {
+    if (!this.instance) {
+      this.instance = this.createInstance(dockerClient);
+    }
+    return this.instance;
+  }
+
+  private static async createInstance(dockerClient: DockerClient): Promise<PortForwarder> {
+    log.debug(`Creating new Port Forwarder`);
+
+    const password = new RandomUuid().nextUuid();
+
+    const container = await new GenericContainer(this.IMAGE_NAME, this.IMAGE_VERSION)
+      .withName(`testcontainers-port-forwarder-${dockerClient.getSessionId()}`)
+      .withExposedPorts(22)
+      .withEnv("PASSWORD", password)
+      .withCmd([
+        "sh",
+        "-c",
+        `echo "root:$PASSWORD" | chpasswd && /usr/sbin/sshd -D -o PermitRootLogin=yes -o AddressFamily=inet -o GatewayPorts=yes`,
+      ])
+      .start();
+
+    const host = dockerClient.getHost();
+    const port = container.getMappedPort(22);
+
+    log.debug(`Connecting to Port Forwarder on ${host}:${port}`);
+
+    const client: Client = await new Promise((resolve) => {
+      const client = new Client();
+      client.on("ready", () => resolve(client));
+      client.connect({ host, port, username: "root", password });
+    });
+
+    return new PortForwarder(client, container);
+  }
+}

--- a/src/reaper.ts
+++ b/src/reaper.ts
@@ -34,7 +34,7 @@ export class ReaperInstance {
 
   private static instance: Promise<Reaper>;
 
-  public static async start(dockerClient: DockerClient): Promise<Reaper> {
+  public static async getInstance(dockerClient: DockerClient): Promise<Reaper> {
     if (!this.instance) {
       if (this.isEnabled()) {
         this.instance = this.createRealInstance(dockerClient);
@@ -62,7 +62,7 @@ export class ReaperInstance {
 
     log.debug(`Creating new Reaper for session: ${sessionId}`);
     const container = await new GenericContainer(this.IMAGE_NAME, this.IMAGE_VERSION)
-      .withName(`ryuk-${sessionId}`)
+      .withName(`testcontainers-ryuk-${sessionId}`)
       .withExposedPorts(8080)
       .withWaitStrategy(Wait.forLogMessage("Started!"))
       .withBindMount("/var/run/docker.sock", "/var/run/docker.sock")

--- a/src/repo-tag.ts
+++ b/src/repo-tag.ts
@@ -5,6 +5,8 @@ export type Image = string;
 export type Tag = string;
 
 export class RepoTag {
+  private readonly helperContainers = new Set([ReaperInstance.IMAGE_NAME, PortForwarderInstance.IMAGE_NAME]);
+
   constructor(private readonly image: Image, private readonly tag: Tag) {}
 
   public equals(repoTag: RepoTag): boolean {
@@ -19,7 +21,7 @@ export class RepoTag {
     return this.image === ReaperInstance.IMAGE_NAME;
   }
 
-  public isPortForwarder(): boolean {
-    return this.image === PortForwarderInstance.IMAGE_NAME;
+  public isHelperContainer(): boolean {
+    return this.helperContainers.has(this.image);
   }
 }

--- a/src/repo-tag.ts
+++ b/src/repo-tag.ts
@@ -5,7 +5,7 @@ export type Image = string;
 export type Tag = string;
 
 export class RepoTag {
-  private readonly helperContainers = new Set([ReaperInstance.IMAGE_NAME, PortForwarderInstance.IMAGE_NAME]);
+  private readonly HELPER_CONTAINERS = new Set([ReaperInstance.IMAGE_NAME, PortForwarderInstance.IMAGE_NAME]);
 
   constructor(private readonly image: Image, private readonly tag: Tag) {}
 
@@ -22,6 +22,6 @@ export class RepoTag {
   }
 
   public isHelperContainer(): boolean {
-    return this.helperContainers.has(this.image);
+    return this.HELPER_CONTAINERS.has(this.image);
   }
 }

--- a/src/repo-tag.ts
+++ b/src/repo-tag.ts
@@ -1,4 +1,5 @@
 import { ReaperInstance } from "./reaper";
+import { PortForwarderInstance } from "./port-forwarder";
 
 export type Image = string;
 export type Tag = string;
@@ -16,5 +17,9 @@ export class RepoTag {
 
   public isReaper(): boolean {
     return this.image === ReaperInstance.IMAGE_NAME;
+  }
+
+  public isPortForwarder(): boolean {
+    return this.image === PortForwarderInstance.IMAGE_NAME;
   }
 }

--- a/src/test-container.ts
+++ b/src/test-container.ts
@@ -11,7 +11,7 @@ import {
   NetworkMode,
   TmpFs,
 } from "./docker-client";
-import { Host } from "./docker-client-factory";
+import { Host } from "./docker-client-instance";
 import { Port } from "./port";
 import { PullPolicy } from "./pull-policy";
 import { WaitStrategy } from "./wait-strategy";
@@ -49,6 +49,8 @@ export interface StartedTestContainer {
   getMappedPort(port: Port): Port;
   getName(): ContainerName;
   getId(): Id;
+  getNetworkNames(): string[];
+  getNetworkId(networkName: string): string;
   getIpAddress(networkName: string): string;
   exec(command: Command[]): Promise<ExecResult>;
   logs(): Promise<Readable>;

--- a/src/test-containers.ts
+++ b/src/test-containers.ts
@@ -1,0 +1,10 @@
+import { Port } from "./port";
+import { PortForwarderInstance } from "./port-forwarder";
+import { DockerClientInstance } from "./docker-client-instance";
+
+export class TestContainers {
+  public static async exposeHostPorts(...ports: Port[]): Promise<void> {
+    const portForwarder = await PortForwarderInstance.getInstance(await DockerClientInstance.getInstance());
+    await Promise.all(ports.map((port) => portForwarder.exposeHostPort(port)));
+  }
+}


### PR DESCRIPTION
#163﻿

Docs: https://www.testcontainers.org/features/networking/#exposing-host-ports-to-the-container

Example usage:

```javascript
const { GenericContainer, TestContainers } = require("testcontainers");
const { createServer } = require("http");

const server = createServer((req, res) => {
  res.writeHead(200);
  res.end("hello world");
});
server.listen(8000);

await TestContainers.exposeHostPorts(8000);

const container = await new GenericContainer("alpine")
  .withCmd(["top"])
  .start();

const { output } = await container.exec(["curl", `http://host.testcontainers.internal:8000`]);
assert(output === "hello world");
```