### PR TITLE
feat: add support for specifying host port on module container instan…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "testcontainers",
-      "version": "8.7.1",
+      "version": "8.8.0",
       "license": "MIT",
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",
@@ -31,7 +31,6 @@
         "@types/node-fetch": "^2.6.1",
         "@types/pg": "^8.6.5",
         "@types/properties-reader": "^2.1.1",
-        "@types/rimraf": "^3.0.2",
         "@types/tar-fs": "^2.0.1",
         "@typescript-eslint/eslint-plugin": "^5.19.0",
         "@typescript-eslint/parser": "^5.19.0",
@@ -1369,16 +1368,6 @@
       "resolved": "https://registry.npmjs.org/@types/properties-reader/-/properties-reader-2.1.1.tgz",
       "integrity": "sha512-IpGxvT1giDlK5VmWXt0l1vCKyD5DtrzFn1x31ho6xHtwADm7W0zzUft8mYMAx4rs6jvlj95DccVjKAvAwQ46PQ==",
       "dev": true
-    },
-    "node_modules/@types/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/glob": "*",
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/ssh2": {
       "version": "0.5.48",
@@ -8195,16 +8184,6 @@
       "resolved": "https://registry.npmjs.org/@types/properties-reader/-/properties-reader-2.1.1.tgz",
       "integrity": "sha512-IpGxvT1giDlK5VmWXt0l1vCKyD5DtrzFn1x31ho6xHtwADm7W0zzUft8mYMAx4rs6jvlj95DccVjKAvAwQ46PQ==",
       "dev": true
