### PR TITLE
Remove private registry acceptance tests

### DIFF
--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -19,11 +19,6 @@ jobs:
           fetch-depth: 0
       - name: Fetch main branch
         run: git fetch origin main
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: cristianrgreco
-          password: b62e3c19-4990-46f6-b221-55cf0bfb6513 # read-only
       - name: Install NodeJS ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -53,11 +48,6 @@ jobs:
         uses: ScribeMD/rootless-docker@0.2.2
       - name: Remove Docket root socket
         run: sudo rm -rf /var/run/docker.sock
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: cristianrgreco
-          password: b62e3c19-4990-46f6-b221-55cf0bfb6513 # read-only
       - name: Install NodeJS
         uses: actions/setup-node@v3
         with:
@@ -79,11 +69,6 @@ jobs:
     steps:
       - name: Code checkout
         uses: actions/checkout@v3
-      - name: Login to Docker Hub  # Move to after Podman installed once https://github.com/containers/podman/discussions/16842 resolved
-        uses: docker/login-action@v2
-        with:
-          username: cristianrgreco
-          password: b62e3c19-4990-46f6-b221-55cf0bfb6513 # read-only
       - name: Setup Podman
         run: |
           curl -fsSL https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/Debian_Testing/Release.key \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,11 +15,6 @@ jobs:
     steps:
       - name: Code checkout
         uses: actions/checkout@v3
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: cristianrgreco
-          password: b62e3c19-4990-46f6-b221-55cf0bfb6513 # read-only
       - name: Install NodeJS ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -43,11 +38,6 @@ jobs:
         uses: ScribeMD/rootless-docker@0.2.2
       - name: Remove Docket root socket
         run: sudo rm -rf /var/run/docker.sock
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: cristianrgreco
-          password: b62e3c19-4990-46f6-b221-55cf0bfb6513 # read-only
       - name: Install NodeJS
         uses: actions/setup-node@v3
         with:
@@ -69,11 +59,6 @@ jobs:
     steps:
       - name: Code checkout
         uses: actions/checkout@v3
-      - name: Login to Docker Hub # Move to after Podman installed once https://github.com/containers/podman/discussions/16842 resolved
-        uses: docker/login-action@v2
-        with:
-          username: cristianrgreco
-          password: b62e3c19-4990-46f6-b221-55cf0bfb6513 # read-only
       - name: Setup Podman
         run: |
           curl -fsSL https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/Debian_Testing/Release.key \

--- a/fixtures/docker/docker-private-multistage/Dockerfile
+++ b/fixtures/docker/docker-private-multistage/Dockerfile
@@ -1,1 +1,0 @@
-FROM cristianrgreco/testcontainer-private:1.1.12 AS first-stage

--- a/fixtures/docker/docker-private/Dockerfile
+++ b/fixtures/docker/docker-private/Dockerfile
@@ -1,1 +1,0 @@
-FROM cristianrgreco/testcontainer-private:1.1.12

--- a/src/generic-container/generic-container.test.ts
+++ b/src/generic-container/generic-container.test.ts
@@ -46,17 +46,6 @@ describe("GenericContainer", () => {
     await container.stop();
   });
 
-  it("should pull an image from a private registry", async () => {
-    const container = await new GenericContainer("cristianrgreco/testcontainer-private:1.1.12")
-      .withPullPolicy(new AlwaysPullPolicy())
-      .withExposedPorts(8080)
-      .start();
-
-    await checkContainerIsHealthy(container);
-
-    await container.stop();
-  });
-
   it("should wait for log", async () => {
     const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
       .withExposedPorts(8080)
@@ -779,26 +768,6 @@ describe("GenericContainer", () => {
         events.destroy();
       });
     }
-
-    it("should pull an image from a private registry", async () => {
-      const context = path.resolve(fixtures, "docker-private");
-      const container = await GenericContainer.fromDockerfile(context).withPullPolicy(new AlwaysPullPolicy()).build();
-      const startedContainer = await container.withExposedPorts(8080).start();
-
-      await checkContainerIsHealthy(startedContainer);
-
-      await startedContainer.stop();
-    });
-
-    it("should pull an image from a private registry in a multistage Dockerfile", async () => {
-      const context = path.resolve(fixtures, "docker-private-multistage");
-      const container = await GenericContainer.fromDockerfile(context).withPullPolicy(new AlwaysPullPolicy()).build();
-      const startedContainer = await container.withExposedPorts(8080).start();
-
-      await checkContainerIsHealthy(startedContainer);
-
-      await startedContainer.stop();
-    });
 
     it("should build and start with custom file name", async () => {
       const context = path.resolve(fixtures, "docker-with-custom-filename");


### PR DESCRIPTION
Because Docker is removing OSS status, the registry used only for integration testing this OSS project needs to be removed.