### PR TITLE
Port host override feature from testcontainers-java

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The following environment variables are supported:
 | `DEBUG` | `testcontainers*` | See all output |
 | `DOCKER_HOST` | `tcp://docker:2375` | Override the Docker host |
 | `TESTCONTAINERS_RYUK_DISABLED` | `true` | Disable [ryuk](#ryuk) |
+| `TESTCONTAINERS_HOST_OVERRIDE` | `docker.svc.local` | Override Docker's host on which ports are exposed |
 | `RYUK_CONTAINER_IMAGE` | `registry.mycompany.com/mirror/ryuk:0.3.0` | Custom image for [ryuk](#ryuk) |
 | `SSHD_CONTAINER_IMAGE` | `registry.mycompany.com/mirror/sshd:1.0.0` | Custom image for [SSHd](#SSHd) |
 

--- a/src/docker-client-instance.ts
+++ b/src/docker-client-instance.ts
@@ -36,7 +36,11 @@ export class DockerClientInstance {
       return host;
     } else {
       const socketPath = modem.socketPath;
-      if (!fs.existsSync("/.dockerenv")) {
+      if (process.env["TESTCONTAINERS_HOST_OVERRIDE"]) {
+        const host = process.env["TESTCONTAINERS_HOST_OVERRIDE"];
+        log.info(`Using TESTCONTAINERS_HOST_OVERRIDE: ${host}, socket path: ${socketPath}`);
+        return host;
+      } else if (!fs.existsSync("/.dockerenv")) {
         const host = "localhost";
         log.info(`Using default Docker host: ${host}, socket path: ${socketPath}`);
         return host;


### PR DESCRIPTION
This is used when a (possibly remote) docker daemon brings up the container at a network address other than localhost.

In testcontainers-java the logic appears here https://github.com/testcontainers/testcontainers-java/blob/c3a8ca76d0ed69f71c94e5bc2f7f1e0eef1a2259/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java#L264
similarly to this testcontainers-node change, this is checked immediately before looking into the "bridge" network to find a gateway address to the container.

We use this environment variable for our Java tests and want to have the Node tests behave the same way. This is because we run our CI on Buildkite, where agents running the tests are already containerized, so they reach out to a docker daemon running outside this container on the physical machine. Therefore the testcontainers are not on the local network address.