### PR TITLE
Pass Dockerode ExecStartOptions to StartedGenericContainer.exec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "testcontainers",
-      "version": "8.13.1-beta.5",
+      "version": "8.13.2",
       "license": "MIT",
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",
@@ -18,7 +18,6 @@
         "docker-compose": "^0.23.17",
         "dockerode": "^3.3.1",
         "get-port": "^5.1.1",
-        "mongoose": "^5.13.15",
         "properties-reader": "^2.2.0",
         "ssh-remote-port-forward": "^1.0.4",
         "tar-fs": "^2.1.1"
@@ -43,6 +42,7 @@
         "jest": "^27.5.1",
         "kafkajs": "^1.16.0",
         "lint-staged": "^12.3.8",
+        "mongoose": "^5.13.15",
         "mysql2": "^2.3.3",
         "nats": "^2.7.1",
         "neo4j-driver": "^4.4.5",
@@ -1232,6 +1232,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.5.tgz",
       "integrity": "sha512-vVLwMUqhYJSQ/WKcE60eFqcyuWse5fGH+NMAXHuKrUAPoryq3ATxk5o4bgYNtg5aOM4APVg7Hnb3ASqUYG0PKg==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -1339,6 +1340,7 @@
       "version": "3.6.20",
       "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.20.tgz",
       "integrity": "sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==",
