### PR TITLE
fix: custom labels on reusable generic containers

### DIFF
--- a/src/generic-container/generic-container.test.ts
+++ b/src/generic-container/generic-container.test.ts
@@ -606,17 +606,19 @@ describe("GenericContainer", () => {
       await checkContainerIsHealthy(container2);
 
       expect(container1.getId()).not.toBe(container2.getId());
+      await container2.stop();
     });
 
     it("should keep the labels passed in when a new reusable container is created", async () => {
-      const container1 = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-        .withName("there_can_only_be_one_with_labels")
+      const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+        .withName("there_can_only_be_one")
         .withExposedPorts(8080)
         .withLabels({ test: "foo", bar: "baz" })
         .withReuse()
         .start();
 
-      expect(container1.getLabels()).toEqual({ test: "foo", bar: "baz", [LABEL_CONTAINER_HASH]: expect.any(String) });
+      expect(container.getLabels()).toEqual({ test: "foo", bar: "baz", [LABEL_CONTAINER_HASH]: expect.any(String) });
+      await container.stop();
     });
   });
 

--- a/src/generic-container/generic-container.test.ts
+++ b/src/generic-container/generic-container.test.ts
@@ -8,6 +8,7 @@ import { RandomUuid } from "../uuid";
 import { checkContainerIsHealthy, getEvents, getRunningContainerNames } from "../test-helper";
 import { Network } from "../network";
 import { getContainerById } from "../docker/functions/container/get-container";
+import { LABEL_CONTAINER_HASH } from "../labels";
 
 describe("GenericContainer", () => {
   jest.setTimeout(180_000);
@@ -605,6 +606,17 @@ describe("GenericContainer", () => {
       await checkContainerIsHealthy(container2);
 
       expect(container1.getId()).not.toBe(container2.getId());
+    });
+
+    it("should keep the labels passed in when a new reusable container is created", async () => {
+      const container1 = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+        .withName("there_can_only_be_one_with_labels")
+        .withExposedPorts(8080)
+        .withLabels({ test: "foo", bar: "baz" })
+        .withReuse()
+        .start();
+
+      expect(container1.getLabels()).toEqual({ test: "foo", bar: "baz", [LABEL_CONTAINER_HASH]: expect.any(String) });
     });
   });
 

--- a/src/generic-container/generic-container.ts
+++ b/src/generic-container/generic-container.ts
@@ -122,7 +122,7 @@ export class GenericContainer implements TestContainer {
 
     if (this.reuse) {
       const containerHash = hash(JSON.stringify(createContainerOptions));
-      createContainerOptions.labels = { [LABEL_CONTAINER_HASH]: containerHash };
+      createContainerOptions.labels = { ...createContainerOptions.labels, [LABEL_CONTAINER_HASH]: containerHash };
       log.debug(`Container reuse has been enabled, hash: ${containerHash}`);
 
       const container = await getContainerByHash(containerHash);


### PR DESCRIPTION
Fixes #442 

Thought I'd open this on the off chance that this is how it should be fixed, in which case getting it fixed in the lib can be a tiny bit faster.