### PR TITLE
Be able to set own project name on withNoRecreate

### DIFF
--- a/src/docker-compose-environment/docker-compose-environment.ts
+++ b/src/docker-compose-environment/docker-compose-environment.ts
@@ -56,9 +56,9 @@ export class DockerComposeEnvironment {
     return this;
   }
 
-  public withNoRecreate(): this {
+  public withNoRecreate(projectName = "testcontainers-node"): this {
     this.recreate = false;
-    this.projectName = "testcontainers-node";
+    this.projectName = projectName;
     return this;
   }
 


### PR DESCRIPTION
If you want to use testcontainers with multiple projects the "testcontainers-node" project name may already be used on your system.
So to be able to use your own projectName in that function would make sense to me.