### PR TITLE
fix: make kafka containers reusable

### DIFF
--- a/src/modules/kafka/kafka-container.test.ts
+++ b/src/modules/kafka/kafka-container.test.ts
@@ -59,6 +59,15 @@ describe("KafkaContainer", () => {
     await network.stop();
   });
 
+  it("should be reusable", async () => {
+    const originalKafkaContainer = await new KafkaContainer().withReuse().start();
+    const newKafkaContainer = await new KafkaContainer().withReuse().start();
+
+    expect(newKafkaContainer.getId()).toBe(originalKafkaContainer.getId());
+
+    await originalKafkaContainer.stop();
+  });
+
   const testPubSub = async (kafkaContainer: StartedTestContainer) => {
     const kafka = new Kafka({
       logLevel: logLevel.NOTHING,

--- a/src/modules/kafka/kafka-container.ts
+++ b/src/modules/kafka/kafka-container.ts
@@ -4,19 +4,18 @@ import { Port } from "../../port";
 import { RandomUuid, Uuid } from "../../uuid";
 import { StartedTestContainer } from "../..";
 import { AbstractStartedContainer } from "../abstract-started-container";
-import { PortGenerator, RandomUniquePortGenerator } from "../../port-generator";
 import { Host } from "../../docker/types";
 import { InspectResult } from "../../docker/functions/container/inspect-container";
 import { dockerClient } from "../../docker/docker-client";
 
 const KAFKA_PORT = 9093;
 const KAFKA_BROKER_PORT = 9092;
+const DEFAULT_ZOOKEEPER_PORT = 2181;
 
 export const KAFKA_IMAGE = "confluentinc/cp-kafka:5.5.4";
 
 export class KafkaContainer extends GenericContainer {
   private readonly uuid: Uuid = new RandomUuid();
-  private readonly portGenerator: PortGenerator = new RandomUniquePortGenerator();
 
   private isZooKeeperProvided = false;
   private zooKeeperHost?: Host;
@@ -56,7 +55,7 @@ export class KafkaContainer extends GenericContainer {
       this.withEnv("KAFKA_ZOOKEEPER_CONNECT", `${this.zooKeeperHost}:${this.zooKeeperPort}`);
     } else {
       this.zooKeeperHost = this.uuid.nextUuid();
-      this.zooKeeperPort = await this.portGenerator.generatePort();
+      this.zooKeeperPort = DEFAULT_ZOOKEEPER_PORT;
       this.addExposedPorts(this.zooKeeperPort);
       this.withEnv("KAFKA_ZOOKEEPER_CONNECT", `localhost:${this.zooKeeperPort}`);
       command += "echo 'clientPort=" + this.zooKeeperPort + "' > zookeeper.properties\n";


### PR DESCRIPTION
This fixes #351 by making the zookeeper port stable.
This will also simplify calling commands to create a user so that the container can be used to test a connection to a cluster that requires SASL.

Alternatively the randomly generated port could not be exposed anymore. It should fix the reusability issue, but will not help with running commands within the container.