+      "dev": true,
       "dependencies": {
         "@types/bson": "*",
         "@types/node": "*"
@@ -2041,7 +2043,8 @@
     "node_modules/bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "dev": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2118,6 +2121,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
       "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==",
+      "dev": true,
       "engines": {
         "node": ">=0.6.19"
       }
@@ -4673,7 +4677,8 @@
     "node_modules/kareem": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.2.tgz",
-      "integrity": "sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ=="
+      "integrity": "sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ==",
+      "dev": true
     },
     "node_modules/kleur": {
       "version": "3.0.3",
@@ -5038,6 +5043,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "dev": true,
       "optional": true
     },
     "node_modules/merge-stream": {
@@ -5157,6 +5163,7 @@
       "version": "3.7.3",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
       "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
+      "dev": true,
       "dependencies": {
         "bl": "^2.2.1",
         "bson": "^1.1.4",
@@ -5195,6 +5202,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
       "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "dev": true,
       "dependencies": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -5204,6 +5212,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
       "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -5212,6 +5221,7 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
       "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
+      "dev": true,
       "dependencies": {
         "require-at": "^1.0.6"
       },
@@ -5223,6 +5233,7 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -5237,6 +5248,7 @@
       "version": "5.13.15",
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.13.15.tgz",
       "integrity": "sha512-cxp1Gbb8yUWkaEbajdhspSaKzAvsIvOtRlYD87GN/P2QEUhpd6bIvebi36T6M0tIVAMauNaK9SPA055N3PwF8Q==",
+      "dev": true,
       "dependencies": {
         "@types/bson": "1.x || 4.0.x",
         "@types/mongodb": "^3.5.27",
@@ -5265,6 +5277,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
       "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==",
+      "dev": true,
       "peerDependencies": {
         "mongoose": "*"
       }
@@ -5273,6 +5286,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5292,6 +5306,7 @@
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.4.tgz",
       "integrity": "sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g==",
+      "dev": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -5300,6 +5315,7 @@
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.5.tgz",
       "integrity": "sha512-VjOKHHgU84wij7IUoZzFRU07IAxd5kWJaDmyUzQlbjHjyoeK5TNeeo8ZsFDtTYnSgpW6n/nMNIHvE3u8Lbrf4A==",
+      "dev": true,
       "dependencies": {
         "bluebird": "3.5.1",
         "debug": "3.1.0",
@@ -5315,6 +5331,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -5322,7 +5339,8 @@
     "node_modules/mquery/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -5666,6 +5684,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.3.tgz",
       "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -6177,7 +6196,8 @@
     "node_modules/regexp-clone": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
-      "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw=="
+      "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw==",
+      "dev": true
     },
     "node_modules/regexpp": {
       "version": "3.2.0",
@@ -6195,6 +6215,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
       "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -6357,6 +6378,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
       "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
@@ -6428,7 +6450,8 @@
     "node_modules/sift": {
       "version": "13.5.2",
       "resolved": "https://registry.npmjs.org/sift/-/sift-13.5.2.tgz",
-      "integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA=="
+      "integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA==",
+      "dev": true
     },
     "node_modules/signal-exit": {
       "version": "3.0.4",
@@ -6494,7 +6517,8 @@
     "node_modules/sliced": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
-      "integrity": "sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA=="
+      "integrity": "sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA==",
+      "dev": true
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -6519,6 +6543,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
@@ -8349,6 +8374,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.5.tgz",
       "integrity": "sha512-vVLwMUqhYJSQ/WKcE60eFqcyuWse5fGH+NMAXHuKrUAPoryq3ATxk5o4bgYNtg5aOM4APVg7Hnb3ASqUYG0PKg==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -8456,6 +8482,7 @@
       "version": "3.6.20",
       "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.20.tgz",
       "integrity": "sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==",
+      "dev": true,
       "requires": {
         "@types/bson": "*",
         "@types/node": "*"
@@ -8980,7 +9007,8 @@
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -9040,7 +9068,8 @@
     "bson": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
-      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg=="
+      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==",
+      "dev": true
     },
     "buffer": {
       "version": "5.7.1",
@@ -10971,7 +11000,8 @@
     "kareem": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.2.tgz",
-      "integrity": "sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ=="
+      "integrity": "sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ==",
+      "dev": true
     },
     "kleur": {
       "version": "3.0.3",
@@ -11266,6 +11296,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "dev": true,
       "optional": true
     },
     "merge-stream": {
@@ -11358,6 +11389,7 @@
       "version": "3.7.3",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
       "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
+      "dev": true,
       "requires": {
         "bl": "^2.2.1",
         "bson": "^1.1.4",
@@ -11371,6 +11403,7 @@
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
           "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+          "dev": true,
           "requires": {
             "readable-stream": "^2.3.5",
             "safe-buffer": "^5.1.1"
@@ -11379,12 +11412,14 @@
         "denque": {
           "version": "1.5.1",
           "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-          "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
+          "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+          "dev": true
         },
         "optional-require": {
           "version": "1.1.8",
           "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
           "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
+          "dev": true,
           "requires": {
             "require-at": "^1.0.6"
           }
@@ -11393,6 +11428,7 @@
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -11409,6 +11445,7 @@
       "version": "5.13.15",
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.13.15.tgz",
       "integrity": "sha512-cxp1Gbb8yUWkaEbajdhspSaKzAvsIvOtRlYD87GN/P2QEUhpd6bIvebi36T6M0tIVAMauNaK9SPA055N3PwF8Q==",
+      "dev": true,
       "requires": {
         "@types/bson": "1.x || 4.0.x",
         "@types/mongodb": "^3.5.27",
@@ -11430,24 +11467,28 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
           "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==",
+          "dev": true,
           "requires": {}
         },
         "safe-buffer": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
         }
       }
     },
     "mpath": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.4.tgz",
-      "integrity": "sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g=="
+      "integrity": "sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g==",
+      "dev": true
     },
     "mquery": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.5.tgz",
       "integrity": "sha512-VjOKHHgU84wij7IUoZzFRU07IAxd5kWJaDmyUzQlbjHjyoeK5TNeeo8ZsFDtTYnSgpW6n/nMNIHvE3u8Lbrf4A==",
+      "dev": true,
       "requires": {
         "bluebird": "3.5.1",
         "debug": "3.1.0",
@@ -11460,6 +11501,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -11467,7 +11509,8 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+          "dev": true
         }
       }
     },
@@ -11744,7 +11787,8 @@
     "optional-require": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.3.tgz",
-      "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA=="
+      "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA==",
+      "dev": true
     },
     "optionator": {
       "version": "0.9.1",
@@ -12108,7 +12152,8 @@
     "regexp-clone": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
-      "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw=="
+      "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw==",
+      "dev": true
     },
     "regexpp": {
       "version": "3.2.0",
@@ -12119,7 +12164,8 @@
     "require-at": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
-      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g=="
+      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g==",
+      "dev": true
     },
     "require-directory": {
       "version": "2.1.1",
@@ -12230,6 +12276,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
       "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "dev": true,
       "optional": true,
       "requires": {
         "sparse-bitfield": "^3.0.3"
@@ -12283,7 +12330,8 @@
     "sift": {
       "version": "13.5.2",
       "resolved": "https://registry.npmjs.org/sift/-/sift-13.5.2.tgz",
-      "integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA=="
+      "integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA==",
+      "dev": true
     },
     "signal-exit": {
       "version": "3.0.4",
@@ -12330,7 +12378,8 @@
     "sliced": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
-      "integrity": "sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA=="
+      "integrity": "sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA==",
+      "dev": true
     },
     "source-map": {
       "version": "0.6.1",
@@ -12352,6 +12401,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "dev": true,
       "optional": true,
       "requires": {
         "memory-pager": "^1.0.2"

--- a/src/docker/functions/container/exec-container.ts
+++ b/src/docker/functions/container/exec-container.ts
@@ -4,9 +4,9 @@ import Dockerode from "dockerode";
 import { log } from "../../../logger";
 
 type ExecContainerOptions = {
-  Tty: boolean;
+  tty: boolean;
   stdin: boolean;
-  Detach: boolean;
+  detach: boolean;
 };
 
 export const execContainer = async (

--- a/src/docker/functions/container/exec-container.ts
+++ b/src/docker/functions/container/exec-container.ts
@@ -41,6 +41,7 @@ const startExec = async (exec: Dockerode.Exec, options?: Dockerode.ExecStartOpti
       stdout: true,
       stderr: true,
     };
+
     const stream = await exec.start(options || defaultOptions);
     stream.setEncoding("utf-8");
     return stream;

--- a/src/docker/functions/container/exec-container.ts
+++ b/src/docker/functions/container/exec-container.ts
@@ -3,8 +3,10 @@ import { Command, ExecResult, ExitCode } from "../../types";
 import Dockerode from "dockerode";
 import { log } from "../../../logger";
 
-export type ExecContainerOptions = {
+type ExecContainerOptions = {
   Tty: boolean;
+  stdin: boolean;
+  Detach: boolean;
 };
 
 export const execContainer = async (

--- a/src/docker/functions/container/exec-container.ts
+++ b/src/docker/functions/container/exec-container.ts
@@ -3,7 +3,11 @@ import { Command, ExecResult, ExitCode } from "../../types";
 import Dockerode from "dockerode";
 import { log } from "../../../logger";
 
-export const execContainer = async (container: Dockerode.Container, command: Command[]): Promise<ExecResult> => {
+export const execContainer = async (
+  container: Dockerode.Container,
+  command: Command[],
+  options?: Dockerode.ExecStartOptions
+): Promise<ExecResult> => {
   try {
     const exec = await container.exec({
       Cmd: command,
@@ -11,7 +15,7 @@ export const execContainer = async (container: Dockerode.Container, command: Com
       AttachStderr: true,
     });
 
-    const stream = await startExec(exec);
+    const stream = await startExec(exec, options);
 
     const chunks: string[] = [];
     stream.on("data", (chunk) => chunks.push(chunk));
@@ -27,9 +31,9 @@ export const execContainer = async (container: Dockerode.Container, command: Com
   }
 };
 
-const startExec = async (exec: Dockerode.Exec): Promise<Readable> => {
+const startExec = async (exec: Dockerode.Exec, options?: Dockerode.ExecStartOptions): Promise<Readable> => {
   try {
-    const options = {
+    const defaultOptions = {
       Detach: false,
       Tty: true,
       stream: true,
@@ -37,7 +41,7 @@ const startExec = async (exec: Dockerode.Exec): Promise<Readable> => {
       stdout: true,
       stderr: true,
     };
-    const stream = await exec.start(options);
+    const stream = await exec.start(options || defaultOptions);
     stream.setEncoding("utf-8");
     return stream;
   } catch (err) {

--- a/src/docker/functions/container/exec-container.ts
+++ b/src/docker/functions/container/exec-container.ts
@@ -3,10 +3,14 @@ import { Command, ExecResult, ExitCode } from "../../types";
 import Dockerode from "dockerode";
 import { log } from "../../../logger";
 
+export type ExecContainerOptions = {
+  Tty: boolean;
+};
+
 export const execContainer = async (
   container: Dockerode.Container,
   command: Command[],
-  options?: Dockerode.ExecStartOptions
+  options: ExecContainerOptions
 ): Promise<ExecResult> => {
   try {
     const exec = await container.exec({
@@ -31,18 +35,9 @@ export const execContainer = async (
   }
 };
 
-const startExec = async (exec: Dockerode.Exec, options?: Dockerode.ExecStartOptions): Promise<Readable> => {
+const startExec = async (exec: Dockerode.Exec, options: ExecContainerOptions): Promise<Readable> => {
   try {
-    const defaultOptions = {
-      Detach: false,
-      Tty: true,
-      stream: true,
-      stdin: true,
-      stdout: true,
-      stderr: true,
-    };
-
-    const stream = await exec.start(options || defaultOptions);
+    const stream = await exec.start(options);
     stream.setEncoding("utf-8");
     return stream;
   } catch (err) {

--- a/src/generic-container/started-generic-container.ts
+++ b/src/generic-container/started-generic-container.ts
@@ -56,11 +56,6 @@ export class StartedGenericContainer implements StartedTestContainer {
     return new StoppedGenericContainer();
   }
 
-  private async execContainer(command: Command[], options: Partial<ExecOptions> = {}): Promise<ExecResult> {
-    const resolvedOptions: ExecOptions = { stdin: true, detach: false, tty: true, ...options };
-    return execContainer(this.container, command, resolvedOptions);
-  }
-
   private async waitForContainer(container: Dockerode.Container, boundPorts: BoundPorts): Promise<void> {
     log.debug(`Waiting for container to be ready: ${container.id}`);
 
@@ -112,7 +107,8 @@ export class StartedGenericContainer implements StartedTestContainer {
   }
 
   public exec(command: Command[], options: Partial<ExecOptions> = {}): Promise<ExecResult> {
-    return this.execContainer(command, options);
+    const resolvedOptions: ExecOptions = { stdin: true, detach: false, tty: true, ...options };
+    return execContainer(this.container, command, resolvedOptions);
   }
 
   public logs(): Promise<Readable> {

--- a/src/generic-container/started-generic-container.ts
+++ b/src/generic-container/started-generic-container.ts
@@ -12,7 +12,7 @@ import { BoundPorts } from "../bound-ports";
 import { log } from "../logger";
 import { removeContainer } from "../docker/functions/container/remove-container";
 import { Port } from "../port";
-import { execContainer, ExecContainerOptions } from "../docker/functions/container/exec-container";
+import { execContainer } from "../docker/functions/container/exec-container";
 import { Readable } from "stream";
 import { containerLogs } from "../docker/functions/container/container-logs";
 import { StoppedGenericContainer } from "./stopped-generic-container";
@@ -111,7 +111,7 @@ export class StartedGenericContainer implements StartedTestContainer {
     return this.inspectResult.networkSettings[networkName].ipAddress;
   }
 
-  public exec(command: Command[], options?: ExecContainerOptions): Promise<ExecResult> {
+  public exec(command: Command[], options: Partial<ExecOptions> = {}): Promise<ExecResult> {
     return this.execContainer(command, options);
   }
 

--- a/src/generic-container/started-generic-container.ts
+++ b/src/generic-container/started-generic-container.ts
@@ -57,7 +57,7 @@ export class StartedGenericContainer implements StartedTestContainer {
   }
 
   private async execContainer(command: Command[], options: Partial<ExecOptions> = {}): Promise<ExecResult> {
-    const resolvedOptions: ExecOptions = { stdin: true, Detach: false, Tty: true, ...options };
+    const resolvedOptions: ExecOptions = { stdin: true, detach: false, tty: true, ...options };
     return execContainer(this.container, command, resolvedOptions);
   }
 

--- a/src/generic-container/started-generic-container.ts
+++ b/src/generic-container/started-generic-container.ts
@@ -100,8 +100,8 @@ export class StartedGenericContainer implements StartedTestContainer {
     return this.inspectResult.networkSettings[networkName].ipAddress;
   }
 
-  public exec(command: Command[]): Promise<ExecResult> {
-    return execContainer(this.container, command);
+  public exec(command: Command[], options?: Dockerode.ExecStartOptions): Promise<ExecResult> {
+    return execContainer(this.container, command, options);
   }
 
   public logs(): Promise<Readable> {

--- a/src/port-check.ts
+++ b/src/port-check.ts
@@ -42,7 +42,9 @@ export class InternalPortCheck implements PortCheck {
       ["/bin/sh", "-c", `nc -vz -w 1 localhost ${port}`],
       ["/bin/bash", "-c", `</dev/tcp/localhost/${port}`],
     ];
-    const commandResults = await Promise.all(commands.map((command) => execContainer(this.container, command)));
+    const commandResults = await Promise.all(
+      commands.map((command) => execContainer(this.container, command, { Tty: true }))
+    );
     return commandResults.some((result) => result.exitCode === 0);
   }
 }

--- a/src/port-check.ts
+++ b/src/port-check.ts
@@ -43,7 +43,7 @@ export class InternalPortCheck implements PortCheck {
       ["/bin/bash", "-c", `</dev/tcp/localhost/${port}`],
     ];
     const commandResults = await Promise.all(
-      commands.map((command) => execContainer(this.container, command, { stdin: true, Detach: false, Tty: true }))
+      commands.map((command) => execContainer(this.container, command, { stdin: true, detach: false, tty: true }))
     );
     return commandResults.some((result) => result.exitCode === 0);
   }

--- a/src/port-check.ts
+++ b/src/port-check.ts
@@ -43,7 +43,7 @@ export class InternalPortCheck implements PortCheck {
       ["/bin/bash", "-c", `</dev/tcp/localhost/${port}`],
     ];
     const commandResults = await Promise.all(
-      commands.map((command) => execContainer(this.container, command, { Tty: true }))
+      commands.map((command) => execContainer(this.container, command, { stdin: true, Detach: false, Tty: true }))
     );
     return commandResults.some((result) => result.exitCode === 0);
   }

--- a/src/test-container.ts
+++ b/src/test-container.ts
@@ -90,7 +90,7 @@ export interface StartedTestContainer {
 
   getIpAddress(networkName: string): string;
 
-  exec(command: Command[]): Promise<ExecResult>;
+  exec(command: Command[], options?: Partial<ExecOptions>): Promise<ExecResult>;
 
   logs(): Promise<Readable>;
 }

--- a/src/test-container.ts
+++ b/src/test-container.ts
@@ -64,8 +64,8 @@ export interface StopOptions {
 }
 
 export interface ExecOptions {
-  Tty: boolean;
-  Detach: boolean;
+  tty: boolean;
+  detach: boolean;
   stdin: boolean;
 }
 

--- a/src/test-container.ts
+++ b/src/test-container.ts
@@ -63,6 +63,12 @@ export interface StopOptions {
   removeVolumes: boolean;
 }
 
+export interface ExecOptions {
+  Tty: boolean;
+  Detach: boolean;
+  stdin: boolean;
+}
+
 export interface StartedTestContainer {
   stop(options?: Partial<StopOptions>): Promise<StoppedTestContainer>;
 


### PR DESCRIPTION
For now the StartedGenericContainer.exec only takes Command[] as argument. startExec sends a hardcoded Dockerode.ExecStartOptions to Dockerode.Exec. 

It might be intressting to send an optional exec options object to StartedGenericContainer.exec. In our use case we need the container to run in "tty : false" mode. 
