### PR TITLE
Improve docker config auth loader registry matching

### DIFF
--- a/src/registry-auth-locator/auths.test.ts
+++ b/src/registry-auth-locator/auths.test.ts
@@ -20,6 +20,11 @@ describe("Auths", () => {
       const dockerConfig: DockerConfig = { auths: { "registry-name": { auth: "value" } } };
       expect(locator.isApplicable("registry-name", dockerConfig)).toBe(true);
     });
+
+    it("should return true when auths contains url for registry", () => {
+      const dockerConfig: DockerConfig = { auths: { "https://index.docker.io/v1/": { auth: "value" } } };
+      expect(locator.isApplicable("index.docker.io", dockerConfig)).toBe(true);
+    });
   });
 
   describe("getAuthConfig", () => {


### PR DESCRIPTION
Allows auth config to be loaded from the docker config file when the entry for a given registry is keyed under the registry's URL.

Implementation based on corresponding logic in `testcontainers-java`: https://github.com/testcontainers/testcontainers-java/blob/b3cf0624c8f251af0e5361d3a92d155d3563b372/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java#L208