### PR TITLE
make unit for startup timeout more obvious

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,7 +793,7 @@ const { GenericContainer } = require("testcontainers");
 
 const container = await new GenericContainer("redis")
   .withExposedPorts(6379)
-  .withStartupTimeout(120000)
+  .withStartupTimeout(120000) // wait 120s 
   .start();
 ```
 

--- a/src/generic-container/generic-container.ts
+++ b/src/generic-container/generic-container.ts
@@ -308,8 +308,8 @@ export class GenericContainer implements TestContainer {
     return this;
   }
 
-  public withStartupTimeout(startupTimeout: number): this {
-    this.startupTimeout = startupTimeout;
+  public withStartupTimeout(startupTimeoutMs: number): this {
+    this.startupTimeout = startupTimeoutMs;
     return this;
   }
 


### PR DESCRIPTION
there is no documentation in what unit the parameter for withStartupTimeout is. Thats why i made it more obvious buy:
- adding a comment in the readme example
- adding "Ms" to the Param-Name (so you see it in your IDE directly)