### PR TITLE
introduce withPortMappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Creating a container explicit port mapping:
 ```javascript
 const { GenericContainer } = require("testcontainers");
 
-const container = await new GenericContainer("alpine").withPortMapping({ 3000: 8080, 3001: 8081 }).start();
+const container = await new GenericContainer("alpine").withPortMappings({ 3000: 8080, 3001: 8081 }).start();
 ```
 
 Creating a container with multiple exposed ports:

--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ const container = await GenericContainer.fromDockerfile(buildContext, "my-docker
   .build();
 ```
 
+Creating a container explicit port mapping:
+
+```javascript
+const { GenericContainer } = require("testcontainers");
+
+const container = await new GenericContainer("alpine").withPortMapping({ 3000: 8080, 3001: 8081 }).start();
+```
+
 Creating a container with multiple exposed ports:
 
 ```javascript

--- a/src/generic-container/generic-container.test.ts
+++ b/src/generic-container/generic-container.test.ts
@@ -496,5 +496,18 @@ describe("GenericContainer", () => {
 
       await startedContainer.stop();
     });
+
+    it("should set port mapping", async () => {
+      const context = path.resolve(fixtures, "docker-with-custom-filename");
+      const container = await GenericContainer.fromDockerfile(context, "Dockerfile-A").build();
+      const fixedPort = 10_000;
+      const startedContainer = await container.withPortMapping({ 8080: fixedPort }).start();
+
+      const url = `http://${startedContainer.getHost()}:${fixedPort}`;
+      const response = await fetch(`${url}/hello-world`);
+
+      expect(response.status).toBe(200);
+      await startedContainer.stop();
+    });
   });
 });

--- a/src/generic-container/generic-container.test.ts
+++ b/src/generic-container/generic-container.test.ts
@@ -501,7 +501,7 @@ describe("GenericContainer", () => {
       const context = path.resolve(fixtures, "docker-with-custom-filename");
       const container = await GenericContainer.fromDockerfile(context, "Dockerfile-A").build();
       const fixedPort = 10_000;
-      const startedContainer = await container.withPortMapping({ 8080: fixedPort }).start();
+      const startedContainer = await container.withPortMappings({ 8080: fixedPort }).start();
 
       const url = `http://${startedContainer.getHost()}:${fixedPort}`;
       const response = await fetch(`${url}/hello-world`);

--- a/src/generic-container/generic-container.ts
+++ b/src/generic-container/generic-container.ts
@@ -189,7 +189,7 @@ export class GenericContainer implements TestContainer {
     return this;
   }
 
-  public withPortMapping(portMappings: PortMappings): this {
+  public withPortMappings(portMappings: PortMappings): this {
     this.portMappings = portMappings;
     return this;
   }

--- a/src/port-mappings.ts
+++ b/src/port-mappings.ts
@@ -1,0 +1,3 @@
+export type HostPort = number;
+export type ContainerPort = number;
+export type PortMappings = Record<HostPort, ContainerPort>;

--- a/src/port-mappings.ts
+++ b/src/port-mappings.ts
@@ -1,3 +1,3 @@
 export type HostPort = number;
 export type ContainerPort = number;
-export type PortMappings = Record<HostPort, ContainerPort>;
+export type PortMappings = Record<ContainerPort, HostPort>;


### PR DESCRIPTION
Introducing `withPortMappings` to let users explicitly specify target host port.