-    },
-    "@types/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==",
-      "dev": true,
-      "requires": {
-        "@types/glob": "*",
-        "@types/node": "*"
-      }
     },
     "@types/ssh2": {
       "version": "0.5.48",

--- a/src/generic-container/generic-container.ts
+++ b/src/generic-container/generic-container.ts
@@ -214,6 +214,10 @@ export class GenericContainer implements TestContainer {
     boundPorts: BoundPorts
   ): Promise<void>;
 
+  protected get hasExposedPorts(): boolean {
+    return Boolean(this.ports.length);
+  }
+
   public withCmd(cmd: Command[]): this {
     this.cmd = cmd;
     return this;

--- a/src/generic-container/generic-container.ts
+++ b/src/generic-container/generic-container.ts
@@ -215,7 +215,7 @@ export class GenericContainer implements TestContainer {
   ): Promise<void>;
 
   protected get hasExposedPorts(): boolean {
-    return Boolean(this.ports.length);
+    return this.ports.length !== 0;
   }
 
   public withCmd(cmd: Command[]): this {

--- a/src/modules/arangodb/arangodb-container.ts
+++ b/src/modules/arangodb/arangodb-container.ts
@@ -9,8 +9,6 @@ const ARANGODB_PORT = 8529;
 const USERNAME = "root";
 
 export class ArangoDBContainer extends GenericContainer {
-  private hostPort: number | null = null;
-
   constructor(image = "arangodb:3.7.13", private password = new RandomUuid().nextUuid()) {
     super(image);
   }
@@ -20,13 +18,8 @@ export class ArangoDBContainer extends GenericContainer {
     return this;
   }
 
-  public withHostPort(hostPort: number): this {
-    this.hostPort = hostPort;
-    return this;
-  }
-
   public async start(): Promise<StartedArangoContainer> {
-    this.withExposedPorts(this.hostPort ? { container: ARANGODB_PORT, host: this.hostPort } : ARANGODB_PORT)
+    this.withExposedPorts(...(this.hasExposedPorts ? this.ports : [ARANGODB_PORT]))
       .withWaitStrategy(Wait.forLogMessage("Have fun!"))
       .withEnv("ARANGO_ROOT_PASSWORD", this.password)
       .withStartupTimeout(120_000);

--- a/src/modules/elasticsearch/elasticsearch-container.ts
+++ b/src/modules/elasticsearch/elasticsearch-container.ts
@@ -5,21 +5,12 @@ import { Port } from "../../port";
 const ELASTIC_SEARCH_HTTP_PORT = 9200;
 
 export class ElasticsearchContainer extends GenericContainer {
-  private hostPort: number | null = null;
-
   constructor(image = "docker.elastic.co/elasticsearch/elasticsearch:7.9.2") {
     super(image);
   }
 
-  public withHostPort(hostPort: number): this {
-    this.hostPort = hostPort;
-    return this;
-  }
-
   public async start(): Promise<StartedElasticsearchContainer> {
-    this.withExposedPorts(
-      this.hostPort ? { container: ELASTIC_SEARCH_HTTP_PORT, host: this.hostPort } : ELASTIC_SEARCH_HTTP_PORT
-    )
+    this.withExposedPorts(...(this.hasExposedPorts ? this.ports : [ELASTIC_SEARCH_HTTP_PORT]))
       .withEnv("discovery.type", "single-node")
       .withStartupTimeout(120_000);
 

--- a/src/modules/elasticsearch/elasticsearch-container.ts
+++ b/src/modules/elasticsearch/elasticsearch-container.ts
@@ -5,12 +5,21 @@ import { Port } from "../../port";
 const ELASTIC_SEARCH_HTTP_PORT = 9200;
 
 export class ElasticsearchContainer extends GenericContainer {
+  private hostPort: number | null = null;
+
   constructor(image = "docker.elastic.co/elasticsearch/elasticsearch:7.9.2") {
     super(image);
   }
 
+  public withHostPort(hostPort: number): this {
+    this.hostPort = hostPort;
+    return this;
+  }
+
   public async start(): Promise<StartedElasticsearchContainer> {
-    this.withExposedPorts(ELASTIC_SEARCH_HTTP_PORT)
+    this.withExposedPorts(
+      this.hostPort ? { container: ELASTIC_SEARCH_HTTP_PORT, host: this.hostPort } : ELASTIC_SEARCH_HTTP_PORT
+    )
       .withEnv("discovery.type", "single-node")
       .withStartupTimeout(120_000);
 

--- a/src/modules/kafka/kafka-container.ts
+++ b/src/modules/kafka/kafka-container.ts
@@ -1,6 +1,6 @@
 import { GenericContainer } from "../../generic-container/generic-container";
 import { BoundPorts } from "../../bound-ports";
-import { Port } from "../../port";
+import { Port, PortWithOptionalBinding } from "../../port";
 import { RandomUuid, Uuid } from "../../uuid";
 import { StartedTestContainer } from "../..";
 import { AbstractStartedContainer } from "../abstract-started-container";
@@ -43,10 +43,10 @@ export class KafkaContainer extends GenericContainer {
   private zooKeeperPort?: Port;
   private saslSslConfig?: SaslSslListenerOptions;
 
-  constructor(image = KAFKA_IMAGE, hostPort?: number) {
+  constructor(image = KAFKA_IMAGE, ports?: PortWithOptionalBinding[]) {
     super(image);
 
-    this.withExposedPorts(hostPort ? { container: KAFKA_PORT, host: hostPort } : KAFKA_PORT)
+    this.withExposedPorts(...(ports || [KAFKA_PORT]))
       .withStartupTimeout(180_000)
       .withEnv("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "BROKER:PLAINTEXT,PLAINTEXT:PLAINTEXT")
       .withEnv("KAFKA_INTER_BROKER_LISTENER_NAME", "BROKER")

--- a/src/modules/kafka/kafka-container.ts
+++ b/src/modules/kafka/kafka-container.ts
@@ -1,6 +1,6 @@
 import { GenericContainer } from "../../generic-container/generic-container";
 import { BoundPorts } from "../../bound-ports";
-import { Port, PortWithOptionalBinding } from "../../port";
+import { Port } from "../../port";
 import { RandomUuid, Uuid } from "../../uuid";
 import { StartedTestContainer } from "../..";
 import { AbstractStartedContainer } from "../abstract-started-container";
@@ -43,10 +43,10 @@ export class KafkaContainer extends GenericContainer {
   private zooKeeperPort?: Port;
   private saslSslConfig?: SaslSslListenerOptions;
 
-  constructor(image = KAFKA_IMAGE, ports?: PortWithOptionalBinding[]) {
+  constructor(image = KAFKA_IMAGE) {
     super(image);
 
-    this.withExposedPorts(...(ports || [KAFKA_PORT]))
+    this.withExposedPorts(KAFKA_PORT)
       .withStartupTimeout(180_000)
       .withEnv("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "BROKER:PLAINTEXT,PLAINTEXT:PLAINTEXT")
       .withEnv("KAFKA_INTER_BROKER_LISTENER_NAME", "BROKER")

--- a/src/modules/kafka/kafka-container.ts
+++ b/src/modules/kafka/kafka-container.ts
@@ -43,10 +43,10 @@ export class KafkaContainer extends GenericContainer {
   private zooKeeperPort?: Port;
   private saslSslConfig?: SaslSslListenerOptions;
 
-  constructor(image = KAFKA_IMAGE) {
+  constructor(image = KAFKA_IMAGE, hostPort?: number) {
     super(image);
 
-    this.withExposedPorts(KAFKA_PORT)
+    this.withExposedPorts(hostPort ? { container: KAFKA_PORT, host: hostPort } : KAFKA_PORT)
       .withStartupTimeout(180_000)
       .withEnv("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "BROKER:PLAINTEXT,PLAINTEXT:PLAINTEXT")
       .withEnv("KAFKA_INTER_BROKER_LISTENER_NAME", "BROKER")

--- a/src/modules/mysql/mysql-container.ts
+++ b/src/modules/mysql/mysql-container.ts
@@ -11,7 +11,6 @@ export class MySqlContainer extends GenericContainer {
   private username = new RandomUuid().nextUuid();
   private userPassword = new RandomUuid().nextUuid();
   private rootPassword = new RandomUuid().nextUuid();
-  private hostPort: number | null = null;
 
   constructor(image = "mysql:8.0.26") {
     super(image);
@@ -37,13 +36,8 @@ export class MySqlContainer extends GenericContainer {
     return this;
   }
 
-  public withHostPort(hostPort: number): this {
-    this.hostPort = hostPort;
-    return this;
-  }
-
   public async start(): Promise<StartedMySqlContainer> {
-    this.withExposedPorts(this.hostPort ? { container: MYSQL_PORT, host: this.hostPort } : MYSQL_PORT)
+    this.withExposedPorts(...(this.hasExposedPorts ? this.ports : [MYSQL_PORT]))
       .withEnv("MYSQL_DATABASE", this.database)
       .withEnv("MYSQL_ROOT_PASSWORD", this.rootPassword)
       .withEnv("MYSQL_USER", this.username)

--- a/src/modules/mysql/mysql-container.ts
+++ b/src/modules/mysql/mysql-container.ts
@@ -4,11 +4,14 @@ import { RandomUuid } from "../../uuid";
 import { AbstractStartedContainer } from "../abstract-started-container";
 import { Port } from "../../port";
 
+const MYSQL_PORT = 3306;
+
 export class MySqlContainer extends GenericContainer {
   private database = "test";
   private username = new RandomUuid().nextUuid();
   private userPassword = new RandomUuid().nextUuid();
   private rootPassword = new RandomUuid().nextUuid();
+  private hostPort: number | null = null;
 
   constructor(image = "mysql:8.0.26") {
     super(image);
@@ -34,8 +37,13 @@ export class MySqlContainer extends GenericContainer {
     return this;
   }
 
+  public withHostPort(hostPort: number): this {
+    this.hostPort = hostPort;
+    return this;
+  }
+
   public async start(): Promise<StartedMySqlContainer> {
-    this.withExposedPorts(3306)
+    this.withExposedPorts(this.hostPort ? { container: MYSQL_PORT, host: this.hostPort } : MYSQL_PORT)
       .withEnv("MYSQL_DATABASE", this.database)
       .withEnv("MYSQL_ROOT_PASSWORD", this.rootPassword)
       .withEnv("MYSQL_USER", this.username)

--- a/src/modules/neo4j/neo4j-container.ts
+++ b/src/modules/neo4j/neo4j-container.ts
@@ -12,6 +12,8 @@ export class Neo4jContainer extends GenericContainer {
   private password = new RandomUuid().nextUuid();
   private apoc = false;
   private ttl?: number;
+  private hostBoltPort: number | null = null;
+  private hostHttpPort: number | null = null;
 
   constructor(image = "neo4j:4.3.2") {
     super(image);
@@ -32,8 +34,21 @@ export class Neo4jContainer extends GenericContainer {
     return this;
   }
 
+  public withHostBoltPort(hostBoltPort: number): this {
+    this.hostBoltPort = hostBoltPort;
+    return this;
+  }
+
+  public withHostHttpPort(hostHttpPort: number): this {
+    this.hostHttpPort = hostHttpPort;
+    return this;
+  }
+
   public async start(): Promise<StartedNeo4jContainer> {
-    this.withExposedPorts(BOLT_PORT, HTTP_PORT)
+    this.withExposedPorts(
+      this.hostBoltPort ? { container: BOLT_PORT, host: this.hostBoltPort } : BOLT_PORT,
+      this.hostHttpPort ? { container: HTTP_PORT, host: this.hostHttpPort } : HTTP_PORT
+    )
       .withWaitStrategy(Wait.forLogMessage("Started."))
       .withEnv("NEO4J_AUTH", `${USERNAME}/${this.password}`)
       .withStartupTimeout(120_000);

--- a/src/modules/neo4j/neo4j-container.ts
+++ b/src/modules/neo4j/neo4j-container.ts
@@ -12,8 +12,6 @@ export class Neo4jContainer extends GenericContainer {
   private password = new RandomUuid().nextUuid();
   private apoc = false;
   private ttl?: number;
-  private hostBoltPort: number | null = null;
-  private hostHttpPort: number | null = null;
 
   constructor(image = "neo4j:4.3.2") {
     super(image);
@@ -34,21 +32,8 @@ export class Neo4jContainer extends GenericContainer {
     return this;
   }
 
-  public withHostBoltPort(hostBoltPort: number): this {
-    this.hostBoltPort = hostBoltPort;
-    return this;
-  }
-
-  public withHostHttpPort(hostHttpPort: number): this {
-    this.hostHttpPort = hostHttpPort;
-    return this;
-  }
-
   public async start(): Promise<StartedNeo4jContainer> {
-    this.withExposedPorts(
-      this.hostBoltPort ? { container: BOLT_PORT, host: this.hostBoltPort } : BOLT_PORT,
-      this.hostHttpPort ? { container: HTTP_PORT, host: this.hostHttpPort } : HTTP_PORT
-    )
+    this.withExposedPorts(...(this.hasExposedPorts ? this.ports : [BOLT_PORT, HTTP_PORT]))
       .withWaitStrategy(Wait.forLogMessage("Started."))
       .withEnv("NEO4J_AUTH", `${USERNAME}/${this.password}`)
       .withStartupTimeout(120_000);

--- a/src/modules/postgresql/postgresql-container.ts
+++ b/src/modules/postgresql/postgresql-container.ts
@@ -4,10 +4,13 @@ import { RandomUuid } from "../../uuid";
 import { AbstractStartedContainer } from "../abstract-started-container";
 import { Port } from "../../port";
 
+const POSTGRES_PORT = 5432;
+
 export class PostgreSqlContainer extends GenericContainer {
   private database = "test";
   private username = new RandomUuid().nextUuid();
   private password = new RandomUuid().nextUuid();
+  private hostPort: number | null = null;
 
   constructor(image = "postgres:13.3-alpine") {
     super(image);
@@ -28,8 +31,13 @@ export class PostgreSqlContainer extends GenericContainer {
     return this;
   }
 
+  public withHostPort(port: number): this {
+    this.hostPort = port;
+    return this;
+  }
+
   public async start(): Promise<StartedPostgreSqlContainer> {
-    this.withExposedPorts(5432)
+    this.withExposedPorts(this.hostPort ? { container: POSTGRES_PORT, host: this.hostPort } : POSTGRES_PORT)
       .withEnv("POSTGRES_DB", this.database)
       .withEnv("POSTGRES_USER", this.username)
       .withEnv("POSTGRES_PASSWORD", this.password)

--- a/src/modules/postgresql/postgresql-container.ts
+++ b/src/modules/postgresql/postgresql-container.ts
@@ -10,7 +10,6 @@ export class PostgreSqlContainer extends GenericContainer {
   private database = "test";
   private username = new RandomUuid().nextUuid();
   private password = new RandomUuid().nextUuid();
-  private hostPort: number | null = null;
 
   constructor(image = "postgres:13.3-alpine") {
     super(image);
@@ -31,13 +30,8 @@ export class PostgreSqlContainer extends GenericContainer {
     return this;
   }
 
-  public withHostPort(port: number): this {
-    this.hostPort = port;
-    return this;
-  }
-
   public async start(): Promise<StartedPostgreSqlContainer> {
-    this.withExposedPorts(this.hostPort ? { container: POSTGRES_PORT, host: this.hostPort } : POSTGRES_PORT)
+    this.withExposedPorts(...(this.hasExposedPorts ? this.ports : [POSTGRES_PORT]))
       .withEnv("POSTGRES_DB", this.database)
       .withEnv("POSTGRES_USER", this.username)
       .withEnv("POSTGRES_PASSWORD", this.password)


### PR DESCRIPTION
…ces just like you can on GenericContainer. Fixes #356

Consumers can now use `withHostPort` on modules to specify a specific host port. (except for `KafkaContainer` where this is specified in the ctor)
If `withHostPort` is not called, the current behaviour is kept where a random port is assigned on the host system.