### PR TITLE
Output daemon container logs

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -4,6 +4,7 @@ import { Command, ContainerName, ExitCode } from "./docker-client";
 import { Port } from "./port";
 import { Duplex, Readable } from "stream";
 import streamToArray from "stream-to-array";
+import { IncomingMessage } from "http";
 
 export type Id = string;
 
@@ -54,7 +55,7 @@ export interface Container {
   stop(options: StopOptions): Promise<void>;
   remove(options: RemoveOptions): Promise<void>;
   exec(options: ExecOptions): Promise<Exec>;
-  logs(): Promise<Readable>;
+  logs(): Promise<IncomingMessage>;
   inspect(): Promise<InspectResult>;
   putArchive(stream: Readable, containerPath: string): Promise<void>;
 }
@@ -101,13 +102,13 @@ export class DockerodeContainer implements Container {
     );
   }
 
-  public async logs(): Promise<Readable> {
+  public async logs(): Promise<IncomingMessage> {
     const options = {
       follow: true,
       stdout: true,
       stderr: true,
     };
-    return (await this.container.logs(options)).setEncoding("utf-8") as Readable;
+    return (await this.container.logs(options)).setEncoding("utf-8") as IncomingMessage;
   }
 
   public async inspect(): Promise<InspectResult> {

--- a/src/docker-client.ts
+++ b/src/docker-client.ts
@@ -167,7 +167,7 @@ export class DockerodeClient implements DockerClient {
         Tmpfs: options.tmpFs,
         LogConfig: this.getLogConfig(options.useDefaultLogDriver),
         Privileged: options.privilegedMode,
-      }
+      },
     });
 
     return new DockerodeContainer(dockerodeContainer);

--- a/src/generic-container.test.ts
+++ b/src/generic-container.test.ts
@@ -8,7 +8,7 @@ import { RandomUuid } from "./uuid";
 import { TestContainers } from "./test-containers";
 import { RandomPortClient } from "./port-client";
 import { getContainerById, getEvents, getRunningContainerNames } from "./test-helper";
-import {Network} from "./network";
+import { Network } from "./network";
 
 describe("GenericContainer", () => {
   jest.setTimeout(180_000);

--- a/src/generic-container.ts
+++ b/src/generic-container.ts
@@ -1,8 +1,8 @@
 import archiver from "archiver";
 import path from "path";
-import {BoundPorts} from "./bound-ports";
-import {Container, Id as ContainerId, InspectResult} from "./container";
-import {ContainerState} from "./container-state";
+import { BoundPorts } from "./bound-ports";
+import { Container, Id as ContainerId, InspectResult } from "./container";
+import { ContainerState } from "./container-state";
 import {
   AuthConfig,
   BindMode,
@@ -23,13 +23,13 @@ import {
   RegistryConfig,
   TmpFs,
 } from "./docker-client";
-import {DockerClientInstance, Host} from "./docker-client-instance";
-import {containerLog, log} from "./logger";
-import {Port} from "./port";
-import {PortBinder} from "./port-binder";
-import {HostPortCheck, InternalPortCheck} from "./port-check";
-import {DefaultPullPolicy, PullPolicy} from "./pull-policy";
-import {DockerImageName} from "./docker-image-name";
+import { DockerClientInstance, Host } from "./docker-client-instance";
+import { containerLog, log } from "./logger";
+import { Port } from "./port";
+import { PortBinder } from "./port-binder";
+import { HostPortCheck, InternalPortCheck } from "./port-check";
+import { DefaultPullPolicy, PullPolicy } from "./pull-policy";
+import { DockerImageName } from "./docker-image-name";
 import {
   DEFAULT_STOP_OPTIONS,
   StartedTestContainer,
@@ -37,13 +37,13 @@ import {
   StoppedTestContainer,
   TestContainer,
 } from "./test-container";
-import {RandomUuid, Uuid} from "./uuid";
-import {HostPortWaitStrategy, WaitStrategy} from "./wait-strategy";
-import {ReaperInstance} from "./reaper";
-import {Readable} from "stream";
-import {PortForwarderInstance} from "./port-forwarder";
-import {getAuthConfig} from "./registry-auth-locator";
-import {getDockerfileImages} from "./dockerfile-parser";
+import { RandomUuid, Uuid } from "./uuid";
+import { HostPortWaitStrategy, WaitStrategy } from "./wait-strategy";
+import { ReaperInstance } from "./reaper";
+import { Readable } from "stream";
+import { PortForwarderInstance } from "./port-forwarder";
+import { getAuthConfig } from "./registry-auth-locator";
+import { getDockerfileImages } from "./dockerfile-parser";
 
 export class GenericContainerBuilder {
   private buildArgs: BuildArgs = {};
@@ -53,8 +53,7 @@ export class GenericContainerBuilder {
     private readonly context: BuildContext,
     private readonly dockerfileName: string,
     private readonly uuid: Uuid = new RandomUuid()
-  ) {
-  }
+  ) {}
 
   public withBuildArg(key: string, value: string): GenericContainerBuilder {
     this.buildArgs[key] = value;
@@ -116,7 +115,7 @@ export class GenericContainerBuilder {
           },
         };
       })
-      .reduce((prev, next) => ({...prev, ...next}), {} as RegistryConfig);
+      .reduce((prev, next) => ({ ...prev, ...next }), {} as RegistryConfig);
   }
 }
 
