### PR TITLE
Add env DOCKER_CONFIG

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The following environment variables are supported:
 - `DOCKER_HOST=tcp://docker:2375` Sets the URL of the docker daemon
 - `DOCKER_TLS_VERIFY=1` When set to `1`, enables TLS communication with the docker
   daemon
+- `DOCKER_CONFIG=/some/path` Configures the path to the `config.json`. Defaults to `~/.docker`
 - `DOCKER_CERT_PATH=/some/path` Configures the path to the `ca.pem`, `cert.pem`, and `key.pem` files used for TLS
   verification. Defaults to `~/.docker`
 - `TESTCONTAINERS_HOST_OVERRIDE=docker.svc.local` Docker's host on which ports are exposed

--- a/src/registry-auth-locator/index.ts
+++ b/src/registry-auth-locator/index.ts
@@ -11,7 +11,9 @@ import { AuthConfig } from "../docker/types";
 
 const DEFAULT_REGISTRY = "https://index.docker.io/v1/";
 
-const dockerConfigFile = path.resolve(os.homedir(), ".docker", "config.json");
+const dockerConfigLocation = process.env.DOCKER_CONFIG || `${os.homedir()}/.docker`;
+
+const dockerConfigFile = path.resolve(dockerConfigLocation, "config.json");
 
 const readDockerConfig = async (): Promise<DockerConfig> => {
   if (!existsSync(dockerConfigFile)) {


### PR DESCRIPTION
Hey, I'd like to add support for the environment variable `DOCKER_CONFIG`.

Since I had a java project and a node project, both of them used testcontainers in test cases.
I found some different behavior, when using the docker config file, testcontainers-java will find `$DOCKER_CONFIG` folder first, and if `$DOCKER_CONFIG` is not defined, use `$HOME/.docker` as well, but testcontainers-node only use `$HOME/.docker`

Please check [RegistryAuthLocator.java#L64](https://github.com/testcontainers/testcontainers-java/blob/master/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java#L64)
```java
final String dockerConfigLocation = System.getenv().getOrDefault("DOCKER_CONFIG",
    System.getProperty("user.home") + "/.docker");
```

In my case, environment have the variable `DOCKER_CONFIG`, I hope testcontainers-node can have the same behavior with testcontainers-java.

Please review my commit : )


