### PR TITLE
Fix withCopyFileToContainer for large files

### DIFF
--- a/src/generic-container/generic-container.ts
+++ b/src/generic-container/generic-container.ts
@@ -179,7 +179,7 @@ export class GenericContainer implements TestContainer {
     }
 
     if (this.tarToCopy) {
-      await this.tarToCopy.finalize();
+      this.tarToCopy.finalize();
       await putContainerArchive({ container, stream: this.tarToCopy, containerPath: "/" });
     }
 


### PR DESCRIPTION
This was broken in v7.13.0 after the changes in [#224](https://github.com/testcontainers/testcontainers-node/pull/224/files#diff-e9908fa461de235d8997a04799b787ee3b57d9682d8262c0ed65b9af47255086R213).

`Archiver.finalize` will simply wait for the `end` event which cannot fire until the stream has been consumed by the following `putContainerArchive` call.