@@ -176,7 +175,7 @@ export class GenericContainer implements TestContainer {
 
     if (!this.dockerImageName.isHelperContainer() && PortForwarderInstance.isRunning()) {
       const portForwarder = await PortForwarderInstance.getInstance(dockerClient);
-      this.extraHosts.push({host: "host.testcontainers.internal", ipAddress: portForwarder.getIpAddress()});
+      this.extraHosts.push({ host: "host.testcontainers.internal", ipAddress: portForwarder.getIpAddress() });
     }
 
     const container = await dockerClient.create({
@@ -278,7 +277,7 @@ export class GenericContainer implements TestContainer {
   }
 
   public withBindMount(source: Dir, target: Dir, bindMode: BindMode = "rw"): this {
-    this.bindMounts.push({source, target, bindMode});
+    this.bindMounts.push({ source, target, bindMode });
     return this;
   }
 
@@ -323,12 +322,12 @@ export class GenericContainer implements TestContainer {
   }
 
   public withCopyFileToContainer(sourcePath: string, containerPath: string): this {
-    this.getTarToCopy().file(sourcePath, {name: containerPath});
+    this.getTarToCopy().file(sourcePath, { name: containerPath });
     return this;
   }
 
   public withCopyContentToContainer(content: string | Buffer | Readable, containerPath: string): this {
-    this.getTarToCopy().append(content, {name: containerPath});
+    this.getTarToCopy().append(content, { name: containerPath });
     return this;
   }
 
@@ -363,8 +362,8 @@ export class GenericContainer implements TestContainer {
       }
 
       try {
-        await container.stop({timeout: 0});
-        await container.remove({removeVolumes: true});
+        await container.stop({ timeout: 0 });
+        await container.remove({ removeVolumes: true });
       } catch (stopErr) {
         log.error(`Failed to stop container after it failed to be ready: ${stopErr}`);
       }
@@ -390,8 +389,7 @@ export class StartedGenericContainer implements StartedTestContainer {
     private readonly boundPorts: BoundPorts,
     private readonly name: ContainerName,
     private readonly dockerClient: DockerClient
-  ) {
-  }
+  ) {}
 
   public async stop(options: Partial<StopOptions> = {}): Promise<StoppedTestContainer> {
     return await this.stopContainer(options);
@@ -399,9 +397,9 @@ export class StartedGenericContainer implements StartedTestContainer {
 
   private async stopContainer(options: Partial<StopOptions> = {}): Promise<StoppedGenericContainer> {
     log.info(`Stopping container with ID: ${this.container.getId()}`);
-    const resolvedOptions = {...DEFAULT_STOP_OPTIONS, ...options};
-    await this.container.stop({timeout: resolvedOptions.timeout});
-    await this.container.remove({removeVolumes: resolvedOptions.removeVolumes});
+    const resolvedOptions = { ...DEFAULT_STOP_OPTIONS, ...options };
+    await this.container.stop({ timeout: resolvedOptions.timeout });
+    await this.container.remove({ removeVolumes: resolvedOptions.removeVolumes });
     return new StoppedGenericContainer();
   }
 
@@ -442,5 +440,4 @@ export class StartedGenericContainer implements StartedTestContainer {
   }
 }
 
-class StoppedGenericContainer implements StoppedTestContainer {
-}
+class StoppedGenericContainer implements StoppedTestContainer {}

--- a/src/generic-container.ts
+++ b/src/generic-container.ts
@@ -1,8 +1,8 @@
 import archiver from "archiver";
 import path from "path";
-import { BoundPorts } from "./bound-ports";
-import { Container, Id as ContainerId, InspectResult } from "./container";
-import { ContainerState } from "./container-state";
+import {BoundPorts} from "./bound-ports";
+import {Container, Id as ContainerId, InspectResult} from "./container";
+import {ContainerState} from "./container-state";
 import {
   AuthConfig,
   BindMode,
@@ -23,13 +23,13 @@ import {
   RegistryConfig,
   TmpFs,
 } from "./docker-client";
-import { DockerClientInstance, Host } from "./docker-client-instance";
-import { containerLog, log } from "./logger";
-import { Port } from "./port";
-import { PortBinder } from "./port-binder";
-import { HostPortCheck, InternalPortCheck } from "./port-check";
-import { DefaultPullPolicy, PullPolicy } from "./pull-policy";
-import { DockerImageName } from "./docker-image-name";
+import {DockerClientInstance, Host} from "./docker-client-instance";
+import {containerLog, log} from "./logger";
+import {Port} from "./port";
+import {PortBinder} from "./port-binder";
+import {HostPortCheck, InternalPortCheck} from "./port-check";
+import {DefaultPullPolicy, PullPolicy} from "./pull-policy";
+import {DockerImageName} from "./docker-image-name";
 import {
   DEFAULT_STOP_OPTIONS,
   StartedTestContainer,
@@ -37,13 +37,13 @@ import {
   StoppedTestContainer,
   TestContainer,
 } from "./test-container";
-import { RandomUuid, Uuid } from "./uuid";
-import { HostPortWaitStrategy, WaitStrategy } from "./wait-strategy";
-import { ReaperInstance } from "./reaper";
-import { Readable } from "stream";
-import { PortForwarderInstance } from "./port-forwarder";
-import { getAuthConfig } from "./registry-auth-locator";
-import { getDockerfileImages } from "./dockerfile-parser";
+import {RandomUuid, Uuid} from "./uuid";
+import {HostPortWaitStrategy, WaitStrategy} from "./wait-strategy";
+import {ReaperInstance} from "./reaper";
+import {Readable} from "stream";
+import {PortForwarderInstance} from "./port-forwarder";
+import {getAuthConfig} from "./registry-auth-locator";
+import {getDockerfileImages} from "./dockerfile-parser";
 
 export class GenericContainerBuilder {
   private buildArgs: BuildArgs = {};
@@ -53,7 +53,8 @@ export class GenericContainerBuilder {
     private readonly context: BuildContext,
     private readonly dockerfileName: string,
     private readonly uuid: Uuid = new RandomUuid()
-  ) {}
+  ) {
+  }
 
   public withBuildArg(key: string, value: string): GenericContainerBuilder {
     this.buildArgs[key] = value;
@@ -115,7 +116,7 @@ export class GenericContainerBuilder {
           },
         };
       })
-      .reduce((prev, next) => ({ ...prev, ...next }), {} as RegistryConfig);
+      .reduce((prev, next) => ({...prev, ...next}), {} as RegistryConfig);
   }
 }
 
@@ -175,7 +176,7 @@ export class GenericContainer implements TestContainer {
 
     if (!this.dockerImageName.isHelperContainer() && PortForwarderInstance.isRunning()) {
       const portForwarder = await PortForwarderInstance.getInstance(dockerClient);
-      this.extraHosts.push({ host: "host.testcontainers.internal", ipAddress: portForwarder.getIpAddress() });
+      this.extraHosts.push({host: "host.testcontainers.internal", ipAddress: portForwarder.getIpAddress()});
     }
 
     const container = await dockerClient.create({
@@ -217,10 +218,13 @@ export class GenericContainer implements TestContainer {
     log.info(`Starting container ${this.dockerImageName} with ID: ${container.getId()}`);
     await dockerClient.start(container);
 
-    if (!this.daemonMode) {
-      (await container.logs())
-        .on("data", (data) => containerLog.trace(`${container.getId()}: ${data}`))
-        .on("err", (data) => containerLog.error(`${container.getId()}: ${data}`));
+    const logs = await container.logs();
+    logs
+      .on("data", (data) => containerLog.trace(`${container.getId()}: ${data}`))
+      .on("err", (data) => containerLog.error(`${container.getId()}: ${data}`));
+
+    if (this.daemonMode) {
+      logs.socket.unref();
     }
 
     const inspectResult = await container.inspect();
@@ -274,7 +278,7 @@ export class GenericContainer implements TestContainer {
   }
 
   public withBindMount(source: Dir, target: Dir, bindMode: BindMode = "rw"): this {
-    this.bindMounts.push({ source, target, bindMode });
+    this.bindMounts.push({source, target, bindMode});
     return this;
   }
 
@@ -319,12 +323,12 @@ export class GenericContainer implements TestContainer {
   }
 
   public withCopyFileToContainer(sourcePath: string, containerPath: string): this {
-    this.getTarToCopy().file(sourcePath, { name: containerPath });
+    this.getTarToCopy().file(sourcePath, {name: containerPath});
     return this;
   }
 
   public withCopyContentToContainer(content: string | Buffer | Readable, containerPath: string): this {
-    this.getTarToCopy().append(content, { name: containerPath });
+    this.getTarToCopy().append(content, {name: containerPath});
     return this;
   }
 
@@ -359,8 +363,8 @@ export class GenericContainer implements TestContainer {
       }
 
       try {
-        await container.stop({ timeout: 0 });
-        await container.remove({ removeVolumes: true });
+        await container.stop({timeout: 0});
+        await container.remove({removeVolumes: true});
       } catch (stopErr) {
         log.error(`Failed to stop container after it failed to be ready: ${stopErr}`);
       }
@@ -386,7 +390,8 @@ export class StartedGenericContainer implements StartedTestContainer {
     private readonly boundPorts: BoundPorts,
     private readonly name: ContainerName,
     private readonly dockerClient: DockerClient
-  ) {}
+  ) {
+  }
 
   public async stop(options: Partial<StopOptions> = {}): Promise<StoppedTestContainer> {
     return await this.stopContainer(options);
@@ -394,9 +399,9 @@ export class StartedGenericContainer implements StartedTestContainer {
 
   private async stopContainer(options: Partial<StopOptions> = {}): Promise<StoppedGenericContainer> {
     log.info(`Stopping container with ID: ${this.container.getId()}`);
-    const resolvedOptions = { ...DEFAULT_STOP_OPTIONS, ...options };
-    await this.container.stop({ timeout: resolvedOptions.timeout });
-    await this.container.remove({ removeVolumes: resolvedOptions.removeVolumes });
+    const resolvedOptions = {...DEFAULT_STOP_OPTIONS, ...options};
+    await this.container.stop({timeout: resolvedOptions.timeout});
+    await this.container.remove({removeVolumes: resolvedOptions.removeVolumes});
     return new StoppedGenericContainer();
   }
 
@@ -437,4 +442,5 @@ export class StartedGenericContainer implements StartedTestContainer {
   }
 }
 
-class StoppedGenericContainer implements StoppedTestContainer {}
+class StoppedGenericContainer implements StoppedTestContainer {
+}

--- a/src/modules/kafka/kafka-container.test.ts
+++ b/src/modules/kafka/kafka-container.test.ts
@@ -16,9 +16,7 @@ describe("KafkaContainer", () => {
   });
 
   it("should connect to kafka using in-built zoo-keeper and custom images", async () => {
-    const kafkaContainer = await new KafkaContainer(KAFKA_IMAGE, undefined, ZK_IMAGE)
-      .withExposedPorts(9093)
-      .start();
+    const kafkaContainer = await new KafkaContainer(KAFKA_IMAGE, undefined, ZK_IMAGE).withExposedPorts(9093).start();
 
     await testPubSub(kafkaContainer);
 

--- a/src/port-forwarder.test.ts
+++ b/src/port-forwarder.test.ts
@@ -1,8 +1,8 @@
-import {createServer, Server} from "http";
-import {GenericContainer} from "./generic-container";
-import {TestContainers} from "./test-containers";
-import {RandomPortClient} from "./port-client";
-import {Network} from "./network";
+import { createServer, Server } from "http";
+import { GenericContainer } from "./generic-container";
+import { TestContainers } from "./test-containers";
+import { RandomPortClient } from "./port-client";
+import { Network } from "./network";
 
 describe("PortForwarder", () => {
   jest.setTimeout(180_000);


### PR DESCRIPTION
This PR enables logs from the daemon containers (ryuk, sshd) by default, in such a way that the log stream does not keep the node process running. This will help identify daemon container related issues such as in #220. To see the logs, you need to enable the container logs: `DEBUG=testcontainers:containers`, or more simply everything `DEBUG=testcontainers*`.