### PR TITLE
Add possibility to specify custom ryuk image

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The following environment variables are supported:
 | `DEBUG` | `testcontainers*` | See all output |
 | `DOCKER_HOST` | `tcp://docker:2375` | Override the Docker host |
 | `TESTCONTAINERS_RYUK_DISABLED` | `true` | Disable [ryuk](#ryuk) |
+| `RYUK_CONTAINER_IMAGE` | `registry.mycompany.com/mirror/ryuk:0.3.0` | Custom image name for [ryuk](#ryuk) |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The following environment variables are supported:
 | `DEBUG` | `testcontainers*` | See all output |
 | `DOCKER_HOST` | `tcp://docker:2375` | Override the Docker host |
 | `TESTCONTAINERS_RYUK_DISABLED` | `true` | Disable [ryuk](#ryuk) |
-| `RYUK_CONTAINER_IMAGE` | `registry.mycompany.com/mirror/ryuk:0.3.0` | Custom image name for [ryuk](#ryuk) |
+| `RYUK_CONTAINER_IMAGE` | `registry.mycompany.com/mirror/ryuk:0.3.0` | Custom image for [ryuk](#ryuk) |
 
 ## Modules
 

--- a/src/reaper.ts
+++ b/src/reaper.ts
@@ -50,14 +50,14 @@ export class ReaperInstance {
     return process.env.TESTCONTAINERS_RYUK_DISABLED !== "true";
   }
 
-  private static resolveRyukImageName(): string {
+  private static getImageName(): string {
     if (process.env.RYUK_CONTAINER_IMAGE !== undefined) {
       this.IMAGE_NAME = process.env.RYUK_CONTAINER_IMAGE.split(/:/)[0];
     }
     return this.IMAGE_NAME;
   }
 
-  private static resolveRyukImageVersion(): string {
+  private static getImageVersion(): string {
     if (process.env.RYUK_CONTAINER_IMAGE !== undefined) {
       this.IMAGE_VERSION = process.env.RYUK_CONTAINER_IMAGE.split(/:/)[1];
     }
@@ -75,10 +75,7 @@ export class ReaperInstance {
     const sessionId = dockerClient.getSessionId();
 
     log.debug(`Creating new Reaper for session: ${sessionId}`);
-    const container = await new GenericContainer(
-      ReaperInstance.resolveRyukImageName(),
-      ReaperInstance.resolveRyukImageVersion()
-    )
+    const container = await new GenericContainer(this.getImageName(), this.getImageVersion())
       .withName(`testcontainers-ryuk-${sessionId}`)
       .withExposedPorts(8080)
       .withWaitStrategy(Wait.forLogMessage("Started!"))

--- a/src/reaper.ts
+++ b/src/reaper.ts
@@ -59,7 +59,7 @@ export class ReaperInstance {
 
   private static resolveRyukImageVersion(): string {
     if (process.env.RYUK_CONTAINER_IMAGE !== undefined) {
-      this.IMAGE_NAME = process.env.RYUK_CONTAINER_IMAGE.split(/:/)[1];
+      this.IMAGE_VERSION = process.env.RYUK_CONTAINER_IMAGE.split(/:/)[1];
     }
     return this.IMAGE_VERSION;
   }

--- a/src/reaper.ts
+++ b/src/reaper.ts
@@ -50,6 +50,20 @@ export class ReaperInstance {
     return process.env.TESTCONTAINERS_RYUK_DISABLED !== "true";
   }
 
+  private static resolveRyukImageName(): string {
+    if (process.env.RYUK_CONTAINER_IMAGE !== undefined) {
+      this.IMAGE_NAME = process.env.RYUK_CONTAINER_IMAGE.split(/:/)[0];
+    }
+    return this.IMAGE_NAME;
+  }
+
+  private static resolveRyukImageVersion(): string {
+    if (process.env.RYUK_CONTAINER_IMAGE !== undefined) {
+      this.IMAGE_NAME = process.env.RYUK_CONTAINER_IMAGE.split(/:/)[1];
+    }
+    return this.IMAGE_VERSION;
+  }
+
   private static createDisabledInstance(dockerClient: DockerClient): Promise<Reaper> {
     const sessionId = dockerClient.getSessionId();
 
@@ -61,7 +75,10 @@ export class ReaperInstance {
     const sessionId = dockerClient.getSessionId();
 
     log.debug(`Creating new Reaper for session: ${sessionId}`);
-    const container = await new GenericContainer(this.IMAGE_NAME, this.IMAGE_VERSION)
+    const container = await new GenericContainer(
+      ReaperInstance.resolveRyukImageName(),
+      ReaperInstance.resolveRyukImageVersion()
+    )
       .withName(`testcontainers-ryuk-${sessionId}`)
       .withExposedPorts(8080)
       .withWaitStrategy(Wait.forLogMessage("Started!"))


### PR DESCRIPTION
In testcontainers-java there is a possibility to customizing Ryuk resource reaper
https://www.testcontainers.org/features/configuration/#customizing-ryuk-resource-reaper
mainly to use private registry for containers pooling(as in my case)