### PR TITLE
Feat/323/add env var startup timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ The following environment variables are supported:
 - `TESTCONTAINERS_HOST_OVERRIDE=docker.svc.local` Docker's host on which ports are exposed
 - `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock` Path to Docker's socket. Used by [ryuk](#ryuk) and
   other [auxiliary containers](#auxiliary-containers) that need to perform Docker actions
+- `TESTCONTAINERS_DEFAULT_STARTUP_TIMEOUT=60000` Overrides the default startup timeout for all containers,
+  useful on slower systems
 - `TESTCONTAINERS_RYUK_PRIVILEGED=true` Run [ryuk](#ryuk) as a privileged container
 - `TESTCONTAINERS_RYUK_DISABLED=true` Disable [ryuk](#ryuk)
 - `RYUK_CONTAINER_IMAGE=registry.mycompany.com/mirror/ryuk:0.3.0` Custom image for [ryuk](#ryuk)

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,37 @@
+export class EnvConfig {
+  public static isHostOverriden(): string {
+    return process.env["TESTCONTAINERS_HOST_OVERRIDE"] ?? "";
+  }
+
+  public static riukContainerImage(): string {
+    return process.env["RYUK_CONTAINER_IMAGE"] ?? "testcontainers/ryuk:0.3.2";
+  }
+
+  public static sshdContainerImage(): string {
+    return process.env["SSHD_CONTAINER_IMAGE"] ?? "testcontainers/sshd:1.0.0";
+  }
+
+  public static isRyukDisabled(): boolean {
+    return EnvConfig.boolean("TESTCONTAINERS_RYUK_DISABLED") ?? false;
+  }
+
+  public static isRyukPrivileged(): boolean {
+    return EnvConfig.boolean("TESTCONTAINERS_RYUK_PRIVILEGED") ?? false;
+  }
+
+  public static dockerSocketOverride(): string {
+    return process.env["TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE"] ?? "/var/run/docker.sock";
+  }
+
+  public static defaultSetupTimeout(): number {
+    return EnvConfig.integer("TESTCONTAINERS_DEFAULT_STARTUP_TIMEOUT") ?? 60_000;
+  }
+
+  private static boolean(key: string): boolean {
+    return process.env[key] === "true";
+  }
+
+  private static integer(key: string): number {
+    return parseInt(process.env[key] || "");
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,37 +1,42 @@
 export class EnvConfig {
   public static isHostOverriden(): string {
-    return process.env["TESTCONTAINERS_HOST_OVERRIDE"] ?? "";
+    return EnvConfig.string("TESTCONTAINERS_HOST_OVERRIDE", "");
   }
 
   public static riukContainerImage(): string {
-    return process.env["RYUK_CONTAINER_IMAGE"] ?? "testcontainers/ryuk:0.3.2";
+    return EnvConfig.string("RYUK_CONTAINER_IMAGE", "testcontainers/ryuk:0.3.2");
   }
 
   public static sshdContainerImage(): string {
-    return process.env["SSHD_CONTAINER_IMAGE"] ?? "testcontainers/sshd:1.0.0";
+    return EnvConfig.string("SSHD_CONTAINER_IMAGE", "testcontainers/sshd:1.0.0");
   }
 
   public static isRyukDisabled(): boolean {
-    return EnvConfig.boolean("TESTCONTAINERS_RYUK_DISABLED") ?? false;
+    return EnvConfig.boolean("TESTCONTAINERS_RYUK_DISABLED");
   }
 
   public static isRyukPrivileged(): boolean {
-    return EnvConfig.boolean("TESTCONTAINERS_RYUK_PRIVILEGED") ?? false;
+    return EnvConfig.boolean("TESTCONTAINERS_RYUK_PRIVILEGED");
   }
 
   public static dockerSocketOverride(): string {
-    return process.env["TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE"] ?? "/var/run/docker.sock";
+    return EnvConfig.string("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE", "/var/run/docker.sock");
   }
 
   public static defaultSetupTimeout(): number {
-    return EnvConfig.integer("TESTCONTAINERS_DEFAULT_STARTUP_TIMEOUT") ?? 60_000;
+    return EnvConfig.integer("TESTCONTAINERS_DEFAULT_STARTUP_TIMEOUT", 60_000);
   }
 
   private static boolean(key: string): boolean {
     return process.env[key] === "true";
   }
 
-  private static integer(key: string): number {
-    return parseInt(process.env[key] || "");
+  private static string(key: string, fallback: string): string {
+    return process.env[key] ?? fallback;
+  }
+
+  private static integer(key: string, fallback: number): number {
+    const int = parseInt(process.env[key] || "");
+    return isNaN(int) ? fallback : int;
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,13 +1,13 @@
 export class EnvConfig {
-  public static isHostOverriden(): string {
+  public static getHostOverride(): string {
     return EnvConfig.string("TESTCONTAINERS_HOST_OVERRIDE", "");
   }
 
-  public static riukContainerImage(): string {
+  public static getRyukContainerImage(): string {
     return EnvConfig.string("RYUK_CONTAINER_IMAGE", "testcontainers/ryuk:0.3.2");
   }
 
-  public static sshdContainerImage(): string {
+  public static getSshdContainerImage(): string {
     return EnvConfig.string("SSHD_CONTAINER_IMAGE", "testcontainers/sshd:1.0.0");
   }
 
@@ -19,11 +19,11 @@ export class EnvConfig {
     return EnvConfig.boolean("TESTCONTAINERS_RYUK_PRIVILEGED");
   }
 
-  public static dockerSocketOverride(): string {
+  public static getDockerSocket(): string {
     return EnvConfig.string("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE", "/var/run/docker.sock");
   }
 
-  public static defaultSetupTimeout(): number {
+  public static getStartupTimeout(): number {
     return EnvConfig.integer("TESTCONTAINERS_DEFAULT_STARTUP_TIMEOUT", 60_000);
   }
 

--- a/src/docker/docker-client.ts
+++ b/src/docker/docker-client.ts
@@ -7,6 +7,7 @@ import fs from "fs";
 import { runInContainer } from "./functions/run-in-container";
 import { logSystemDiagnostics } from "../log-system-diagnostics";
 import "../testcontainers-properties-file";
+import { EnvConfig } from "../config";
 
 type DockerClient = {
   host: Host;
@@ -150,8 +151,8 @@ class NpipeSocketStrategy implements DockerClientStrategy {
 }
 
 const resolveHost = async (dockerode: Dockerode, uri: string): Promise<string> => {
-  if (process.env.TESTCONTAINERS_HOST_OVERRIDE !== undefined) {
-    return process.env.TESTCONTAINERS_HOST_OVERRIDE;
+  if (EnvConfig.isHostOverriden()) {
+    return EnvConfig.isHostOverriden();
   }
 
   const { protocol, hostname } = new URL(uri);

--- a/src/docker/docker-client.ts
+++ b/src/docker/docker-client.ts
@@ -151,8 +151,8 @@ class NpipeSocketStrategy implements DockerClientStrategy {
 }
 
 const resolveHost = async (dockerode: Dockerode, uri: string): Promise<string> => {
-  if (EnvConfig.isHostOverriden()) {
-    return EnvConfig.isHostOverriden();
+  if (EnvConfig.getHostOverride()) {
+    return EnvConfig.getHostOverride();
   }
 
   const { protocol, hostname } = new URL(uri);

--- a/src/generic-container/generic-container.test.ts
+++ b/src/generic-container/generic-container.test.ts
@@ -330,7 +330,7 @@ describe("GenericContainer", () => {
     expect(await getRunningContainerNames()).not.toContain(containerName);
   });
 
-  it("should read TESTCONTAINERS_DEFAULT_STARTUP_TIMEOUT to setup the startup variable", async () => {
+  it("should read TESTCONTAINERS_DEFAULT_STARTUP_TIMEOUT to setup the startup timeout", async () => {
     process.env.TESTCONTAINERS_DEFAULT_STARTUP_TIMEOUT = "0";
     const containerName = `container-${new RandomUuid().nextUuid()}`;
 

--- a/src/generic-container/generic-container.test.ts
+++ b/src/generic-container/generic-container.test.ts
@@ -330,6 +330,18 @@ describe("GenericContainer", () => {
     expect(await getRunningContainerNames()).not.toContain(containerName);
   });
 
+  it("should read TESTCONTAINERS_DEFAULT_STARTUP_TIMEOUT to setup the startup variable", async () => {
+    process.env.TESTCONTAINERS_DEFAULT_STARTUP_TIMEOUT = "0";
+    const containerName = `container-${new RandomUuid().nextUuid()}`;
+
+    await expect(
+      new GenericContainer("cristianrgreco/testcontainer:1.1.12").withName(containerName).withExposedPorts(8081).start()
+    ).rejects.toThrowError("Port 8081 not bound after 0ms");
+
+    expect(await getRunningContainerNames()).not.toContain(containerName);
+    process.env.TESTCONTAINERS_DEFAULT_STARTUP_TIMEOUT = "";
+  });
+
   it("should stop the container when the health check wait strategy times out", async () => {
     const containerName = `container-${new RandomUuid().nextUuid()}`;
 

--- a/src/generic-container/generic-container.ts
+++ b/src/generic-container/generic-container.ts
@@ -40,6 +40,7 @@ import { removeContainer } from "../docker/functions/container/remove-container"
 import { putContainerArchive } from "../docker/functions/container/put-container-archive";
 import { GenericContainerBuilder } from "./generic-container-builder";
 import { StartedGenericContainer } from "./started-generic-container";
+import { EnvConfig } from "../config";
 
 export class GenericContainer implements TestContainer {
   public static fromDockerfile(context: BuildContext, dockerfileName = "Dockerfile"): GenericContainerBuilder {
@@ -58,7 +59,7 @@ export class GenericContainer implements TestContainer {
   protected tmpFs: TmpFs = {};
   protected healthCheck?: HealthCheck;
   protected waitStrategy?: WaitStrategy;
-  protected startupTimeout = 60_000;
+  protected startupTimeout = EnvConfig.defaultSetupTimeout();
   protected useDefaultLogDriver = false;
   protected privilegedMode = false;
   protected ipcMode?: string;

--- a/src/generic-container/generic-container.ts
+++ b/src/generic-container/generic-container.ts
@@ -59,7 +59,7 @@ export class GenericContainer implements TestContainer {
   protected tmpFs: TmpFs = {};
   protected healthCheck?: HealthCheck;
   protected waitStrategy?: WaitStrategy;
-  protected startupTimeout = EnvConfig.defaultSetupTimeout();
+  protected startupTimeout = EnvConfig.getStartupTimeout();
   protected useDefaultLogDriver = false;
   protected privilegedMode = false;
   protected ipcMode?: string;

--- a/src/images.ts
+++ b/src/images.ts
@@ -1,4 +1,4 @@
 import { EnvConfig } from "./config";
 
-export const REAPER_IMAGE = EnvConfig.riukContainerImage();
-export const SSHD_IMAGE = EnvConfig.sshdContainerImage();
+export const REAPER_IMAGE = EnvConfig.getRyukContainerImage();
+export const SSHD_IMAGE = EnvConfig.getSshdContainerImage();

--- a/src/images.ts
+++ b/src/images.ts
@@ -1,2 +1,4 @@
-export const REAPER_IMAGE = process.env["RYUK_CONTAINER_IMAGE"] ?? "testcontainers/ryuk:0.3.2";
-export const SSHD_IMAGE = process.env["SSHD_CONTAINER_IMAGE"] ?? "testcontainers/sshd:1.0.0";
+import { EnvConfig } from "./config";
+
+export const REAPER_IMAGE = EnvConfig.riukContainerImage();
+export const SSHD_IMAGE = EnvConfig.sshdContainerImage();

--- a/src/reaper.ts
+++ b/src/reaper.ts
@@ -5,6 +5,7 @@ import { StartedTestContainer } from "./test-container";
 import { sessionId } from "./docker/session-id";
 import { dockerClient } from "./docker/docker-client";
 import { REAPER_IMAGE } from "./images";
+import { EnvConfig } from "./config";
 
 export interface Reaper {
   addProject(projectName: string): void;
@@ -66,11 +67,11 @@ export class ReaperInstance {
   }
 
   private static isEnabled(): boolean {
-    return process.env.TESTCONTAINERS_RYUK_DISABLED !== "true";
+    return EnvConfig.isRyukDisabled();
   }
 
   private static isPrivileged(): boolean {
-    return process.env.TESTCONTAINERS_RYUK_PRIVILEGED === "true";
+    return EnvConfig.isRyukPrivileged();
   }
 
   private static createDisabledInstance(): Promise<Reaper> {
@@ -79,7 +80,7 @@ export class ReaperInstance {
   }
 
   private static async createRealInstance(): Promise<Reaper> {
-    const dockerSocket = process.env["TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE"] ?? "/var/run/docker.sock";
+    const dockerSocket = EnvConfig.dockerSocketOverride();
 
     log.debug(`Creating new Reaper for session: ${sessionId}`);
     const container = new GenericContainer(REAPER_IMAGE)

--- a/src/reaper.ts
+++ b/src/reaper.ts
@@ -67,7 +67,7 @@ export class ReaperInstance {
   }
 
   private static isEnabled(): boolean {
-    return EnvConfig.isRyukDisabled();
+    return !EnvConfig.isRyukDisabled();
   }
 
   private static isPrivileged(): boolean {
@@ -80,7 +80,7 @@ export class ReaperInstance {
   }
 
   private static async createRealInstance(): Promise<Reaper> {
-    const dockerSocket = EnvConfig.dockerSocketOverride();
+    const dockerSocket = EnvConfig.getDockerSocket();
 
     log.debug(`Creating new Reaper for session: ${sessionId}`);
     const container = new GenericContainer(REAPER_IMAGE)

--- a/src/wait-strategy.ts
+++ b/src/wait-strategy.ts
@@ -8,6 +8,7 @@ import { HealthCheckStatus } from "./docker/types";
 import Dockerode from "dockerode";
 import { containerLogs } from "./docker/functions/container/container-logs";
 import { inspectContainer } from "./docker/functions/container/inspect-container";
+import { EnvConfig } from "./config";
 
 export interface WaitStrategy {
   waitUntilReady(container: Dockerode.Container, boundPorts: BoundPorts): Promise<void>;
@@ -15,7 +16,7 @@ export interface WaitStrategy {
 }
 
 abstract class AbstractWaitStrategy implements WaitStrategy {
-  protected startupTimeout = 60_000;
+  protected startupTimeout = EnvConfig.defaultSetupTimeout();
 
   public abstract waitUntilReady(container: Dockerode.Container, boundPorts: BoundPorts): Promise<void>;
 

--- a/src/wait-strategy.ts
+++ b/src/wait-strategy.ts
@@ -16,7 +16,7 @@ export interface WaitStrategy {
 }
 
 abstract class AbstractWaitStrategy implements WaitStrategy {
-  protected startupTimeout = EnvConfig.defaultSetupTimeout();
+  protected startupTimeout = EnvConfig.getStartupTimeout();
 
   public abstract waitUntilReady(container: Dockerode.Container, boundPorts: BoundPorts): Promise<void>;
 


### PR DESCRIPTION
I added the timeout in WaitStrategy and generic-container, so I needed a way to keep env pulling in one place, took the liberty to move others `process.env` configs to the same spot.

closes #323 