### PR TITLE
Support running container as a user

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,16 @@ const container = await new GenericContainer("redis")
   .start();
 ```
 
+Creating and running a container with a specific user, note that the value can be a username or UID (format: `<name|uid>[:<group|gid>]`):
+
+```javascript
+const { GenericContainer } = require("testcontainers");
+
+const container = await new GenericContainer("alpine")
+  .withUser("bob")
+  .start();
+```
+
 Creating a container with privileged mode:
 
 ```javascript

--- a/src/docker-client-instance.ts
+++ b/src/docker-client-instance.ts
@@ -36,7 +36,7 @@ export class DockerClientInstance {
     const nodeInfo = {
       version: process.version,
       architecture: process.arch,
-      platform: process.platform
+      platform: process.platform,
     };
 
     const dockerInfo = await dockerClient.getInfo();
@@ -45,7 +45,7 @@ export class DockerClientInstance {
     const info = {
       node: nodeInfo,
       docker: dockerInfo,
-      dockerCompose: dockerComposeInfo
+      dockerCompose: dockerComposeInfo,
     };
 
     log.debug(`System diagnostics: ${JSON.stringify(info, null, 2)}`);
@@ -54,10 +54,10 @@ export class DockerClientInstance {
   private static async getDockerComposeInfo(): Promise<DockerComposeInfo | undefined> {
     try {
       return {
-        version: (await dockerCompose.version()).data.version
+        version: (await dockerCompose.version()).data.version,
       };
     } catch {
-      log.warn('Unable to detect docker-compose version, is it installed?')
+      log.warn("Unable to detect docker-compose version, is it installed?");
       return undefined;
     }
   }

--- a/src/docker-client.ts
+++ b/src/docker-client.ts
@@ -91,6 +91,7 @@ type CreateOptions = {
   autoRemove: boolean;
   extraHosts: ExtraHost[];
   ipcMode?: string;
+  user?: string;
 };
 
 export type CreateNetworkOptions = {
@@ -160,6 +161,7 @@ export class DockerodeClient implements DockerClient {
 
     const dockerodeContainer = await this.dockerode.createContainer({
       name: options.name,
+      User: options.user,
       Image: options.dockerImageName.toString(),
       Env: this.getEnv(options.env),
       ExposedPorts: this.getExposedPorts(options.boundPorts),

--- a/src/generic-container.test.ts
+++ b/src/generic-container.test.ts
@@ -293,7 +293,7 @@ describe("GenericContainer", () => {
 
     const { output } = await container.exec(["whoami"]);
 
-    expect(output.trim()).toBe('node');
+    expect(output.trim()).toBe("node");
   });
 
   it("should stop the container when the host port check wait strategy times out", async () => {

--- a/src/generic-container.test.ts
+++ b/src/generic-container.test.ts
@@ -285,6 +285,17 @@ describe("GenericContainer", () => {
     await container.stop();
   });
 
+  it("should set the user", async () => {
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.12")
+      .withUser("node")
+      .withExposedPorts(8080)
+      .start();
+
+    const { output } = await container.exec(["whoami"]);
+
+    expect(output.trim()).toBe('node');
+  });
+
   it("should stop the container when the host port check wait strategy times out", async () => {
     const containerName = `container-${new RandomUuid().nextUuid()}`;
 

--- a/src/generic-container.ts
+++ b/src/generic-container.ts
@@ -194,7 +194,7 @@ export class GenericContainer implements TestContainer {
       autoRemove: this.daemonMode,
       extraHosts: this.extraHosts,
       ipcMode: this.ipcMode,
-      user: this.user
+      user: this.user,
     });
 
     if (!this.dockerImageName.isHelperContainer() && PortForwarderInstance.isRunning()) {

--- a/src/generic-container.ts
+++ b/src/generic-container.ts
@@ -146,6 +146,7 @@ export class GenericContainer implements TestContainer {
   protected privilegedMode = false;
   protected daemonMode = false;
   protected ipcMode?: string;
+  protected user?: string;
   protected pullPolicy: PullPolicy = new DefaultPullPolicy();
   protected tarToCopy?: archiver.Archiver;
 
@@ -193,6 +194,7 @@ export class GenericContainer implements TestContainer {
       autoRemove: this.daemonMode,
       extraHosts: this.extraHosts,
       ipcMode: this.ipcMode,
+      user: this.user
     });
 
     if (!this.dockerImageName.isHelperContainer() && PortForwarderInstance.isRunning()) {
@@ -303,6 +305,11 @@ export class GenericContainer implements TestContainer {
 
   public withPrivilegedMode(): this {
     this.privilegedMode = true;
+    return this;
+  }
+
+  public withUser(user: string): this {
+    this.user = user;
     return this;
   }
 

--- a/src/modules/neo4j/neo4j-container.test.ts
+++ b/src/modules/neo4j/neo4j-container.test.ts
@@ -55,10 +55,7 @@ describe("Neo4jContainer", () => {
   });
 
   it("should have APOC plugin installed", async () => {
-    const container = await new Neo4jContainer()
-      .withApoc()
-      .withStartupTimeout(120_000)
-      .start();
+    const container = await new Neo4jContainer().withApoc().withStartupTimeout(120_000).start();
 
     const driver = neo4j.driver(
       container.getBoltUri(),

--- a/src/test-container.ts
+++ b/src/test-container.ts
@@ -28,6 +28,7 @@ export interface TestContainer {
   withNetworkMode(networkMode: NetworkMode): this;
   withDefaultLogDriver(): this;
   withPrivilegedMode(): this;
+  withUser(user: string): this;
   withPullPolicy(pullPolicy: PullPolicy): this;
   withCopyFileToContainer(sourcePath: string, containerPath: string): this;
   withCopyContentToContainer(content: string | Buffer | Readable, containerPath: string): this;


### PR DESCRIPTION
#230 

Example usage:

```javascript
const container = await new GenericContainer("alpine")
  .withUser("bob")
  .start();
```