### PR TITLE
Add TS type for bind mounts in SELinux-enabled systems

### DIFF
--- a/src/docker/types.ts
+++ b/src/docker/types.ts
@@ -10,7 +10,7 @@ export type Env = { [key in EnvKey]: EnvValue };
 
 export type Dir = string;
 
-export type BindMode = "rw" | "ro";
+export type BindMode = "rw" | "ro" | "z";
 
 export type BindMount = {
   source: Dir;

--- a/src/docker/types.ts
+++ b/src/docker/types.ts
@@ -10,7 +10,7 @@ export type Env = { [key in EnvKey]: EnvValue };
 
 export type Dir = string;
 
-export type BindMode = "rw" | "ro" | "z";
+export type BindMode = "rw" | "ro" | "z" | "Z";
 
 export type BindMount = {
   source: Dir;


### PR DESCRIPTION
Add the 'z' bind mount option to the TypeScript type alias for SELinux-enabled systems.

Here is the documentation for the label: https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label

My current workaround is to use type casting:

```typescript
  const genericContainer = new GenericContainer('fedora')
    .withBindMount(`/path/to/mount`, '/mount', 'z' as 'rw')
    .withCmd('ls /mount');
```