### PR TITLE
refactor: performance improvements

### DIFF
--- a/src/docker/functions/container/exec-container.ts
+++ b/src/docker/functions/container/exec-container.ts
@@ -29,7 +29,7 @@ export const execContainer = async (
 
     stream.on("data", (chunk) => chunks.push(chunk));
 
-    if (shouldLog) {
+    if (shouldLog && execLog.enabled()) {
       byline(stream).on("data", (line) => execLog.trace(`${container.id}: ${line}`));
     }
 

--- a/src/docker/functions/image/pull-image.ts
+++ b/src/docker/functions/image/pull-image.ts
@@ -1,14 +1,13 @@
 import { DockerImageName } from "../../../docker-image-name";
 import { log } from "../../../logger";
 import { PullStreamParser } from "../../pull-stream-parser";
-import { AuthConfig } from "../../types";
 import { imageExists } from "./image-exists";
 import Dockerode from "dockerode";
+import { getAuthConfig } from "../../../registry-auth-locator";
 
 export type PullImageOptions = {
   imageName: DockerImageName;
   force: boolean;
-  authConfig?: AuthConfig;
 };
 
 export const pullImage = async (dockerode: Dockerode, options: PullImageOptions): Promise<void> => {
@@ -19,7 +18,8 @@ export const pullImage = async (dockerode: Dockerode, options: PullImageOptions)
     }
 
     log.info(`Pulling image: ${options.imageName}`);
-    const stream = await dockerode.pull(options.imageName.toString(), { authconfig: options.authConfig });
+    const authconfig = await getAuthConfig(options.imageName.registry);
+    const stream = await dockerode.pull(options.imageName.toString(), { authconfig });
 
     await new PullStreamParser(options.imageName, log).consume(stream);
   } catch (err) {

--- a/src/docker/functions/image/pull-image.ts
+++ b/src/docker/functions/image/pull-image.ts
@@ -4,24 +4,29 @@ import { PullStreamParser } from "../../pull-stream-parser";
 import { imageExists } from "./image-exists";
 import Dockerode from "dockerode";
 import { getAuthConfig } from "../../../registry-auth-locator";
+import AsyncLock from "async-lock";
 
 export type PullImageOptions = {
   imageName: DockerImageName;
   force: boolean;
 };
 
+const imagePullLock = new AsyncLock();
+
 export const pullImage = async (dockerode: Dockerode, options: PullImageOptions): Promise<void> => {
   try {
-    if ((await imageExists(dockerode, options.imageName)) && !options.force) {
-      log.debug(`Not pulling image as it already exists: ${options.imageName}`);
-      return;
-    }
+    return imagePullLock.acquire(options.imageName.toString(), async () => {
+      if (!options.force && (await imageExists(dockerode, options.imageName))) {
+        log.debug(`Not pulling image as it already exists: ${options.imageName}`);
+        return;
+      }
 
-    log.info(`Pulling image: ${options.imageName}`);
-    const authconfig = await getAuthConfig(options.imageName.registry);
-    const stream = await dockerode.pull(options.imageName.toString(), { authconfig });
+      log.info(`Pulling image: ${options.imageName}`);
+      const authconfig = await getAuthConfig(options.imageName.registry);
+      const stream = await dockerode.pull(options.imageName.toString(), { authconfig });
 
-    await new PullStreamParser(options.imageName, log).consume(stream);
+      await new PullStreamParser(options.imageName, log).consume(stream);
+    });
   } catch (err) {
     log.error(`Failed to pull image "${options.imageName}": ${err}`);
     throw err;

--- a/src/generic-container/generic-container.ts
+++ b/src/generic-container/generic-container.ts
@@ -9,7 +9,6 @@ import { DockerImageName } from "../docker-image-name";
 import { StartedTestContainer, TestContainer } from "../test-container";
 import { defaultWaitStrategy, WaitStrategy } from "../wait-strategy";
 import { PortForwarderInstance } from "../port-forwarder";
-import { getAuthConfig } from "../registry-auth-locator";
 import {
   BindMount,
   ContentToCopy,
@@ -83,7 +82,6 @@ export class GenericContainer implements TestContainer {
     await pullImage((await dockerClient()).dockerode, {
       imageName: this.imageName,
       force: this.pullPolicy.shouldPull(),
-      authConfig: await getAuthConfig(this.imageName.registry),
     });
 
     if (!this.imageName.isReaper()) {

--- a/src/log-system-diagnostics.ts
+++ b/src/log-system-diagnostics.ts
@@ -4,6 +4,11 @@ import { getDockerInfo } from "./docker/functions/get-info";
 import Dockerode from "dockerode";
 
 export const logSystemDiagnostics = async (dockerode: Dockerode): Promise<void> => {
+  if (!log.enabled) {
+    // Logs are not enabled, no point in doing the work of fetching the information
+    return;
+  }
+
   log.debug("Fetching system diagnostics");
 
   const info = {

--- a/src/log-system-diagnostics.ts
+++ b/src/log-system-diagnostics.ts
@@ -4,7 +4,7 @@ import { getDockerInfo } from "./docker/functions/get-info";
 import Dockerode from "dockerode";
 
 export const logSystemDiagnostics = async (dockerode: Dockerode): Promise<void> => {
-  if (!log.enabled) {
+  if (!log.enabled()) {
     // Logs are not enabled, no point in doing the work of fetching the information
     return;
   }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -3,6 +3,7 @@ import debug, { IDebugger } from "debug";
 type Message = string;
 
 export interface Logger {
+  enabled(): boolean;
   trace(message: Message): void;
   debug(message: Message): void;
   info(message: Message): void;
@@ -15,6 +16,10 @@ class DebugLogger implements Logger {
 
   constructor(namespace: string) {
     this.logger = debug(namespace);
+  }
+
+  public enabled(): boolean {
+    return this.logger.enabled;
   }
 
   public trace(message: Message): void {
@@ -44,6 +49,10 @@ export class FakeLogger implements Logger {
   public readonly infoLogs: Message[] = [];
   public readonly warnLogs: Message[] = [];
   public readonly errorLogs: Message[] = [];
+
+  public enabled(): boolean {
+    return true;
+  }
 
   public trace(message: Message): void {
     this.traceLogs.push(message);

--- a/src/port-check.test.ts
+++ b/src/port-check.test.ts
@@ -18,6 +18,9 @@ describe("PortCheck", () => {
       jest.resetAllMocks();
       mockContainer = { id: "containerId" } as Dockerode.Container;
       portCheck = new InternalPortCheck(mockContainer);
+
+      // Make sure logging is enabled to capture all logs
+      mockLogger.enabled.mockImplementation(() => true);
     });
 
     it("should return true when at least one command returns exit code 0", async () => {

--- a/src/port-check.ts
+++ b/src/port-check.ts
@@ -47,7 +47,7 @@ export class InternalPortCheck implements PortCheck {
 
     const commandResults = await Promise.all(
       commands.map((command) =>
-        execContainer(this.container, command, { stdin: true, detach: false, tty: true }, false)
+        execContainer(this.container, command, { stdin: true, detach: false, tty: log.enabled() }, false)
       )
     );
     const isBound = commandResults.some((result) => result.exitCode === 0);
@@ -61,7 +61,7 @@ export class InternalPortCheck implements PortCheck {
             `The HostPortWaitStrategy will not work on a distroless image, use an alternate wait strategy for container ${this.container.id}`
           );
         }
-      } else {
+      } else if (log.enabled()) {
         commandResults
           .map((result) => ({ ...result, output: result.output.trim() }))
           .filter((result) => result.exitCode !== 126 && result.output.length > 0)

--- a/src/port-check.ts
+++ b/src/port-check.ts
@@ -52,7 +52,7 @@ export class InternalPortCheck implements PortCheck {
     );
     const isBound = commandResults.some((result) => result.exitCode === 0);
 
-    if (!isBound) {
+    if (!isBound && log.enabled()) {
       const shellExists = commandResults.some((result) => result.exitCode !== 126);
       if (!shellExists) {
         if (!this.isDistroless) {
@@ -61,7 +61,7 @@ export class InternalPortCheck implements PortCheck {
             `The HostPortWaitStrategy will not work on a distroless image, use an alternate wait strategy for container ${this.container.id}`
           );
         }
-      } else if (log.enabled()) {
+      } else {
         commandResults
           .map((result) => ({ ...result, output: result.output.trim() }))
           .filter((result) => result.exitCode !== 126 && result.output.length > 0)

--- a/src/port-check.ts
+++ b/src/port-check.ts
@@ -47,7 +47,7 @@ export class InternalPortCheck implements PortCheck {
 
     const commandResults = await Promise.all(
       commands.map((command) =>
-        execContainer(this.container, command, { stdin: true, detach: false, tty: log.enabled() }, false)
+        execContainer(this.container, command, { stdin: true, detach: false, tty: true }, false)
       )
     );
     const isBound = commandResults.some((result) => result.exitCode === 0);


### PR DESCRIPTION
I think I found a few places that can be tuned to help increase performance in setups that have many parallel test cases, and to put these into context, I used one of the test sets I have access to where testcontainers is being rolled out.

The test set is fairly large, consisting of about 1300 jest test cases  (in about 180 test suites), where almost each test case touches a container - container reuse is enabled, however they still go through `GenericContainer` and the reuse logic there (i.e no memory level resource sharing between test cases). All of the test-cases are marked `concurrent` and through all of my test runs, I used 4 jest workers (so 4 test suites were running in parallel).

I ran each scenario 5 times, probably not statistically significant, but as the test set is pretty big, it takes too long to run them more than that. I did discard any test run that failed (there are some test cases that are flaky and fail sometimes), but all in all, <5 runs were discarded.

Here's the baseline I captured with version 9.1.3:
```
Run 1 - Done in 351.90s.
Run 2 - Done in 337.98s.
Run 3 - Done in 309.03s.
Run 4 - Done in 339.93s.
Run 5 - Done in 316.15s.
= Average 330.99s
```

After moving the auth config lookup to only occur when an image actually needs pulling, adding a lock around image pulling and avoiding some logic if logging is disabled (mainly determining the system statistics) [1]:
```
Run 1 - Done in 307.70s.
Run 2 - Done in 340.78s.
Run 3 - Done in 290.94s.
Run 4 - Done in 288.53s.
Run 5 - Done in 278.26s.
= Average 301.24s
```

After optimising the way the image existence check occurs [2]:
```
Run 1 - Done in 284.07s
Run 2 - Done in 272.30s.
Run 3 - Done in 270.35s.
Run 4 - Done in 298.30s.
Run 5 - Done in 278.50s.
=  Average 280.70s
```

### Reasoning

[1] - The auth check does not need to occur if we decide to not pull the image, this also fixes a bug, as previously `runInContainer` did not do the auth config checkup, which I assume it should have. The lock I added to avoid concurrent tests starting to pull an image that they all share, this way we only pull the image once and then determine that it already exists for the other checks. Determining the statistics, although spun off as a promise that is not awaited, I still think it does not make sense if logging is not enabled (which is probably in majority of cases).

[2] - Previously every single check fetched the entire list of images from Docker, which on certain machines can be quite a large set. This new approach caches the results and again also applies a lock to avoid parallel checks for the same image from doing parallel work. Images that do not exist always update the full list of images we have.

### Followup

I suspect there is some more room for improvement, one thing I notice is the default waiting strategy, which uses `Promise.all` for the internal port check commands. It could probably be improved by using a modified approach with `Promise.any`, allowing for resolving fast in case one of the commands is faster then the others and gives a positive answer. I left this out as `Promise.any` was introduced in Node 15, and if I understand correctly, this project also supports Node 14.

It is also possible that the `execContainer` utility could be improved to avoid polling, at least [dockerode's issue](https://github.com/apocas/dockerode/issues/534) on this seems to suggest that latest versions of docker have a shim that solves the original issue why `stream.on('end')` was not properly working on Windows (not sure whether that is the reason why this library uses the polling approach or not).