### PR TITLE
Demux container logs

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -111,7 +111,7 @@ export class DockerodeContainer implements Container {
       const rawStream = (await this.container.logs(options)) as IncomingMessage;
       rawStream.socket.unref();
 
-      const stream = new PassThrough({ encoding: "utf-8" });
+      const stream = new PassThrough({ autoDestroy: true, encoding: "utf-8" });
       this.container.modem.demuxStream(rawStream, stream, stream);
       rawStream.on("end", () => stream.end());
       return stream;

--- a/src/container.ts
+++ b/src/container.ts
@@ -2,7 +2,7 @@ import dockerode, { ContainerInspectInfo } from "dockerode";
 import { log } from "./logger";
 import { Command, ContainerName, ExitCode } from "./docker-client";
 import { Port } from "./port";
-import { Duplex, Readable } from "stream";
+import { Duplex, PassThrough, Readable } from "stream";
 import { IncomingMessage } from "http";
 
 export type Id = string;
@@ -54,7 +54,7 @@ export interface Container {
   stop(options: StopOptions): Promise<void>;
   remove(options: RemoveOptions): Promise<void>;
   exec(options: ExecOptions): Promise<Exec>;
-  logs(): Promise<IncomingMessage>;
+  logs(): Promise<Readable>;
   inspect(): Promise<InspectResult>;
   putArchive(stream: Readable, containerPath: string): Promise<void>;
 }
@@ -101,13 +101,24 @@ export class DockerodeContainer implements Container {
     );
   }
 
