### PR TITLE
Add support for container reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,22 @@ const container = await new GenericContainer("alpine")
   .start();
 ```
 
+Enabling container reuse, note that two containers are considered equal if their options (exposed ports, commands, mounts, etc) match:
+
+```javascript
+const { GenericContainer } = require("testcontainers");
+
+const container1 = await new GenericContainer("alpine")
+  .withReuse()
+  .start();
+
+const container2 = await new GenericContainer("alpine")
+  .withReuse()
+  .start();
+
+assert(container1.getId() === container2.getId());
+```
+
 Creating a container with a specified name:
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -135,10 +135,12 @@ Enabling container reuse, note that two containers are considered equal if their
 const { GenericContainer } = require("testcontainers");
 
 const container1 = await new GenericContainer("alpine")
+  .withCmd(["sleep", "infinity"])
   .withReuse()
   .start();
 
 const container2 = await new GenericContainer("alpine")
+  .withCmd(["sleep", "infinity"])
   .withReuse()
   .start();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "testcontainers",
-      "version": "8.1.2",
+      "version": "8.4.0",
       "license": "MIT",
       "dependencies": {
         "@types/archiver": "^5.1.1",

--- a/src/docker/functions/container/create-container.ts
+++ b/src/docker/functions/container/create-container.ts
@@ -3,7 +3,7 @@ import { DockerImageName } from "../../../docker-image-name";
 import { dockerClient } from "../../docker-client";
 import Dockerode, { PortMap as DockerodePortBindings } from "dockerode";
 import { getContainerPort, hasHostBinding, PortString, PortWithOptionalBinding } from "../../../port";
-import { createLabels } from "../create-labels";
+import { createLabels, Labels } from "../create-labels";
 import { BindMount, Command, ContainerName, Env, ExtraHost, HealthCheck, NetworkMode, TmpFs } from "../../types";
 
 export type CreateContainerOptions = {
@@ -14,6 +14,8 @@ export type CreateContainerOptions = {
   tmpFs: TmpFs;
   exposedPorts: PortWithOptionalBinding[];
   name?: ContainerName;
+  reusable: boolean;
+  labels?: Labels;
   networkMode?: NetworkMode;
   healthCheck?: HealthCheck;
   useDefaultLogDriver: boolean;
@@ -36,7 +38,7 @@ export const createContainer = async (options: CreateContainerOptions): Promise<
       Env: getEnv(options.env),
       ExposedPorts: getExposedPorts(options.exposedPorts),
       Cmd: options.cmd,
-      Labels: createLabels(options.imageName),
+      Labels: createLabels(options.reusable, options.imageName, options.labels),
       // @ts-ignore
       Healthcheck: getHealthCheck(options.healthCheck),
       HostConfig: {

--- a/src/docker/functions/container/get-container.ts
+++ b/src/docker/functions/container/get-container.ts
@@ -1,8 +1,36 @@
 import { dockerClient } from "../../docker-client";
 import Dockerode from "dockerode";
 import { Id } from "../../types";
+import { log } from "../../../logger";
+import { LABEL_CONTAINER_HASH } from "../../../labels";
 
 export const getContainerById = async (id: Id): Promise<Dockerode.Container> => {
-  const { dockerode } = await dockerClient;
-  return dockerode.getContainer(id);
+  try {
+    const { dockerode } = await dockerClient;
+    return dockerode.getContainer(id);
+  } catch (err) {
+    log.error(`Failed to get container by ID: ${err}`);
+    throw err;
+  }
+};
+
+export const getContainerByHash = async (hash: string): Promise<Dockerode.Container | undefined> => {
+  try {
+    const { dockerode } = await dockerClient;
+    const containers = await dockerode.listContainers({
+      limit: 1,
+      filters: {
+        status: ["running"],
+        label: [`${LABEL_CONTAINER_HASH}=${hash}`],
+      },
+    });
+    if (containers.length === 0) {
+      return undefined;
+    } else {
+      return await getContainerById(containers[0].Id);
+    }
+  } catch (err) {
+    log.error(`Failed to get container by hash (${hash}): ${err}`);
+    throw err;
+  }
 };

--- a/src/docker/functions/create-labels.test.ts
+++ b/src/docker/functions/create-labels.test.ts
@@ -1,0 +1,24 @@
+import { createLabels } from "./create-labels";
+import { DockerImageName } from "../../docker-image-name";
+import { REAPER_IMAGE } from "../../images";
+import { LABEL_SESSION_ID } from "../../labels";
+
+test("should add session ID label when not reusable (for the Reaper)", () => {
+  expect(createLabels(false)).toEqual({ [LABEL_SESSION_ID]: expect.any(String) });
+});
+
+test("should not add session ID label when reusable (to avoid Reaper)", () => {
+  expect(createLabels(true)).toEqual({});
+});
+
+test("should not add session ID label when the container is the Reaper (to avoid Reaper killing self)", () => {
+  const labels = createLabels(false, DockerImageName.fromString(REAPER_IMAGE));
+  expect(labels).toEqual({});
+});
+
+test("should support extra labels", () => {
+  expect(createLabels(false, undefined, { key: "value" })).toEqual({
+    [LABEL_SESSION_ID]: expect.any(String),
+    key: "value",
+  });
+});

--- a/src/docker/functions/create-labels.ts
+++ b/src/docker/functions/create-labels.ts
@@ -1,9 +1,23 @@
 import { DockerImageName } from "../../docker-image-name";
 import { sessionId } from "../session-id";
+import { LABEL_SESSION_ID } from "../../labels";
 
-export const createLabels = (dockerImageName?: DockerImageName): { [label: string]: string } => {
+export type Labels = { [key: string]: string };
+
+export const createLabels = (
+  reusable: boolean,
+  dockerImageName?: DockerImageName,
+  extraLabels: Labels = {}
+): Labels => {
+  const labels: Labels = { ...extraLabels };
+
   if (dockerImageName && dockerImageName.isReaper()) {
-    return {};
+    return labels;
   }
-  return { "org.testcontainers.session-id": sessionId };
+
+  if (!reusable) {
+    labels[LABEL_SESSION_ID] = sessionId;
+  }
+
+  return labels;
 };

--- a/src/docker/functions/image/build-image.ts
+++ b/src/docker/functions/image/build-image.ts
@@ -32,7 +32,7 @@ export const buildImage = async (options: BuildImageOptions): Promise<void> => {
           dockerfile: options.dockerfileName,
           buildargs: options.buildArgs,
           t: options.imageName.toString(),
-          labels: createLabels(options.imageName),
+          labels: createLabels(false, options.imageName),
           registryconfig: options.registryConfig,
           pull: options.pullPolicy.shouldPull() ? "any" : undefined,
         })

--- a/src/docker/functions/network/create-network.ts
+++ b/src/docker/functions/network/create-network.ts
@@ -29,7 +29,7 @@ export const createNetwork = async (options: CreateNetworkOptions): Promise<stri
       Ingress: options.ingress,
       EnableIPv6: options.enableIPv6,
       Options: options.options,
-      Labels: { ...options.labels, ...createLabels() },
+      Labels: { ...options.labels, ...createLabels(false) },
     });
 
     return network.id;

--- a/src/generic-container/generic-container.test.ts
+++ b/src/generic-container/generic-container.test.ts
@@ -497,6 +497,8 @@ describe("GenericContainer", () => {
         .start();
       await checkContainerIsHealthy(container2);
 
+      expect(container1.getId()).toBe(container2.getId());
+
       await container1.stop();
     });
 
@@ -514,6 +516,8 @@ describe("GenericContainer", () => {
         .withReuse()
         .start();
       await checkContainerIsHealthy(container2);
+
+      expect(container1.getId()).not.toBe(container2.getId());
     });
   });
 

--- a/src/generic-container/generic-container.test.ts
+++ b/src/generic-container/generic-container.test.ts
@@ -446,6 +446,42 @@ describe("GenericContainer", () => {
       await container.stop();
     });
 
+    it("should not reuse the container even when there is a candidate 1", async () => {
+      const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.12")
+        .withName("there_can_only_be_one")
+        .withExposedPorts(8080)
+        .withReuse()
+        .start();
+      await checkContainerIsHealthy(container);
+
+      await expect(() =>
+        new GenericContainer("cristianrgreco/testcontainer:1.1.12")
+          .withName("there_can_only_be_one")
+          .withExposedPorts(8080)
+          .start()
+      ).rejects.toThrowError();
+
+      await container.stop();
+    });
+
+    it("should not reuse the container even when there is a candidate 2", async () => {
+      const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.12")
+        .withName("there_can_only_be_one")
+        .withExposedPorts(8080)
+        .start();
+      await checkContainerIsHealthy(container);
+
+      await expect(() =>
+        new GenericContainer("cristianrgreco/testcontainer:1.1.12")
+          .withName("there_can_only_be_one")
+          .withExposedPorts(8080)
+          .withReuse()
+          .start()
+      ).rejects.toThrowError();
+
+      await container.stop();
+    });
+
     it("should reuse the container", async () => {
       const container1 = await new GenericContainer("cristianrgreco/testcontainer:1.1.12")
         .withName("there_can_only_be_one")

--- a/src/generic-container/started-generic-container.ts
+++ b/src/generic-container/started-generic-container.ts
@@ -13,8 +13,6 @@ import { StoppedGenericContainer } from "./stopped-generic-container";
 import { stopContainer } from "../docker/functions/container/stop-container";
 
 export class StartedGenericContainer implements StartedTestContainer {
-  private stopped = false;
-
   constructor(
     private readonly container: Dockerode.Container,
     private readonly host: Host,
@@ -29,17 +27,12 @@ export class StartedGenericContainer implements StartedTestContainer {
 
   private async stopContainer(options: Partial<StopOptions> = {}): Promise<StoppedGenericContainer> {
     log.info(`Stopping container with ID: ${this.container.id}`);
-    this.stopped = true;
 
     const resolvedOptions: StopOptions = { timeout: 0, removeVolumes: true, ...options };
     await stopContainer(this.container, { timeout: resolvedOptions.timeout });
     await removeContainer(this.container, { removeVolumes: resolvedOptions.removeVolumes });
 
     return new StoppedGenericContainer();
-  }
-
-  public isStopped(): boolean {
-    return this.stopped;
   }
 
   public getHost(): Host {

--- a/src/generic-container/started-generic-container.ts
+++ b/src/generic-container/started-generic-container.ts
@@ -13,6 +13,8 @@ import { StoppedGenericContainer } from "./stopped-generic-container";
 import { stopContainer } from "../docker/functions/container/stop-container";
 
 export class StartedGenericContainer implements StartedTestContainer {
+  private stopped = false;
+
   constructor(
     private readonly container: Dockerode.Container,
     private readonly host: Host,
@@ -27,12 +29,17 @@ export class StartedGenericContainer implements StartedTestContainer {
 
   private async stopContainer(options: Partial<StopOptions> = {}): Promise<StoppedGenericContainer> {
     log.info(`Stopping container with ID: ${this.container.id}`);
+    this.stopped = true;
 
     const resolvedOptions: StopOptions = { timeout: 0, removeVolumes: true, ...options };
     await stopContainer(this.container, { timeout: resolvedOptions.timeout });
     await removeContainer(this.container, { removeVolumes: resolvedOptions.removeVolumes });
 
     return new StoppedGenericContainer();
+  }
+
+  public isStopped(): boolean {
+    return this.stopped;
   }
 
   public getHost(): Host {

--- a/src/hash.test.ts
+++ b/src/hash.test.ts
@@ -1,0 +1,8 @@
+import { hash } from "./hash";
+
+test("should return a hash", () => {
+  const str = "Hello, world!";
+
+  expect(hash(str)).toBe("6cd3556deb0da54bca060b4c39479839");
+  expect(hash(str)).toBe("6cd3556deb0da54bca060b4c39479839");
+});

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -1,0 +1,5 @@
+import crypto from "crypto";
+
+export const hash = (str: string): string => {
+  return crypto.createHash("md5").update(str).digest("hex");
+};

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -1,0 +1,2 @@
+export const LABEL_SESSION_ID = "org.testcontainers.session-id";
+export const LABEL_CONTAINER_HASH = "org.testcontainers.container-hash";

--- a/src/reaper.ts
+++ b/src/reaper.ts
@@ -6,6 +6,7 @@ import { sessionId } from "./docker/session-id";
 import { dockerClient } from "./docker/docker-client";
 import { REAPER_IMAGE } from "./images";
 import { getContainerPort } from "./port";
+import { LABEL_SESSION_ID } from "./labels";
 
 export interface Reaper {
   addProject(projectName: string): void;
@@ -117,7 +118,7 @@ export class ReaperInstance {
     return new Promise((resolve) => {
       socket.connect(getContainerPort(port), host, () => {
         log.debug(`Connected to Reaper ${containerId}`);
-        socket.write(`label=org.testcontainers.session-id=${sessionId}\r\n`);
+        socket.write(`label=${LABEL_SESSION_ID}=${sessionId}\r\n`);
         const reaper = new RealReaper(startedContainer, socket);
         resolve(reaper);
       });

--- a/src/test-container.ts
+++ b/src/test-container.ts
@@ -46,6 +46,8 @@ export interface TestContainer {
 
   withPullPolicy(pullPolicy: PullPolicy): this;
 
+  withReuse(): this;
+
   withCopyFileToContainer(sourcePath: string, containerPath: string): this;
 
   withCopyContentToContainer(content: string | Buffer | Readable, containerPath: string): this;
@@ -58,6 +60,8 @@ export interface StopOptions {
 
 export interface StartedTestContainer {
   stop(options?: Partial<StopOptions>): Promise<StoppedTestContainer>;
+
+  isStopped(): boolean;
 
   getHost(): Host;
 

--- a/src/test-container.ts
+++ b/src/test-container.ts
@@ -61,8 +61,6 @@ export interface StopOptions {
 export interface StartedTestContainer {
   stop(options?: Partial<StopOptions>): Promise<StoppedTestContainer>;
 
-  isStopped(): boolean;
-
   getHost(): Host;
 
   getMappedPort(port: Port): Port;


### PR DESCRIPTION
Implements #319.

Two containers are considered equal if their options (exposed ports, commands, mounts, etc) match. Example:

```javascript
const { GenericContainer } = require("testcontainers");

const container1 = await new GenericContainer("alpine")
  .withCmd(["sleep", "infinity"])
  .withReuse()
  .start();

const container2 = await new GenericContainer("alpine")
  .withCmd(["sleep", "infinity"])
  .withReuse()
  .start();

assert(container1.getId() === container2.getId());
```