### PR TITLE
Add ability to copy files to a container before it is started

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,18 @@ const container = await new GenericContainer("postgres")
   .start();
 ```
 
+Copy a file to a container before it is started:
+
+```javascript
+const { GenericContainer } = require("testcontainers");
+
+const container = await new GenericContainer("postgres")
+  .withExposedPorts(5432)
+  .withCopyFileToContainer("/local/file.txt", "/remote/file1.txt")
+  .withCopyContentToContainer("hello world", "/remote/file2.txt")
+  .start();
+```
+
 Creating a container with environment variables:
 
 ```javascript

--- a/package-lock.json
+++ b/package-lock.json
@@ -737,6 +737,15 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@types/archiver": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-5.1.0.tgz",
+      "integrity": "sha512-baFOhanb/hxmcOd1Uey2TfFg43kTSmM6py1Eo7Rjbv/ivcl7PXLhY0QgXGf50Hx/eskGCFqPfhs/7IZLb15C5g==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "*"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.12",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.12.tgz",
@@ -1170,6 +1179,84 @@
         "xhr": "^2.4.1"
       }
     },
+    "archiver": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.2.0.tgz",
+      "integrity": "sha512-QEAKlgQuAtUxKeZB9w5/ggKXh21bZS+dzzuQ0RPBC20qtDCbTyzqmisoeJP46MP39fg4B4IcyvR+yeyEBdblsQ==",
+      "requires": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.0",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.0.0",
+        "tar-stream": "^2.1.4",
+        "zip-stream": "^4.0.4"
+      },
+      "dependencies": {
+        "bl": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+          "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.4.0"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+              "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+            }
+          }
+        },
+        "tar-stream": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+          "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+          "requires": {
+            "bl": "^4.0.3",
+            "end-of-stream": "^1.4.1",
+            "fs-constants": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1"
+          }
+        }
+      }
+    },
+    "archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "requires": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        }
+      }
+    },
     "arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -1240,6 +1327,11 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
+    },
+    "async": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -1468,6 +1560,11 @@
         "ieee754": "^1.1.13"
       }
     },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -1692,6 +1789,17 @@
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
+    "compress-commons": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.2.tgz",
+      "integrity": "sha512-qhd32a9xgzmpfoga1VQEiLEwdKZ6Plnpx5UCgIsf89FSolyJ7WnifY4Gtjgv5WR6hWAyRaHxC5MiEhU/38U70A==",
+      "requires": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1715,8 +1823,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cosmiconfig": {
       "version": "7.0.0",
@@ -1729,6 +1836,24 @@
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
+      }
+    },
+    "crc-32": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
+      "integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
+      "requires": {
+        "exit-on-epipe": "~1.0.1",
+        "printj": "~1.1.0"
+      }
+    },
+    "crc32-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.1.tgz",
+      "integrity": "sha512-FN5V+weeO/8JaXsamelVYO1PHyeCsuL3HcG4cqsj0ceARcocxalaShCsohZMSAF+db7UYFwBy1rARK/0oFItUw==",
+      "requires": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
       }
     },
     "create-require": {
@@ -2343,6 +2468,11 @@
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
+    "exit-on-epipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
+      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw=="
+    },
     "expand-brackets": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -2795,8 +2925,7 @@
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-      "dev": true
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "growly": {
       "version": "1.3.0",
@@ -3221,8 +3350,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -3909,6 +4037,30 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "lazystream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+      "requires": {
+        "readable-stream": "^2.0.5"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        }
+      }
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -4028,6 +4180,26 @@
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+    },
+    "lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -4039,6 +4211,11 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
+    },
+    "lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
     },
     "log-symbols": {
       "version": "4.0.0",
@@ -4345,8 +4522,7 @@
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -4645,11 +4821,21 @@
         "react-is": "^17.0.1"
       }
     },
