### PR TITLE
Fix kafka module listener protocols, add ability to get in-built zook…

### DIFF
--- a/src/modules/kafka/kafka-container.test.ts
+++ b/src/modules/kafka/kafka-container.test.ts
@@ -59,6 +59,22 @@ describe("KafkaContainer", () => {
     await network.stop();
   });
 
+  it("should return in-built zoo-keeper name", async () => {
+    const kafkaContainer = await new KafkaContainer().withExposedPorts(9093).start();
+
+    expect(kafkaContainer.getZookeeperName()).toBeDefined();
+
+    await kafkaContainer.stop();
+  });
+
+  it("should return in-built zoo-keeper port", async () => {
+    const kafkaContainer = await new KafkaContainer().withExposedPorts(9093).start();
+
+    expect(kafkaContainer.getZookeeperPort()).toBeDefined();
+
+    await kafkaContainer.stop();
+  });
+
   const testPubSub = async (kafkaContainer: StartedTestContainer) => {
     const kafka = new Kafka({
       logLevel: logLevel.NOTHING,


### PR DESCRIPTION
…eeper name and port

The changes are needed for the case when Kafka is used with Schema registry. Schema registry requires broker protocol to be PLAINTEXT. 
Also added useful methods to get Zookeeper name & port as they have to be provided to Schema registry container too.