-  public async logs(): Promise<IncomingMessage> {
-    const options = {
-      follow: true,
-      stdout: true,
-      stderr: true,
-    };
-    return (await this.container.logs(options)).setEncoding("utf-8") as IncomingMessage;
+  public async logs(): Promise<Readable> {
+    try {
+      const options = {
+        follow: true,
+        stdout: true,
+        stderr: true,
+      };
+      const rawStream = (await this.container.logs(options)) as IncomingMessage;
+      rawStream.socket.unref();
+
+      const stream = new PassThrough({ encoding: "utf-8" });
+      this.container.modem.demuxStream(rawStream, stream, stream);
+      rawStream.on("end", () => stream.end());
+      return stream;
+    } catch (err) {
+      log.error(`Failed to get container logs: ${err}`);
+      throw err;
+    }
   }
 
   public async inspect(): Promise<InspectResult> {

--- a/src/generic-container.ts
+++ b/src/generic-container.ts
@@ -220,8 +220,8 @@ export class GenericContainer implements TestContainer {
 
     const logs = await container.logs();
     logs
-      .on("data", (data) => containerLog.trace(`${container.getId()}: ${data}`))
-      .on("err", (data) => containerLog.error(`${container.getId()}: ${data}`));
+      .on("data", (data) => containerLog.trace(`${container.getId()}: ${data.trim()}`))
+      .on("err", (data) => containerLog.error(`${container.getId()}: ${data.trim()}`));
 
     const inspectResult = await container.inspect();
 

--- a/src/generic-container.ts
+++ b/src/generic-container.ts
@@ -223,10 +223,6 @@ export class GenericContainer implements TestContainer {
       .on("data", (data) => containerLog.trace(`${container.getId()}: ${data}`))
       .on("err", (data) => containerLog.error(`${container.getId()}: ${data}`));
 
-    if (this.daemonMode) {
-      logs.socket.unref();
-    }
-
     const inspectResult = await container.inspect();
 
     await this.waitForContainer(dockerClient, container, boundPorts);

--- a/src/log-system-diagnostics.ts
+++ b/src/log-system-diagnostics.ts
@@ -42,8 +42,8 @@ const getDockerComposeInfo = async (): Promise<DockerComposeInfo | undefined> =>
     return {
       version: (await dockerCompose.version()).data.version,
     };
-  } catch {
-    log.warn("Unable to detect docker-compose version, is it installed?");
+  } catch (err) {
+    log.warn(`Unable to detect docker-compose version, is it installed? ${err}`);
     return undefined;
   }
 };

--- a/src/reaper.test.ts
+++ b/src/reaper.test.ts
@@ -12,7 +12,7 @@ import { RandomUuid } from "./uuid";
 import waitForExpect from "wait-for-expect";
 
 describe("Reaper", () => {
-  jest.setTimeout(60_000);
+  jest.setTimeout(180_000);
 
   it("should remove containers", async () => {
     const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.12").start();

--- a/src/run-in-container.ts
+++ b/src/run-in-container.ts
@@ -17,8 +17,8 @@ export const runInContainer = async (
     const promise = new Promise<void>((resolve) => {
       stream.on("end", () => resolve());
 
-      const out = new PassThrough({ encoding: "utf-8" }).on("data", (chunk) => chunks.push(chunk));
-      const err = new PassThrough({ encoding: "utf-8" }).on("data", () => resolve(undefined));
+      const out = new PassThrough({ autoDestroy: true, encoding: "utf-8" }).on("data", (chunk) => chunks.push(chunk));
+      const err = new PassThrough({ autoDestroy: true, encoding: "utf-8" }).on("data", () => resolve(undefined));
 
       container.modem.demuxStream(stream, out, err);
     });


### PR DESCRIPTION
Before (note the characters that have been incorrectly encoded from the `testcontainers:containers` logger)
```
  testcontainers INFO  Using default Docker host: localhost, socket path: /var/run/docker.sock +0ms
  testcontainers DEBUG Creating new Reaper for session: ab78852e7602e2ba0de2d35512bed896 +28ms
  testcontainers INFO  Creating container for image: cristianrgreco/ryuk:0.4.0 +21ms
  testcontainers INFO  Starting container cristianrgreco/ryuk:0.4.0 with ID: 362e1a4e019d7750f4af69bd4a73e887c11611db2ec5c4f4410932699de2e8d8 +43ms
  testcontainers:containers TRACE 362e1a4e019d7750f4af69bd4a73e887c11611db2ec5c4f4410932699de2e8d8:       &2021/07/23 08:38:09 Pinging Docker...
  testcontainers:containers       02021/07/23 08:38:09 Docker daemon is available!
  testcontainers:containers       -2021/07/23 08:38:09 Starting on port 8080...
  testcontainers:containers       2021/07/23 08:38:09 Started!
  testcontainers:containers  +0ms
  testcontainers DEBUG Waiting for container to be ready: 362e1a4e019d7750f4af69bd4a73e887c11611db2ec5c4f4410932699de2e8d8 +1s
  testcontainers DEBUG Waiting for host port 16361 for 362e1a4e019d7750f4af69bd4a73e887c11611db2ec5c4f4410932699de2e8d8 +1ms
  testcontainers DEBUG Waiting for internal port 8080 for 362e1a4e019d7750f4af69bd4a73e887c11611db2ec5c4f4410932699de2e8d8 +1ms
  testcontainers DEBUG Host port 16361 ready for 362e1a4e019d7750f4af69bd4a73e887c11611db2ec5c4f4410932699de2e8d8 +4ms
  testcontainers:containers TRACE 362e1a4e019d7750f4af69bd4a73e887c11611db2ec5c4f4410932699de2e8d8:       ;2021/07/23 08:38:09 New client connected: 172.17.0.1:62176
  testcontainers:containers       2021/07/23 08:38:09 EOF
  testcontainers:containers       :2021/07/23 08:38:09 Client disconnected: 172.17.0.1:62176
  testcontainers:containers       22021/07/23 08:38:09 Received the first connection
  testcontainers:containers  +20ms
  testcontainers:containers TRACE 362e1a4e019d7750f4af69bd4a73e887c11611db2ec5c4f4410932699de2e8d8:       :2021/07/23 08:38:10 New client connected: 127.0.0.1:45787
  testcontainers:containers       2021/07/23 08:38:10 EOF
  testcontainers:containers       92021/07/23 08:38:10 Client disconnected: 127.0.0.1:45787
  testcontainers:containers  +295ms
  testcontainers DEBUG Internal port 8080 ready for 362e1a4e019d7750f4af69bd4a73e887c11611db2ec5c4f4410932699de2e8d8 +338ms
  testcontainers INFO  Container is ready +0ms
  testcontainers DEBUG Connecting to Reaper 362e1a4e019d7750f4af69bd4a73e887c11611db2ec5c4f4410932699de2e8d8 on localhost:16361 +0ms
  testcontainers DEBUG Connected to Reaper 362e1a4e019d7750f4af69bd4a73e887c11611db2ec5c4f4410932699de2e8d8 +1ms
  testcontainers INFO  Creating container for image: cristianrgreco/testcontainer:1.1.12 +1ms
  testcontainers:containers TRACE 362e1a4e019d7750f4af69bd4a73e887c11611db2ec5c4f4410932699de2e8d8:       ;2021/07/23 08:38:10 New client connected: 172.17.0.1:62180
  testcontainers:containers       m2021/07/23 08:38:10 Adding {"label":{"org.testcontainers.session-id=ab78852e7602e2ba0de2d35512bed896":true}}
  testcontainers:containers  +42ms
  testcontainers INFO  Starting container cristianrgreco/testcontainer:1.1.12 with ID: e8a604979052b04d6fa4a928e64e25cacc99dce150742271dbda1b40ee0fa7a6 +48ms
  testcontainers DEBUG Waiting for container to be ready: e8a604979052b04d6fa4a928e64e25cacc99dce150742271dbda1b40ee0fa7a6 +2s
  testcontainers DEBUG Waiting for host port 45992 for e8a604979052b04d6fa4a928e64e25cacc99dce150742271dbda1b40ee0fa7a6 +0ms
  testcontainers DEBUG Waiting for internal port 8080 for e8a604979052b04d6fa4a928e64e25cacc99dce150742271dbda1b40ee0fa7a6 +0ms
  testcontainers DEBUG Host port 45992 ready for e8a604979052b04d6fa4a928e64e25cacc99dce150742271dbda1b40ee0fa7a6 +2ms
  testcontainers:containers TRACE e8a604979052b04d6fa4a928e64e25cacc99dce150742271dbda1b40ee0fa7a6:       Listening on port 8080
  testcontainers:containers  +2s
  testcontainers DEBUG Internal port 8080 ready for e8a604979052b04d6fa4a928e64e25cacc99dce150742271dbda1b40ee0fa7a6 +433ms
  testcontainers INFO  Container is ready +0ms
  testcontainers INFO  Stopping container with ID: e8a604979052b04d6fa4a928e64e25cacc99dce150742271dbda1b40ee0fa7a6 +27ms

```

After
```
  testcontainers INFO  Using default Docker host: localhost, socket path: /var/run/docker.sock +1ms
  testcontainers DEBUG Creating new Reaper for session: ac57a553e4cce78438986def14762b2f +24ms
  testcontainers INFO  Creating container for image: cristianrgreco/ryuk:0.4.0 +24ms
  testcontainers INFO  Starting container cristianrgreco/ryuk:0.4.0 with ID: 49407b5a630e2c1530c76e38a5ed40421e9a189a50de7d9b612a818c6fbc341a +25ms
  testcontainers:containers TRACE 49407b5a630e2c1530c76e38a5ed40421e9a189a50de7d9b612a818c6fbc341a: 2021/07/23 08:29:26 Pinging Docker... +0ms
  testcontainers:containers TRACE 49407b5a630e2c1530c76e38a5ed40421e9a189a50de7d9b612a818c6fbc341a: 2021/07/23 08:29:26 Docker daemon is available! +0ms
  testcontainers:containers TRACE 49407b5a630e2c1530c76e38a5ed40421e9a189a50de7d9b612a818c6fbc341a: 2021/07/23 08:29:26 Starting on port 8080... +0ms
  testcontainers:containers TRACE 49407b5a630e2c1530c76e38a5ed40421e9a189a50de7d9b612a818c6fbc341a: 2021/07/23 08:29:26 Started! +0ms
  testcontainers DEBUG Waiting for container to be ready: 49407b5a630e2c1530c76e38a5ed40421e9a189a50de7d9b612a818c6fbc341a +2s
  testcontainers DEBUG Waiting for host port 35273 for 49407b5a630e2c1530c76e38a5ed40421e9a189a50de7d9b612a818c6fbc341a +0ms
  testcontainers DEBUG Waiting for internal port 8080 for 49407b5a630e2c1530c76e38a5ed40421e9a189a50de7d9b612a818c6fbc341a +2ms
  testcontainers DEBUG Host port 35273 ready for 49407b5a630e2c1530c76e38a5ed40421e9a189a50de7d9b612a818c6fbc341a +2ms
  testcontainers:containers TRACE 49407b5a630e2c1530c76e38a5ed40421e9a189a50de7d9b612a818c6fbc341a: 2021/07/23 08:29:26 New client connected: 172.17.0.1:62160 +11ms
  testcontainers:containers TRACE 49407b5a630e2c1530c76e38a5ed40421e9a189a50de7d9b612a818c6fbc341a: 2021/07/23 08:29:26 EOF +0ms
  testcontainers:containers TRACE 49407b5a630e2c1530c76e38a5ed40421e9a189a50de7d9b612a818c6fbc341a: 2021/07/23 08:29:26 Client disconnected: 172.17.0.1:62160 +0ms
  testcontainers:containers TRACE 49407b5a630e2c1530c76e38a5ed40421e9a189a50de7d9b612a818c6fbc341a: 2021/07/23 08:29:26 Received the first connection +0ms
  testcontainers:containers TRACE 49407b5a630e2c1530c76e38a5ed40421e9a189a50de7d9b612a818c6fbc341a: 2021/07/23 08:29:26 New client connected: 127.0.0.1:39487 +193ms
  testcontainers:containers TRACE 49407b5a630e2c1530c76e38a5ed40421e9a189a50de7d9b612a818c6fbc341a: 2021/07/23 08:29:26 EOF +1ms
  testcontainers:containers TRACE 49407b5a630e2c1530c76e38a5ed40421e9a189a50de7d9b612a818c6fbc341a: 2021/07/23 08:29:26 Client disconnected: 127.0.0.1:39487 +0ms
  testcontainers DEBUG Internal port 8080 ready for 49407b5a630e2c1530c76e38a5ed40421e9a189a50de7d9b612a818c6fbc341a +220ms
  testcontainers INFO  Container is ready +0ms
  testcontainers DEBUG Connecting to Reaper 49407b5a630e2c1530c76e38a5ed40421e9a189a50de7d9b612a818c6fbc341a on localhost:35273 +0ms
  testcontainers DEBUG Connected to Reaper 49407b5a630e2c1530c76e38a5ed40421e9a189a50de7d9b612a818c6fbc341a +3ms
  testcontainers INFO  Creating container for image: cristianrgreco/testcontainer:1.1.12 +0ms
  testcontainers:containers TRACE 49407b5a630e2c1530c76e38a5ed40421e9a189a50de7d9b612a818c6fbc341a: 2021/07/23 08:29:26 New client connected: 172.17.0.1:62164 +32ms
  testcontainers:containers TRACE 49407b5a630e2c1530c76e38a5ed40421e9a189a50de7d9b612a818c6fbc341a: 2021/07/23 08:29:26 Adding {"label":{"org.testcontainers.session-id=ac57a553e4cce78438986def14762b2f":true}} +2ms
  testcontainers INFO  Starting container cristianrgreco/testcontainer:1.1.12 with ID: 6eb5c356b45e6cb8f2e5899113fea5dc5f6a0723855435b9f2858cb2eed744aa +45ms
  testcontainers DEBUG Waiting for container to be ready: 6eb5c356b45e6cb8f2e5899113fea5dc5f6a0723855435b9f2858cb2eed744aa +1s
  testcontainers DEBUG Waiting for host port 61718 for 6eb5c356b45e6cb8f2e5899113fea5dc5f6a0723855435b9f2858cb2eed744aa +0ms
  testcontainers DEBUG Waiting for internal port 8080 for 6eb5c356b45e6cb8f2e5899113fea5dc5f6a0723855435b9f2858cb2eed744aa +0ms
  testcontainers DEBUG Host port 61718 ready for 6eb5c356b45e6cb8f2e5899113fea5dc5f6a0723855435b9f2858cb2eed744aa +6ms
  testcontainers:containers TRACE 6eb5c356b45e6cb8f2e5899113fea5dc5f6a0723855435b9f2858cb2eed744aa: Listening on port 8080 +2s
  testcontainers DEBUG Internal port 8080 ready for 6eb5c356b45e6cb8f2e5899113fea5dc5f6a0723855435b9f2858cb2eed744aa +321ms
  testcontainers INFO  Container is ready +1ms
  testcontainers INFO  Stopping container with ID: 6eb5c356b45e6cb8f2e5899113fea5dc5f6a0723855435b9f2858cb2eed744aa +19ms
```