+    "printj": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
+      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ=="
+    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -4739,6 +4925,14 @@
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
+      }
+    },
+    "readdir-glob": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.1.tgz",
+      "integrity": "sha512-91/k1EzZwDx6HbERR+zucygRFfiPl2zkIYZtv3Jjr6Mn7SkKcVct8aVO+sSRiGMc6fLf72du3d92/uY63YPdEA==",
+      "requires": {
+        "minimatch": "^3.0.4"
       }
     },
     "regenerator-runtime": {
@@ -6309,6 +6503,16 @@
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
+    },
+    "zip-stream": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.4.tgz",
+      "integrity": "sha512-a65wQ3h5gcQ/nQGWV1mSZCEzCML6EK/vyVPcrPNynySP1j3VBbQKh3nhC8CbORb+jfl2vXvh56Ul5odP1bAHqw==",
+      "requires": {
+        "archiver-utils": "^2.1.0",
+        "compress-commons": "^4.0.2",
+        "readable-stream": "^3.6.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@types/dockerode": "^3.2.1",
+    "archiver": "^5.2.0",
     "byline": "^5.0.0",
     "debug": "^4.3.1",
     "docker-compose": "^0.23.5",
@@ -45,6 +46,7 @@
   },
   "devDependencies": {
     "@elastic/elasticsearch": "^7.10.0",
+    "@types/archiver": "^5.1.0",
     "@types/byline": "^4.2.32",
     "@types/debug": "4.1.5",
     "@types/glob": "^7.1.3",

--- a/src/container.ts
+++ b/src/container.ts
@@ -55,6 +55,7 @@ export interface Container {
   exec(options: ExecOptions): Promise<Exec>;
   logs(): Promise<Readable>;
   inspect(): Promise<InspectResult>;
+  putArchive(stream: Readable, containerPath: string): Promise<void>;
 }
 
 export class DockerodeContainer implements Container {
@@ -117,6 +118,15 @@ export class DockerodeContainer implements Container {
       healthCheckStatus: this.getHealthCheckStatus(inspectResult),
       networkSettings: this.getNetworkSettings(inspectResult),
     };
+  }
+
+  public async putArchive(stream: Readable, containerPath: string): Promise<void> {
+    const respStream = await this.container.putArchive(stream, { path: containerPath });
+    await new Promise((resolve, reject) =>
+      this.container.modem.followProgress(respStream, (err: unknown, res: unknown) =>
+        err ? reject(err) : resolve(res)
+      )
+    );
   }
 
   private getName(inspectInfo: ContainerInspectInfo): ContainerName {

--- a/src/container.ts
+++ b/src/container.ts
@@ -3,6 +3,7 @@ import { log } from "./logger";
 import { Command, ContainerName, ExitCode } from "./docker-client";
 import { Port } from "./port";
 import { Duplex, Readable } from "stream";
+import streamToArray from "stream-to-array";
 
 export type Id = string;
 
@@ -122,11 +123,7 @@ export class DockerodeContainer implements Container {
 
   public async putArchive(stream: Readable, containerPath: string): Promise<void> {
     const respStream = await this.container.putArchive(stream, { path: containerPath });
-    await new Promise((resolve, reject) =>
-      this.container.modem.followProgress(respStream, (err: unknown, res: unknown) =>
-        err ? reject(err) : resolve(res)
-      )
-    );
+    await streamToArray(respStream);
   }
 
   private getName(inspectInfo: ContainerInspectInfo): ContainerName {

--- a/src/generic-container.test.ts
+++ b/src/generic-container.test.ts
@@ -355,6 +355,32 @@ describe("GenericContainer", () => {
     await container.stop();
   });
 
+  it("should copy file to container", async () => {
+    const source = path.resolve(fixtures, "docker", "test.txt");
+    const target = "/tmp/test.txt";
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.12")
+      .withCopyFileToContainer(source, target)
+      .withExposedPorts(8080)
+      .start();
+    const { output } = await container.exec(["cat", target]);
+
+    expect(output).toBe("hello world");
+    await container.stop();
+  });
+
+  it("should copy content to container", async () => {
+    const content = "hello world";
+    const target = "/tmp/test.txt";
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.12")
+      .withCopyContentToContainer(content, target)
+      .withExposedPorts(8080)
+      .start();
+    const { output } = await container.exec(["cat", target]);
+
+    expect(output).toBe(content);
+    await container.stop();
+  });
+
   describe("from Dockerfile", () => {
     it("should build and start", async () => {
       const context = path.resolve(fixtures, "docker");

--- a/src/generic-container.ts
+++ b/src/generic-container.ts
@@ -90,7 +90,7 @@ export class GenericContainer implements TestContainer {
   protected privilegedMode = false;
   protected daemonMode = false;
   protected pullPolicy: PullPolicy = new DefaultPullPolicy();
-  protected tarToCopy: archiver.Archiver | undefined;
+  protected tarToCopy?: archiver.Archiver;
 
   private extraHosts: ExtraHost[] = [];
 

--- a/src/generic-container.ts
+++ b/src/generic-container.ts
@@ -1,3 +1,4 @@
+import archiver from "archiver";
 import { BoundPorts } from "./bound-ports";
 import { Container, Id as ContainerId, InspectResult } from "./container";
 import { ContainerState } from "./container-state";
@@ -89,6 +90,7 @@ export class GenericContainer implements TestContainer {
   protected privilegedMode = false;
   protected daemonMode = false;
   protected pullPolicy: PullPolicy = new DefaultPullPolicy();
+  protected tarToCopy: archiver.Archiver | undefined;
 
   private extraHosts: ExtraHost[] = [];
 
@@ -143,6 +145,11 @@ export class GenericContainer implements TestContainer {
       if (!this.networkMode || !excludedNetworks.includes(this.networkMode)) {
         await dockerClient.connectToNetwork(container.getId(), portForwarderNetworkId);
       }
+    }
+
+    if (this.tarToCopy) {
+      this.tarToCopy.finalize();
+      await container.putArchive(this.tarToCopy, "/");
     }
 
     log.info(`Starting container ${this.dockerImageName} with ID: ${container.getId()}`);
@@ -239,9 +246,26 @@ export class GenericContainer implements TestContainer {
     return this;
   }
 
+  public withCopyFileToContainer(sourcePath: string, containerPath: string): this {
+    this.getTarToCopy().file(sourcePath, { name: containerPath });
+    return this;
+  }
+
+  public withCopyContentToContainer(content: string | Buffer | Readable, containerPath: string): this {
+    this.getTarToCopy().append(content, { name: containerPath });
+    return this;
+  }
+
   public async isImageCached(dockerClient: DockerClient): Promise<boolean> {
     const dockerImageNames = await dockerClient.fetchDockerImageNames();
     return dockerImageNames.some((dockerImageName) => dockerImageName.equals(this.dockerImageName));
+  }
+
+  protected getTarToCopy(): archiver.Archiver {
+    if (!this.tarToCopy) {
+      this.tarToCopy = archiver("tar");
+    }
+    return this.tarToCopy;
   }
 
   protected preCreate?(dockerClient: DockerClient, boundPorts: BoundPorts): Promise<void>;

--- a/src/test-container.ts
+++ b/src/test-container.ts
@@ -29,6 +29,8 @@ export interface TestContainer {
   withDefaultLogDriver(): this;
   withPrivilegedMode(): this;
   withPullPolicy(pullPolicy: PullPolicy): this;
+  withCopyFileToContainer(sourcePath: string, containerPath: string): this;
+  withCopyContentToContainer(content: string | Buffer | Readable, containerPath: string): this;
 }
 
 export interface StopOptions {


### PR DESCRIPTION
This adds two functions to `GenericContainer`:
```typescript
withCopyFileToContainer(sourcePath: string, containerPath: string);

withCopyContentToContainer(content: string | Buffer | Readable, containerPath: string);
```
Similar API also exists in the [Java library](https://javadoc.io/static/org.testcontainers/testcontainers/1.15.1/org/testcontainers/containers/GenericContainer.html#withCopyFileToContainer-org.testcontainers.utility.MountableFile-java.lang.String-).