### PR TITLE
Support starting a subset of docker-compose services

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,19 @@ describe("DockerComposeEnvironment", () => {
 });
 ```
 
+You can supply a list of service names to only start those services:
+
+```javascript
+const { DockerComposeEnvironment } = require("testcontainers");
+
+const environment = await new DockerComposeEnvironment(composeFilePath, composeFile).up(["database_service", "queue_service"]);
+
+// only database_service and queue_service will be started and available
+
+await environment.stop();
+
+```
+
 Create the containers with their own wait strategies:
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -472,12 +472,9 @@ You can supply a list of service names to only start those services:
 ```javascript
 const { DockerComposeEnvironment } = require("testcontainers");
 
-const environment = await new DockerComposeEnvironment(composeFilePath, composeFile).up(["database_service", "queue_service"]);
-
+const environment = await new DockerComposeEnvironment(composeFilePath, composeFile)
+  .up(["database_service", "queue_service"]);
 // only database_service and queue_service will be started and available
-
-await environment.stop();
-
 ```
 
 Create the containers with their own wait strategies:

--- a/fixtures/docker-compose/docker-compose-with-many-services.yml
+++ b/fixtures/docker-compose/docker-compose-with-many-services.yml
@@ -1,0 +1,27 @@
+version: "3.5"
+
+services:
+  service_1:
+    image: cristianrgreco/testcontainer:1.1.12
+    ports:
+      - 8080
+  service_2:
+    image: cristianrgreco/testcontainer:1.1.12
+    ports:
+      - 8080
+  service_3:
+    image: cristianrgreco/testcontainer:1.1.12
+    ports:
+      - 8080
+  service_4:
+    image: cristianrgreco/testcontainer:1.1.12
+    ports:
+      - 8080
+  service_5:
+    image: cristianrgreco/testcontainer:1.1.12
+    ports:
+      - 8080
+  service_6:
+    image: cristianrgreco/testcontainer:1.1.12
+    ports:
+      - 8080

--- a/src/docker-compose-environment/docker-compose-environment.test.ts
+++ b/src/docker-compose-environment/docker-compose-environment.test.ts
@@ -159,4 +159,31 @@ describe("DockerComposeEnvironment", () => {
     );
     await startedEnvironment.down();
   });
+
+  it("should support starting a subset of services defined in the docker-compose file", async () => {
+    const servicesToStart = ["service_2", "service_4", "service_6"];
+    const startedEnvironment = await new DockerComposeEnvironment(fixtures, "docker-compose-with-many-services.yml").up(
+      servicesToStart
+    );
+
+    await Promise.all(
+      servicesToStart.map(async (serviceName) => {
+        const containerName = `${serviceName}_1`;
+        const container = startedEnvironment.getContainer(containerName);
+        const url = `http://${container.getHost()}:${container.getMappedPort(8080)}`;
+        const response = await fetch(`${url}/hello-world`);
+        expect(response.status).toBe(200);
+      })
+    );
+    expect(() => startedEnvironment.getContainer("service_1")).toThrowError(
+      `Cannot get container "service_1" as it is not running`
+    );
+    expect(() => startedEnvironment.getContainer("service_3")).toThrowError(
+      `Cannot get container "service_3" as it is not running`
+    );
+    expect(() => startedEnvironment.getContainer("service_5")).toThrowError(
+      `Cannot get container "service_5" as it is not running`
+    );
+    await startedEnvironment.down();
+  });
 });

--- a/src/docker-compose-environment/docker-compose-environment.ts
+++ b/src/docker-compose-environment/docker-compose-environment.ts
@@ -52,7 +52,7 @@ export class DockerComposeEnvironment {
     return this;
   }
 
-  public async up(): Promise<StartedDockerComposeEnvironment> {
+  public async up(services?: Array<string>): Promise<StartedDockerComposeEnvironment> {
     log.info(`Starting DockerCompose environment ${this.projectName}`);
 
     (await ReaperInstance.getInstance()).addProject(this.projectName);
@@ -61,7 +61,7 @@ export class DockerComposeEnvironment {
     if (this.build) {
       commandOptions.push("--build");
     }
-    await dockerComposeUp({ ...this.options, commandOptions, env: this.env });
+    await dockerComposeUp({ ...this.options, commandOptions, env: this.env }, services);
 
     const startedContainers = (await listContainers()).filter(
       (container) => container.Labels["com.docker.compose.project"] === this.projectName

--- a/src/docker-compose/functions/docker-compose-up.ts
+++ b/src/docker-compose/functions/docker-compose-up.ts
@@ -1,14 +1,18 @@
 import { log } from "../../logger";
-import { upAll } from "docker-compose";
+import { upAll, upMany } from "docker-compose";
 import { defaultDockerComposeOptions } from "../default-docker-compose-options";
 import { DockerComposeOptions } from "../docker-compose-options";
 import { dockerComposeDown } from "./docker-compose-down";
 
-export const dockerComposeUp = async (options: DockerComposeOptions): Promise<void> => {
+export const dockerComposeUp = async (options: DockerComposeOptions, services?: Array<string>): Promise<void> => {
   log.info(`Upping DockerCompose environment`);
 
   try {
-    await upAll(defaultDockerComposeOptions(options));
+    if (services) {
+      await upMany(services, defaultDockerComposeOptions(options));
+    } else {
+      await upAll(defaultDockerComposeOptions(options));
+    }
     log.info(`Upped DockerCompose environment`);
   } catch (err) {
     log.error(`Failed to up DockerCompose environment: ${err}`);


### PR DESCRIPTION
Prior to this change, the `DockerComposeEnvironment().up()` method would
start all services defined in the target `docker-compose.yml` file, and
did not allow starting just a subset of services.

This change adds support for optionally passing an array of service
names to start to the `DockerComposeEnvironment.up()` method. If
provided, the underlying `docker-compose` `upMany` method is used to
start just that subset of services.