### PR TITLE
fix: correctly evaluate predicates in HttpWaitStrategy

### DIFF
--- a/src/http-wait-strategy.test.ts
+++ b/src/http-wait-strategy.test.ts
@@ -27,7 +27,7 @@ describe("HttpWaitStrategy", () => {
     await container.stop();
   });
 
-  it("should timeout for falsy status code", async () => {
+  it("should timeout for mismatching status code", async () => {
     await expect(() =>
       new GenericContainer("cristianrgreco/testcontainer:1.1.14")
         .withExposedPorts(8080)

--- a/src/http-wait-strategy.test.ts
+++ b/src/http-wait-strategy.test.ts
@@ -27,6 +27,16 @@ describe("HttpWaitStrategy", () => {
     await container.stop();
   });
 
+  it("should timeout for falsy status code", async () => {
+    await expect(() =>
+      new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+        .withExposedPorts(8080)
+        .withStartupTimeout(3000)
+        .withWaitStrategy(Wait.forHttp("/unknown-path", 8080).forStatusCode(200))
+        .start()
+    ).rejects.toThrowError("URL /unknown-path not accessible after 3000ms for");
+  });
+
   it("should wait for status code matching", async () => {
     const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
       .withExposedPorts(8080)
@@ -42,6 +52,16 @@ describe("HttpWaitStrategy", () => {
     await container.stop();
   });
 
+  it("should timeout for falsy status code matching", async () => {
+    await expect(() =>
+      new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+        .withExposedPorts(8080)
+        .withStartupTimeout(3000)
+        .withWaitStrategy(Wait.forHttp("/hello-world", 8080).forStatusCodeMatching(() => false))
+        .start()
+    ).rejects.toThrowError("URL /hello-world not accessible after 3000ms for");
+  });
+
   it("should wait for response body predicate", async () => {
     const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
       .withExposedPorts(8080)
@@ -53,6 +73,16 @@ describe("HttpWaitStrategy", () => {
     await checkContainerIsHealthy(container);
 
     await container.stop();
+  });
+
+  it("should timeout for falsy response body predicate", async () => {
+    await expect(() =>
+      new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+        .withExposedPorts(8080)
+        .withStartupTimeout(3000)
+        .withWaitStrategy(Wait.forHttp("/hello-world", 8080).forResponsePredicate(() => false))
+        .start()
+    ).rejects.toThrowError("URL /hello-world not accessible after 3000ms for");
   });
 
   it("should set method", async () => {

--- a/src/http-wait-strategy.ts
+++ b/src/http-wait-strategy.ts
@@ -83,13 +83,19 @@ export class HttpWaitStrategy extends AbstractWaitStrategy {
           return undefined;
         }
       },
-      (response) => {
+      async (response) => {
         if (response === undefined) {
           return false;
         } else if (!this.predicates.length) {
           return response.ok;
         } else {
-          return this.predicates.every((predicate) => predicate(response));
+          for (const predicate of this.predicates) {
+            const result = await predicate(response);
+            if (!result) {
+              return false;
+            }
+          }
+          return true;
         }
       },
       () => {


### PR DESCRIPTION
`this.predicates.every((predicate) => predicate(response))` in `HttpWaitStrategy` always resolved to `true`, because Promise objects were tested, which are always truthy. Fixing it by looping over predicates with async `for..of`.

Not too sure about the timeout tests, they add a bit of time.