### PR TITLE
Enable reading docker config from environment variable (#428)

### DIFF
--- a/README.md
+++ b/README.md
@@ -914,7 +914,9 @@ const container = await new GenericContainer("redis")
 ## Authentication
 
 Testcontainers will automatically pick up and use credentials from `$HOME/.docker/config.json`, using
-credential helpers, credential stores, or raw auth as necessary and in that order.
+credential helpers, credential stores, or raw auth as necessary and in that order. It can also pick up credentials
+from the `DOCKER_CONFIG_AUTH` environment variable, the variable should contain the serialized contents of a
+`.docker/config.json` file.
 
 ## Auxiliary Containers
 

--- a/src/registry-auth-locator/config.test.ts
+++ b/src/registry-auth-locator/config.test.ts
@@ -1,0 +1,57 @@
+import { DockerConfig } from "./types";
+
+import fs from "fs";
+import { readDockerConfig } from "./config";
+
+const spyExists = jest.spyOn(fs, "existsSync");
+const spyRead = jest.spyOn(fs.promises, "readFile");
+
+describe("Config", () => {
+  const dockerConfig: DockerConfig = {
+    auths: {
+      "https://registry.example.com": {
+        email: "user@example.com",
+        username: "user",
+        password: "pass",
+      },
+    },
+  };
+
+  afterEach(() => (process.env.DOCKER_AUTH_CONFIG = undefined));
+
+  it("should return empty object if neither config nor environment variable exists", async () => {
+    spyExists.mockReturnValueOnce(false);
+
+    const config = await readDockerConfig();
+    expect(config).toEqual({});
+  });
+
+  it("should use the docker environment variable if it exists", async () => {
+    process.env.DOCKER_AUTH_CONFIG = JSON.stringify(dockerConfig);
+
+    spyExists.mockReturnValueOnce(false);
+
+    const config = await readDockerConfig();
+    expect(config).toEqual(dockerConfig);
+  });
+
+  it("should use the docker config file if it exists", async () => {
+    spyExists.mockReturnValueOnce(true);
+    spyRead.mockResolvedValueOnce(JSON.stringify(dockerConfig));
+
+    const config = await readDockerConfig();
+    expect(config).toEqual(dockerConfig);
+  });
+
+  it("should prioritize the docker config file over environment variable", async () => {
+    spyExists.mockReturnValueOnce(true);
+    spyRead.mockResolvedValueOnce(JSON.stringify(dockerConfig));
+
+    const envDockerConfig: DockerConfig = {};
+    process.env.DOCKER_AUTH_CONFIG = JSON.stringify(envDockerConfig);
+
+    const config = await readDockerConfig();
+    expect(config).toEqual(dockerConfig);
+    expect(config).not.toEqual(envDockerConfig);
+  });
+});

--- a/src/registry-auth-locator/config.ts
+++ b/src/registry-auth-locator/config.ts
@@ -1,0 +1,46 @@
+import os from "os";
+import path from "path";
+import { DockerConfig } from "./types";
+import { existsSync, promises as fs } from "fs";
+
+const dockerConfigLocation = process.env.DOCKER_CONFIG || `${os.homedir()}/.docker`;
+
+const dockerConfigFile = path.resolve(dockerConfigLocation, "config.json");
+
+/**
+ * Read the docker config file from the default location and returns the {@link DockerConfig}.
+ */
+const readDockerConfigFromFile = async (): Promise<DockerConfig> => {
+  const buffer = await fs.readFile(dockerConfigFile);
+  const object = JSON.parse(buffer.toString());
+
+  return {
+    credsStore: object.credsStore,
+    credHelpers: object.credHelpers,
+    auths: object.auths,
+  };
+};
+
+/**
+ * Reads the docker config file from environment variable and returns the {@link DockerConfig}.
+ *
+ * Some CI environments (e.g. GitLab) encourages configuring docker using the environment variable
+ * DOCKER_AUTH_CONFIG. If it exists, it will be used when there is no default config file.
+ */
+const readDockerConfigFromEnv = (): DockerConfig => {
+  return JSON.parse(process.env.DOCKER_AUTH_CONFIG!);
+};
+
+/**
+ * Reads the docker config file or environment variable and returns the {@link DockerConfig}.
+ * If both exist, the config file will be used.
+ */
+export const readDockerConfig = async (): Promise<DockerConfig> => {
+  if (existsSync(dockerConfigFile)) {
+    return readDockerConfigFromFile();
+  } else if (process.env.DOCKER_AUTH_CONFIG) {
+    return readDockerConfigFromEnv();
+  } else {
+    return {};
+  }
+};

--- a/src/registry-auth-locator/index.ts
+++ b/src/registry-auth-locator/index.ts
@@ -1,34 +1,12 @@
-import path from "path";
-import os from "os";
-import { DockerConfig } from "./types";
-import { existsSync, promises as fs } from "fs";
 import { CredHelpers } from "./cred-helpers";
 import { CredsStore } from "./creds-store";
 import { Auths } from "./auths";
 import { RegistryAuthLocator } from "./registry-auth-locator";
 import { log } from "../logger";
 import { AuthConfig } from "../docker/types";
+import { readDockerConfig } from "./config";
 
 const DEFAULT_REGISTRY = "https://index.docker.io/v1/";
-
-const dockerConfigLocation = process.env.DOCKER_CONFIG || `${os.homedir()}/.docker`;
-
-const dockerConfigFile = path.resolve(dockerConfigLocation, "config.json");
-
-const readDockerConfig = async (): Promise<DockerConfig> => {
-  if (!existsSync(dockerConfigFile)) {
-    return Promise.resolve({});
-  }
-
-  const buffer = await fs.readFile(dockerConfigFile);
-  const object = JSON.parse(buffer.toString());
-
-  return {
-    credsStore: object.credsStore,
-    credHelpers: object.credHelpers,
-    auths: object.auths,
-  };
-};
 
 const dockerConfig = readDockerConfig();
 


### PR DESCRIPTION
When using `testcontainers` in a docker in docker environment it can be a bit stainious to setup config files. GitLab alread suggests using a environment variable DOCKER_AUTH_CONFIG to configure docker.

With this fix `testcontainers` checks if the DOCKER_AUTH_CONFIG is available after trying all other means of authentication.