### PR TITLE
Add withEnvFile to support the --env-file option of docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,6 +547,16 @@ const environment = await new DockerComposeEnvironment(composeFilePath, composeF
   .up();
 ```
 
+Specify the [environment file](https://docs.docker.com/compose/environment-variables/#using-the---env-file--option):
+
+```javascript
+const { DockerComposeEnvironment } = require("testcontainers");
+
+const environment = await new DockerComposeEnvironment(composeFilePath, composeFile)
+    .withEnvFile(".env.custom")
+    .up();
+```
+
 Specify [profiles](https://docs.docker.com/compose/profiles/):
 
 ```javascript

--- a/fixtures/docker-compose/docker-compose-with-env-file/.env
+++ b/fixtures/docker-compose/docker-compose-with-env-file/.env
@@ -1,0 +1,1 @@
+ENV_VAR=default

--- a/fixtures/docker-compose/docker-compose-with-env-file/.env.override
+++ b/fixtures/docker-compose/docker-compose-with-env-file/.env.override
@@ -1,0 +1,1 @@
+ENV_VAR=override

--- a/fixtures/docker-compose/docker-compose-with-env-file/docker-compose.yml
+++ b/fixtures/docker-compose/docker-compose-with-env-file/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.5"
+
+services:
+  container:
+    image: cristianrgreco/testcontainer:1.1.12
+    ports:
+      - 8080
+    environment:
+      - ENV_VAR=${ENV_VAR}

--- a/src/docker-compose-environment/docker-compose-environment.ts
+++ b/src/docker-compose-environment/docker-compose-environment.ts
@@ -24,6 +24,7 @@ export class DockerComposeEnvironment {
   private projectName: string;
   private build = false;
   private recreate = true;
+  private envFile = "";
   private profiles: string[] = [];
   private env: Env = {};
   private waitStrategy: { [containerName: string]: WaitStrategy } = {};
@@ -42,6 +43,11 @@ export class DockerComposeEnvironment {
 
   public withEnv(key: EnvKey, value: EnvValue): this {
     this.env[key] = value;
+    return this;
+  }
+
+  public withEnvFile(envFile: string): this {
+    this.envFile = envFile;
     return this;
   }
 
@@ -86,6 +92,9 @@ export class DockerComposeEnvironment {
     }
 
     const composeOptions: string[] = [];
+    if (this.envFile) {
+      composeOptions.push("--env-file", this.envFile);
+    }
     this.profiles.forEach((profile) => composeOptions.push("--profile", profile));
 
     await dockerComposeUp({ ...options, commandOptions, composeOptions, env: this.env }, services);


### PR DESCRIPTION
Hey!

I'd like to add support for the `--env-file` docker-compose option. This is useful in environments where a developer has `.env` file that is used for local development (this .env file gets picked up automatically from docker-compose) and the CI/test environment wants to use different values (i.e. ports or environment vars).

fixes #184 

[0] https://github.com/testcontainers/testcontainers-node/issues/184