### PR TITLE
Propagate a clear error when a container with LogWaitStrategy fails

### DIFF
--- a/src/wait-strategy.ts
+++ b/src/wait-strategy.ts
@@ -120,7 +120,7 @@ export class LogWaitStrategy extends AbstractWaitStrategy {
         .on("end", () => {
           stream.destroy();
           clearTimeout(timeout);
-          reject();
+          reject(new Error(`Log stream ended and message "${this.message}" was not received`));
         });
     });
   }


### PR DESCRIPTION
Right now if a container that uses `Wait.forLogMessage` fails ot start, then `undefined` is thrown and the only thing that gets printed by e.g. Jest is
```
thrown: undefined
```