### PR TITLE
Move mongoose to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "docker-compose": "^0.23.17",
     "dockerode": "^3.3.1",
     "get-port": "^5.1.1",
-    "mongoose": "^5.13.15",
     "properties-reader": "^2.2.0",
     "ssh-remote-port-forward": "^1.0.4",
     "tar-fs": "^2.1.1"
@@ -67,6 +66,7 @@
     "kafkajs": "^1.16.0",
     "lint-staged": "^12.3.8",
     "mysql2": "^2.3.3",
+    "mongoose": "^5.13.15",
     "nats": "^2.7.1",
     "neo4j-driver": "^4.4.5",
     "node-fetch": "^2.6.7",


### PR DESCRIPTION
The `mongoose` module is only used in [tests for the MongoDB container](https://github.com/testcontainers/testcontainers-node/blob/master/src/modules/mongodb/mongodb-container.test.ts). It can be listed as a _dev_ dependency, so that projects using `testcontainers` don't have to pull-in `mongoose` and its dependency tree.