### PR TITLE
Split GenericContainer tests to run faster

### DIFF
--- a/src/generic-container/generic-container-dockerfile.test.ts
+++ b/src/generic-container/generic-container-dockerfile.test.ts
@@ -1,0 +1,81 @@
+import path from "path";
+import { GenericContainer } from "./generic-container";
+import { AlwaysPullPolicy } from "../pull-policy";
+import { Wait } from "../wait";
+import { checkContainerIsHealthy, getEvents } from "../test-helper";
+
+describe("GenericContainer Dockerfile", () => {
+  jest.setTimeout(180_000);
+
+  const fixtures = path.resolve(__dirname, "..", "..", "fixtures", "docker");
+
+  it("should build and start", async () => {
+    const context = path.resolve(fixtures, "docker");
+    const container = await GenericContainer.fromDockerfile(context).build();
+    const startedContainer = await container.withExposedPorts(8080).start();
+
+    await checkContainerIsHealthy(startedContainer);
+
+    await startedContainer.stop();
+  });
+
+  // https://github.com/containers/podman/issues/17779
+  if (!process.env["CI_PODMAN"]) {
+    it("should use pull policy", async () => {
+      const containerSpec = GenericContainer.fromDockerfile(path.resolve(fixtures, "docker")).withPullPolicy(
+        new AlwaysPullPolicy()
+      );
+      await containerSpec.build();
+
+      const events = await getEvents();
+      const pullPromise = new Promise<void>((resolve) => {
+        events.on("data", (data) => {
+          try {
+            const { status } = JSON.parse(data);
+            if (status === "pull") {
+              resolve();
+            }
+          } catch {
+            // ignored
+          }
+        });
+      });
+      await containerSpec.build();
+
+      await pullPromise;
+
+      events.destroy();
+    });
+  }
+
+  it("should build and start with custom file name", async () => {
+    const context = path.resolve(fixtures, "docker-with-custom-filename");
+    const container = await GenericContainer.fromDockerfile(context, "Dockerfile-A").build();
+    const startedContainer = await container.withExposedPorts(8080).start();
+
+    await checkContainerIsHealthy(startedContainer);
+
+    await startedContainer.stop();
+  });
+
+  it("should set build arguments", async () => {
+    const context = path.resolve(fixtures, "docker-with-buildargs");
+    const container = await GenericContainer.fromDockerfile(context).withBuildArgs({ VERSION: "10-alpine" }).build();
+    const startedContainer = await container.withExposedPorts(8080).start();
+
+    await checkContainerIsHealthy(startedContainer);
+
+    await startedContainer.stop();
+  });
+
+  it("should exit immediately and stop without exception", async () => {
+    const message = "This container will exit immediately.";
+    const context = path.resolve(fixtures, "docker-exit-immediately");
+    const container = await GenericContainer.fromDockerfile(context).build();
+    const startedContainer = await container.withWaitStrategy(Wait.forLogMessage(message)).start();
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 1000));
+
+    await startedContainer.stop();
+  });
+});

--- a/src/generic-container/generic-container-logs.test.ts
+++ b/src/generic-container/generic-container-logs.test.ts
@@ -1,0 +1,28 @@
+import { GenericContainer } from "./generic-container";
+import { containerLog } from "../logger";
+
+describe("GenericContainer logs", () => {
+  jest.setTimeout(180_000);
+
+  it("should stream logs from a running container", async () => {
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14").withExposedPorts(8080).start();
+
+    const stream = await container.logs();
+    const log = await new Promise((resolve) => stream.on("data", (line) => resolve(line)));
+    expect(log).toContain("Listening on port 8080");
+
+    await container.stop();
+  });
+
+  it("should stream logs from a running container after restart", async () => {
+    const containerLogTraceSpy = jest.spyOn(containerLog, "trace");
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14").withExposedPorts(8080).start();
+
+    await container.restart();
+
+    const logs = containerLogTraceSpy.mock.calls.flat();
+    expect(logs.some((line) => line.includes("Listening on port 8080"))).toBe(true);
+
+    await container.stop();
+  });
+});

--- a/src/generic-container/generic-container-network.test.ts
+++ b/src/generic-container/generic-container-network.test.ts
@@ -1,0 +1,52 @@
+import { GenericContainer } from "./generic-container";
+import { Network } from "../network";
+import { getContainerById } from "../docker/functions/container/get-container";
+
+describe("GenericContainer network", () => {
+  jest.setTimeout(180_000);
+
+  it("should set network mode", async () => {
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14").withNetworkMode("host").start();
+    const dockerContainer = await getContainerById(container.getId());
+    const containerInfo = await dockerContainer.inspect();
+
+    expect(containerInfo.HostConfig.NetworkMode).toBe("host");
+
+    await container.stop();
+  });
+
+  it("should set network aliases", async () => {
+    const network = await new Network().start();
+    const fooContainer = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+      .withNetwork(network)
+      .withNetworkAliases("foo")
+      .start();
+    const barContainer = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+      .withNetwork(network)
+      .withNetworkAliases("bar", "baz")
+      .start();
+
+    expect((await fooContainer.exec(["getent", "hosts", "bar"])).exitCode).toBe(0);
+    expect((await fooContainer.exec(["getent", "hosts", "baz"])).exitCode).toBe(0);
+    expect((await barContainer.exec(["getent", "hosts", "foo"])).exitCode).toBe(0);
+    expect((await barContainer.exec(["getent", "hosts", "unknown"])).exitCode).not.toBe(0);
+
+    await barContainer.stop();
+    await fooContainer.stop();
+    await network.stop();
+  });
+
+  it("should set extra hosts", async () => {
+    const fooContainer = await new GenericContainer("cristianrgreco/testcontainer:1.1.14").start();
+
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+      .withExtraHosts([{ host: "foo", ipAddress: fooContainer.getIpAddress(fooContainer.getNetworkNames()[0]) }])
+      .start();
+
+    expect((await container.exec(["getent", "hosts", "foo"])).exitCode).toBe(0);
+    expect((await container.exec(["getent", "hosts", "unknown"])).exitCode).not.toBe(0);
+
+    await container.stop();
+    await fooContainer.stop();
+  });
+});

--- a/src/generic-container/generic-container-resources-quota.test.ts
+++ b/src/generic-container/generic-container-resources-quota.test.ts
@@ -1,0 +1,64 @@
+import { GenericContainer } from "./generic-container";
+import { getContainerById } from "../docker/functions/container/get-container";
+
+describe("GenericContainer resources quota", () => {
+  jest.setTimeout(180_000);
+
+  if (!process.env["CI_ROOTLESS"]) {
+    it("should set resources quota", async () => {
+      const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+        .withResourcesQuota({ memory: 0.5, cpu: 1 })
+        .start();
+
+      const dockerContainer = await getContainerById(container.getId());
+      const containerInfo = await dockerContainer.inspect();
+
+      expect(containerInfo.HostConfig.Memory).toEqual(536870912);
+      expect(containerInfo.HostConfig.NanoCpus).toEqual(1000000000);
+
+      await container.stop();
+    });
+  }
+
+  it("resources quota should be 0 for cpu and memory if not set by user", async () => {
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14").start();
+
+    const dockerContainer = await getContainerById(container.getId());
+    const containerInfo = await dockerContainer.inspect();
+
+    expect(containerInfo.HostConfig.Memory).toEqual(0);
+    expect(containerInfo.HostConfig.NanoCpus).toEqual(0);
+
+    await container.stop();
+  });
+
+  it("should set resources quota memory only, cpu should be 0", async () => {
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+      .withResourcesQuota({ memory: 0.5 })
+      .start();
+
+    const dockerContainer = await getContainerById(container.getId());
+    const containerInfo = await dockerContainer.inspect();
+
+    expect(containerInfo.HostConfig.Memory).toEqual(536870912);
+    expect(containerInfo.HostConfig.NanoCpus).toEqual(0);
+
+    await container.stop();
+  });
+
+  if (!process.env["CI_ROOTLESS"]) {
+    it("should set resources quota cpu only, memory should be 0", async () => {
+      const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+        .withResourcesQuota({ cpu: 1 })
+        .start();
+
+      const dockerContainer = await getContainerById(container.getId());
+      const containerInfo = await dockerContainer.inspect();
+
+      expect(containerInfo.HostConfig.Memory).toEqual(0);
+      expect(containerInfo.HostConfig.NanoCpus).toEqual(1000000000);
+
+      await container.stop();
+    });
+  }
+});

--- a/src/generic-container/generic-container-restart.test.ts
+++ b/src/generic-container/generic-container-restart.test.ts
@@ -1,7 +1,7 @@
 import { GenericContainer } from "./generic-container";
 import { checkContainerIsHealthy } from "../test-helper";
 
-describe("GenericContainer", () => {
+describe("GenericContainer restart", () => {
   jest.setTimeout(180_000);
 
   it("should restart", async () => {

--- a/src/generic-container/generic-container-restart.test.ts
+++ b/src/generic-container/generic-container-restart.test.ts
@@ -1,0 +1,39 @@
+import { GenericContainer } from "./generic-container";
+import { checkContainerIsHealthy } from "../test-helper";
+
+describe("GenericContainer", () => {
+  jest.setTimeout(180_000);
+
+  it("should restart", async () => {
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+      .withName("restartingContainer")
+      .withExposedPorts(8080)
+      .start();
+    await checkContainerIsHealthy(container);
+
+    await container.restart();
+    await checkContainerIsHealthy(container);
+
+    expect(container.getId()).toStrictEqual(container.getId());
+    expect(container.getName()).toStrictEqual(container.getName());
+
+    await container.stop();
+  });
+
+  it("should restart persisting state", async () => {
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+      .withName("restartingContainer2")
+      .withExposedPorts(8080)
+      .start();
+    await checkContainerIsHealthy(container);
+    await container.exec(["sh", "-c", "echo 'testconfig' >> config.txt"]);
+
+    await container.restart();
+    await checkContainerIsHealthy(container);
+    const result = await container.exec(["cat", "config.txt"]);
+
+    expect(result.output).toEqual(expect.stringContaining("testconfig"));
+
+    await container.stop();
+  });
+});

--- a/src/generic-container/generic-container-reuse.test.ts
+++ b/src/generic-container/generic-container-reuse.test.ts
@@ -1,0 +1,126 @@
+import { GenericContainer } from "./generic-container";
+import { checkContainerIsHealthy } from "../test-helper";
+
+describe("GenericContainer reuse", () => {
+  jest.setTimeout(180_000);
+
+  it("should not reuse the container by default", async () => {
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+      .withName("there_can_only_be_one")
+      .withExposedPorts(8080)
+      .start();
+    await checkContainerIsHealthy(container);
+
+    try {
+      await expect(() =>
+        new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+          .withName("there_can_only_be_one")
+          .withExposedPorts(8080)
+          .start()
+      ).rejects.toThrowError();
+    } finally {
+      await container.stop();
+    }
+  });
+
+  it("should not reuse the container even when there is a candidate 1", async () => {
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+      .withName("there_can_only_be_one")
+      .withExposedPorts(8080)
+      .withReuse()
+      .start();
+    await checkContainerIsHealthy(container);
+
+    try {
+      await expect(() =>
+        new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+          .withName("there_can_only_be_one")
+          .withExposedPorts(8080)
+          .start()
+      ).rejects.toThrowError();
+    } finally {
+      await container.stop();
+    }
+  });
+
+  it("should not reuse the container even when there is a candidate 2", async () => {
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+      .withName("there_can_only_be_one")
+      .withExposedPorts(8080)
+      .start();
+    await checkContainerIsHealthy(container);
+
+    try {
+      await expect(() =>
+        new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+          .withName("there_can_only_be_one")
+          .withExposedPorts(8080)
+          .withReuse()
+          .start()
+      ).rejects.toThrowError();
+    } finally {
+      await container.stop();
+    }
+  });
+
+  it("should reuse the container", async () => {
+    const container1 = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+      .withName("there_can_only_be_one")
+      .withExposedPorts(8080)
+      .withReuse()
+      .start();
+    await checkContainerIsHealthy(container1);
+
+    const container2 = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+      .withName("there_can_only_be_one")
+      .withExposedPorts(8080)
+      .withReuse()
+      .start();
+    await checkContainerIsHealthy(container2);
+
+    expect(container1.getId()).toBe(container2.getId());
+
+    await container1.stop();
+  });
+
+  it("should create a new container when an existing reusable container has stopped", async () => {
+    const container1 = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+      .withName("there_can_only_be_one")
+      .withExposedPorts(8080)
+      .withReuse()
+      .start();
+    await container1.stop();
+
+    const container2 = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+      .withName("there_can_only_be_one")
+      .withExposedPorts(8080)
+      .withReuse()
+      .start();
+    await checkContainerIsHealthy(container2);
+
+    expect(container1.getId()).not.toBe(container2.getId());
+    await container2.stop();
+  });
+
+  it("should keep the labels passed in when a new reusable container is created", async () => {
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+      .withName("there_can_only_be_one")
+      .withExposedPorts(8080)
+      .withLabels({ test: "foo", bar: "baz" })
+      .withReuse()
+      .start();
+
+    expect(container.getLabels()).toEqual(expect.objectContaining({ test: "foo" }));
+    await container.stop();
+  });
+
+  it("should not create multiple reusable containers if called in parallel", async () => {
+    const [container1, container2] = await Promise.all([
+      new GenericContainer("cristianrgreco/testcontainer:1.1.14").withExposedPorts(8080).withReuse().start(),
+      new GenericContainer("cristianrgreco/testcontainer:1.1.14").withExposedPorts(8080).withReuse().start(),
+    ]);
+
+    expect(container1.getId()).toBe(container2.getId());
+    await container2.stop();
+  });
+});

--- a/src/generic-container/generic-container-wait-strategies.test.ts
+++ b/src/generic-container/generic-container-wait-strategies.test.ts
@@ -1,0 +1,167 @@
+import path from "path";
+import { GenericContainer } from "./generic-container";
+import { Wait } from "../wait";
+import { checkContainerIsHealthy, getRunningContainerNames } from "../test-helper";
+import { RandomUuid } from "../uuid";
+
+describe("GenericContainer wait strategies", () => {
+  jest.setTimeout(180_000);
+
+  const fixtures = path.resolve(__dirname, "..", "..", "fixtures", "docker");
+
+  it("should wait for port", async () => {
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14").withExposedPorts(8080).start();
+
+    await checkContainerIsHealthy(container);
+
+    await container.stop();
+  });
+
+  it("should wait for log", async () => {
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+      .withExposedPorts(8080)
+      .withWaitStrategy(Wait.forLogMessage("Listening on port 8080"))
+      .start();
+
+    await checkContainerIsHealthy(container);
+
+    await container.stop();
+  });
+
+  it("should wait for log with regex", async () => {
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+      .withExposedPorts(8080)
+      .withWaitStrategy(Wait.forLogMessage(/Listening on port \d+/))
+      .start();
+
+    await checkContainerIsHealthy(container);
+
+    await container.stop();
+  });
+
+  it("should wait for a new log after restart", async () => {
+    const start = new Date();
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+      .withCommand(["/bin/sh", "-c", 'sleep 2; echo "Ready"'])
+      .withWaitStrategy(Wait.forLogMessage("Ready"))
+      .start();
+
+    expect(new Date().getTime() - start.getTime()).toBeGreaterThanOrEqual(2_000);
+    await container.restart();
+    expect(new Date().getTime() - start.getTime()).toBeGreaterThanOrEqual(4_000);
+
+    await container.stop();
+  });
+
+  it("should wait for health check", async () => {
+    const context = path.resolve(fixtures, "docker-with-health-check");
+    const customGenericContainer = await GenericContainer.fromDockerfile(context).build();
+    const container = await customGenericContainer
+      .withExposedPorts(8080)
+      .withWaitStrategy(Wait.forHealthCheck())
+      .start();
+
+    await checkContainerIsHealthy(container);
+
+    await container.stop();
+  });
+
+  it("should wait for custom health check", async () => {
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+      .withExposedPorts(8080)
+      .withHealthCheck({
+        test: ["CMD-SHELL", "curl -f http://localhost:8080/hello-world || exit 1"],
+        interval: 1000,
+        timeout: 3000,
+        retries: 5,
+        startPeriod: 1000,
+      })
+      .withWaitStrategy(Wait.forHealthCheck())
+      .start();
+
+    await checkContainerIsHealthy(container);
+
+    await container.stop();
+  });
+
+  it("should stop the container when the host port check wait strategy times out", async () => {
+    const containerName = `container-${new RandomUuid().nextUuid()}`;
+
+    await expect(
+      new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+        .withName(containerName)
+        .withExposedPorts(8081)
+        .withStartupTimeout(0)
+        .start()
+    ).rejects.toThrowError("Port 8081 not bound after 0ms");
+
+    expect(await getRunningContainerNames()).not.toContain(containerName);
+  });
+
+  it("should stop the container when the log message wait strategy times out", async () => {
+    const containerName = `container-${new RandomUuid().nextUuid()}`;
+
+    await expect(
+      new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+        .withName(containerName)
+        .withExposedPorts(8080)
+        .withWaitStrategy(Wait.forLogMessage("unexpected"))
+        .withStartupTimeout(0)
+        .start()
+    ).rejects.toThrowError(`Log message "unexpected" not received after 0ms`);
+
+    expect(await getRunningContainerNames()).not.toContain(containerName);
+  });
+
+  it("should stop the container when the health check wait strategy times out", async () => {
+    const containerName = `container-${new RandomUuid().nextUuid()}`;
+
+    const context = path.resolve(fixtures, "docker-with-health-check");
+    const customGenericContainer = await GenericContainer.fromDockerfile(context).build();
+    await expect(
+      customGenericContainer
+        .withName(containerName)
+        .withExposedPorts(8080)
+        .withWaitStrategy(Wait.forHealthCheck())
+        .withStartupTimeout(0)
+        .start()
+    ).rejects.toThrowError("Health check not healthy after 0ms");
+
+    expect(await getRunningContainerNames()).not.toContain(containerName);
+  });
+
+  it("should stop the container when the health check fails", async () => {
+    const containerName = `container-${new RandomUuid().nextUuid()}`;
+
+    const context = path.resolve(fixtures, "docker-with-health-check");
+    const customGenericContainer = await GenericContainer.fromDockerfile(context).build();
+    await expect(
+      customGenericContainer
+        .withName(containerName)
+        .withExposedPorts(8080)
+        .withHealthCheck({ test: ["CMD-SHELL", "exit 1"], interval: 1, timeout: 3, retries: 3 })
+        .withWaitStrategy(Wait.forHealthCheck())
+        .start()
+    ).rejects.toThrowError("Health check failed");
+
+    expect(await getRunningContainerNames()).not.toContain(containerName);
+  });
+
+  it("should wait for custom health check using CMD to run the command directly without a shell", async () => {
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+      .withExposedPorts(8080)
+      .withHealthCheck({
+        test: ["CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/hello-world"],
+        interval: 1000,
+        timeout: 3000,
+        retries: 5,
+        startPeriod: 1000,
+      })
+      .withWaitStrategy(Wait.forHealthCheck())
+      .start();
+
+    await checkContainerIsHealthy(container);
+
+    await container.stop();
+  });
+});

--- a/src/generic-container/generic-container.test.ts
+++ b/src/generic-container/generic-container.test.ts
@@ -3,25 +3,13 @@ import path from "path";
 import getPort from "get-port";
 import { GenericContainer } from "./generic-container";
 import { AlwaysPullPolicy } from "../pull-policy";
-import { Wait } from "../wait";
-import { RandomUuid } from "../uuid";
-import { checkContainerIsHealthy, getEvents, getRunningContainerNames } from "../test-helper";
-import { Network } from "../network";
+import { checkContainerIsHealthy, getEvents } from "../test-helper";
 import { getContainerById } from "../docker/functions/container/get-container";
-import { containerLog } from "../logger";
 
 describe("GenericContainer", () => {
   jest.setTimeout(180_000);
 
   const fixtures = path.resolve(__dirname, "..", "..", "fixtures", "docker");
-
-  it("should wait for port", async () => {
-    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14").withExposedPorts(8080).start();
-
-    await checkContainerIsHealthy(container);
-
-    await container.stop();
-  });
 
   it("should return first mapped port", async () => {
     const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14").withExposedPorts(8080).start();
@@ -46,116 +34,15 @@ describe("GenericContainer", () => {
     await container.stop();
   });
 
-  it("should wait for log", async () => {
-    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-      .withExposedPorts(8080)
-      .withWaitStrategy(Wait.forLogMessage("Listening on port 8080"))
-      .start();
+  it("should execute a command on a running container", async () => {
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14").withExposedPorts(8080).start();
 
-    await checkContainerIsHealthy(container);
+    const { output, exitCode } = await container.exec(["echo", "hello", "world"]);
 
-    await container.stop();
-  });
-
-  it("should wait for log with regex", async () => {
-    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-      .withExposedPorts(8080)
-      .withWaitStrategy(Wait.forLogMessage(/Listening on port \d+/))
-      .start();
-
-    await checkContainerIsHealthy(container);
+    expect(exitCode).toBe(0);
+    expect(output).toEqual(expect.stringContaining("hello world"));
 
     await container.stop();
-  });
-
-  it("should wait for a new log after restart", async () => {
-    const start = new Date();
-    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-      .withCommand(["/bin/sh", "-c", 'sleep 2; echo "Ready"'])
-      .withWaitStrategy(Wait.forLogMessage("Ready"))
-      .start();
-
-    expect(new Date().getTime() - start.getTime()).toBeGreaterThanOrEqual(2_000);
-    await container.restart();
-    expect(new Date().getTime() - start.getTime()).toBeGreaterThanOrEqual(4_000);
-
-    await container.stop();
-  });
-
-  it("should wait for health check", async () => {
-    const context = path.resolve(fixtures, "docker-with-health-check");
-    const customGenericContainer = await GenericContainer.fromDockerfile(context).build();
-    const container = await customGenericContainer
-      .withExposedPorts(8080)
-      .withWaitStrategy(Wait.forHealthCheck())
-      .start();
-
-    await checkContainerIsHealthy(container);
-
-    await container.stop();
-  });
-
-  it("should wait for custom health check", async () => {
-    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-      .withExposedPorts(8080)
-      .withHealthCheck({
-        test: ["CMD-SHELL", "curl -f http://localhost:8080/hello-world || exit 1"],
-        interval: 1000,
-        timeout: 3000,
-        retries: 5,
-        startPeriod: 1000,
-      })
-      .withWaitStrategy(Wait.forHealthCheck())
-      .start();
-
-    await checkContainerIsHealthy(container);
-
-    await container.stop();
-  });
-
-  it("should set network mode", async () => {
-    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14").withNetworkMode("host").start();
-    const dockerContainer = await getContainerById(container.getId());
-    const containerInfo = await dockerContainer.inspect();
-
-    expect(containerInfo.HostConfig.NetworkMode).toBe("host");
-
-    await container.stop();
-  });
-
-  it("should set network aliases", async () => {
-    const network = await new Network().start();
-    const fooContainer = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-      .withNetwork(network)
-      .withNetworkAliases("foo")
-      .start();
-    const barContainer = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-      .withNetwork(network)
-      .withNetworkAliases("bar", "baz")
-      .start();
-
-    expect((await fooContainer.exec(["getent", "hosts", "bar"])).exitCode).toBe(0);
-    expect((await fooContainer.exec(["getent", "hosts", "baz"])).exitCode).toBe(0);
-    expect((await barContainer.exec(["getent", "hosts", "foo"])).exitCode).toBe(0);
-    expect((await barContainer.exec(["getent", "hosts", "unknown"])).exitCode).not.toBe(0);
-
-    await barContainer.stop();
-    await fooContainer.stop();
-    await network.stop();
-  });
-
-  it("should set extra hosts", async () => {
-    const fooContainer = await new GenericContainer("cristianrgreco/testcontainer:1.1.14").start();
-
-    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-      .withExtraHosts([{ host: "foo", ipAddress: fooContainer.getIpAddress(fooContainer.getNetworkNames()[0]) }])
-      .start();
-
-    expect((await container.exec(["getent", "hosts", "foo"])).exitCode).toBe(0);
-    expect((await container.exec(["getent", "hosts", "unknown"])).exitCode).not.toBe(0);
-
-    await container.stop();
-    await fooContainer.stop();
   });
 
   it("should set environment variables", async () => {
@@ -359,39 +246,6 @@ describe("GenericContainer", () => {
     await container2.stop();
   });
 
-  it("should execute a command on a running container", async () => {
-    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14").withExposedPorts(8080).start();
-
-    const { output, exitCode } = await container.exec(["echo", "hello", "world"]);
-
-    expect(exitCode).toBe(0);
-    expect(output).toEqual(expect.stringContaining("hello world"));
-
-    await container.stop();
-  });
-
-  it("should stream logs from a running container", async () => {
-    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14").withExposedPorts(8080).start();
-
-    const stream = await container.logs();
-    const log = await new Promise((resolve) => stream.on("data", (line) => resolve(line)));
-    expect(log).toContain("Listening on port 8080");
-
-    await container.stop();
-  });
-
-  it("should stream logs from a running container after restart", async () => {
-    const containerLogTraceSpy = jest.spyOn(containerLog, "trace");
-    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14").withExposedPorts(8080).start();
-
-    await container.restart();
-
-    const logs = containerLogTraceSpy.mock.calls.flat();
-    expect(logs.some((line) => line.includes("Listening on port 8080"))).toBe(true);
-
-    await container.stop();
-  });
-
   it("should set the IPC mode", async () => {
     const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
       .withIpcMode("host")
@@ -414,109 +268,6 @@ describe("GenericContainer", () => {
     expect(output).toEqual(expect.stringContaining("node"));
 
     await container.stop();
-  });
-
-  it("should stop the container when the host port check wait strategy times out", async () => {
-    const containerName = `container-${new RandomUuid().nextUuid()}`;
-
-    await expect(
-      new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-        .withName(containerName)
-        .withExposedPorts(8081)
-        .withStartupTimeout(0)
-        .start()
-    ).rejects.toThrowError("Port 8081 not bound after 0ms");
-
-    expect(await getRunningContainerNames()).not.toContain(containerName);
-  });
-
-  it("should stop the container when the log message wait strategy times out", async () => {
-    const containerName = `container-${new RandomUuid().nextUuid()}`;
-
-    await expect(
-      new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-        .withName(containerName)
-        .withExposedPorts(8080)
-        .withWaitStrategy(Wait.forLogMessage("unexpected"))
-        .withStartupTimeout(0)
-        .start()
-    ).rejects.toThrowError(`Log message "unexpected" not received after 0ms`);
-
-    expect(await getRunningContainerNames()).not.toContain(containerName);
-  });
-
-  it("should stop the container when the health check wait strategy times out", async () => {
-    const containerName = `container-${new RandomUuid().nextUuid()}`;
-
-    const context = path.resolve(fixtures, "docker-with-health-check");
-    const customGenericContainer = await GenericContainer.fromDockerfile(context).build();
-    await expect(
-      customGenericContainer
-        .withName(containerName)
-        .withExposedPorts(8080)
-        .withWaitStrategy(Wait.forHealthCheck())
-        .withStartupTimeout(0)
-        .start()
-    ).rejects.toThrowError("Health check not healthy after 0ms");
-
-    expect(await getRunningContainerNames()).not.toContain(containerName);
-  });
-
-  it("should stop the container when the health check fails", async () => {
-    const containerName = `container-${new RandomUuid().nextUuid()}`;
-
-    const context = path.resolve(fixtures, "docker-with-health-check");
-    const customGenericContainer = await GenericContainer.fromDockerfile(context).build();
-    await expect(
-      customGenericContainer
-        .withName(containerName)
-        .withExposedPorts(8080)
-        .withHealthCheck({ test: ["CMD-SHELL", "exit 1"], interval: 1, timeout: 3, retries: 3 })
-        .withWaitStrategy(Wait.forHealthCheck())
-        .start()
-    ).rejects.toThrowError("Health check failed");
-
-    expect(await getRunningContainerNames()).not.toContain(containerName);
-  });
-
-  it("should wait for custom health check using CMD to run the command directly without a shell", async () => {
-    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-      .withExposedPorts(8080)
-      .withHealthCheck({
-        test: ["CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/hello-world"],
-        interval: 1000,
-        timeout: 3000,
-        retries: 5,
-        startPeriod: 1000,
-      })
-      .withWaitStrategy(Wait.forHealthCheck())
-      .start();
-
-    await checkContainerIsHealthy(container);
-
-    await container.stop();
-  });
-
-  it("should honour .dockerignore file", async () => {
-    const context = path.resolve(fixtures, "docker-with-dockerignore");
-    const container = await GenericContainer.fromDockerfile(context).build();
-    const startedContainer = await container.withExposedPorts(8080).start();
-
-    const { output } = await startedContainer.exec(["find"]);
-
-    expect(output).toContain("exist1.txt");
-    expect(output).toContain("exist2.txt");
-    expect(output).toContain("exist7.txt");
-    expect(output).not.toContain("example1.txt");
-    expect(output).not.toContain("example2.txt");
-    expect(output).not.toContain("example3.txt");
-    expect(output).not.toContain("example4.txt");
-    expect(output).not.toContain("example5.txt");
-    expect(output).not.toContain("example6.txt");
-    expect(output).not.toContain("example7.txt");
-    expect(output).not.toContain("Dockerfile");
-
-    await startedContainer.stop();
   });
 
   it("should copy file to container", async () => {
@@ -547,292 +298,25 @@ describe("GenericContainer", () => {
     await container.stop();
   });
 
-  describe("resources quota", () => {
-    if (!process.env["CI_ROOTLESS"]) {
-      it("should set resources quota", async () => {
-        const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-          .withResourcesQuota({ memory: 0.5, cpu: 1 })
-          .start();
+  it("should honour .dockerignore file", async () => {
+    const context = path.resolve(fixtures, "docker-with-dockerignore");
+    const container = await GenericContainer.fromDockerfile(context).build();
+    const startedContainer = await container.withExposedPorts(8080).start();
 
-        const dockerContainer = await getContainerById(container.getId());
-        const containerInfo = await dockerContainer.inspect();
+    const { output } = await startedContainer.exec(["find"]);
 
-        expect(containerInfo.HostConfig.Memory).toEqual(536870912);
-        expect(containerInfo.HostConfig.NanoCpus).toEqual(1000000000);
+    expect(output).toContain("exist1.txt");
+    expect(output).toContain("exist2.txt");
+    expect(output).toContain("exist7.txt");
+    expect(output).not.toContain("example1.txt");
+    expect(output).not.toContain("example2.txt");
+    expect(output).not.toContain("example3.txt");
+    expect(output).not.toContain("example4.txt");
+    expect(output).not.toContain("example5.txt");
+    expect(output).not.toContain("example6.txt");
+    expect(output).not.toContain("example7.txt");
+    expect(output).not.toContain("Dockerfile");
 
-        await container.stop();
-      });
-    }
-
-    it("resources quota should be 0 for cpu and memory if not set by user", async () => {
-      const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14").start();
-
-      const dockerContainer = await getContainerById(container.getId());
-      const containerInfo = await dockerContainer.inspect();
-
-      expect(containerInfo.HostConfig.Memory).toEqual(0);
-      expect(containerInfo.HostConfig.NanoCpus).toEqual(0);
-
-      await container.stop();
-    });
-
-    it("should set resources quota memory only, cpu should be 0", async () => {
-      const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-        .withResourcesQuota({ memory: 0.5 })
-        .start();
-
-      const dockerContainer = await getContainerById(container.getId());
-      const containerInfo = await dockerContainer.inspect();
-
-      expect(containerInfo.HostConfig.Memory).toEqual(536870912);
-      expect(containerInfo.HostConfig.NanoCpus).toEqual(0);
-
-      await container.stop();
-    });
-
-    if (!process.env["CI_ROOTLESS"]) {
-      it("should set resources quota cpu only, memory should be 0", async () => {
-        const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-          .withResourcesQuota({ cpu: 1 })
-          .start();
-
-        const dockerContainer = await getContainerById(container.getId());
-        const containerInfo = await dockerContainer.inspect();
-
-        expect(containerInfo.HostConfig.Memory).toEqual(0);
-        expect(containerInfo.HostConfig.NanoCpus).toEqual(1000000000);
-
-        await container.stop();
-      });
-    }
-  });
-
-  describe("reuse", () => {
-    it("should not reuse the container by default", async () => {
-      const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-        .withName("there_can_only_be_one")
-        .withExposedPorts(8080)
-        .start();
-      await checkContainerIsHealthy(container);
-
-      try {
-        await expect(() =>
-          new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-            .withName("there_can_only_be_one")
-            .withExposedPorts(8080)
-            .start()
-        ).rejects.toThrowError();
-      } finally {
-        await container.stop();
-      }
-    });
-
-    it("should not reuse the container even when there is a candidate 1", async () => {
-      const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-        .withName("there_can_only_be_one")
-        .withExposedPorts(8080)
-        .withReuse()
-        .start();
-      await checkContainerIsHealthy(container);
-
-      try {
-        await expect(() =>
-          new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-            .withName("there_can_only_be_one")
-            .withExposedPorts(8080)
-            .start()
-        ).rejects.toThrowError();
-      } finally {
-        await container.stop();
-      }
-    });
-
-    it("should not reuse the container even when there is a candidate 2", async () => {
-      const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-        .withName("there_can_only_be_one")
-        .withExposedPorts(8080)
-        .start();
-      await checkContainerIsHealthy(container);
-
-      try {
-        await expect(() =>
-          new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-            .withName("there_can_only_be_one")
-            .withExposedPorts(8080)
-            .withReuse()
-            .start()
-        ).rejects.toThrowError();
-      } finally {
-        await container.stop();
-      }
-    });
-
-    it("should reuse the container", async () => {
-      const container1 = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-        .withName("there_can_only_be_one")
-        .withExposedPorts(8080)
-        .withReuse()
-        .start();
-      await checkContainerIsHealthy(container1);
-
-      const container2 = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-        .withName("there_can_only_be_one")
-        .withExposedPorts(8080)
-        .withReuse()
-        .start();
-      await checkContainerIsHealthy(container2);
-
-      expect(container1.getId()).toBe(container2.getId());
-
-      await container1.stop();
-    });
-
-    it("should create a new container when an existing reusable container has stopped", async () => {
-      const container1 = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-        .withName("there_can_only_be_one")
-        .withExposedPorts(8080)
-        .withReuse()
-        .start();
-      await container1.stop();
-
-      const container2 = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-        .withName("there_can_only_be_one")
-        .withExposedPorts(8080)
-        .withReuse()
-        .start();
-      await checkContainerIsHealthy(container2);
-
-      expect(container1.getId()).not.toBe(container2.getId());
-      await container2.stop();
-    });
-
-    it("should keep the labels passed in when a new reusable container is created", async () => {
-      const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-        .withName("there_can_only_be_one")
-        .withExposedPorts(8080)
-        .withLabels({ test: "foo", bar: "baz" })
-        .withReuse()
-        .start();
-
-      expect(container.getLabels()).toEqual(expect.objectContaining({ test: "foo" }));
-      await container.stop();
-    });
-
-    it("should not create multiple reusable containers if called in parallel", async () => {
-      const [container1, container2] = await Promise.all([
-        new GenericContainer("cristianrgreco/testcontainer:1.1.14").withExposedPorts(8080).withReuse().start(),
-        new GenericContainer("cristianrgreco/testcontainer:1.1.14").withExposedPorts(8080).withReuse().start(),
-      ]);
-
-      expect(container1.getId()).toBe(container2.getId());
-      await container2.stop();
-    });
-  });
-
-  describe("from Dockerfile", () => {
-    it("should build and start", async () => {
-      const context = path.resolve(fixtures, "docker");
-      const container = await GenericContainer.fromDockerfile(context).build();
-      const startedContainer = await container.withExposedPorts(8080).start();
-
-      await checkContainerIsHealthy(startedContainer);
-
-      await startedContainer.stop();
-    });
-
-    // https://github.com/containers/podman/issues/17779
-    if (!process.env["CI_PODMAN"]) {
-      it("should use pull policy", async () => {
-        const containerSpec = GenericContainer.fromDockerfile(path.resolve(fixtures, "docker")).withPullPolicy(
-          new AlwaysPullPolicy()
-        );
-        await containerSpec.build();
-
-        const events = await getEvents();
-        const pullPromise = new Promise<void>((resolve) => {
-          events.on("data", (data) => {
-            try {
-              const { status } = JSON.parse(data);
-              if (status === "pull") {
-                resolve();
-              }
-            } catch {
-              // ignored
-            }
-          });
-        });
-        await containerSpec.build();
-
-        await pullPromise;
-
-        events.destroy();
-      });
-    }
-
-    it("should build and start with custom file name", async () => {
-      const context = path.resolve(fixtures, "docker-with-custom-filename");
-      const container = await GenericContainer.fromDockerfile(context, "Dockerfile-A").build();
-      const startedContainer = await container.withExposedPorts(8080).start();
-
-      await checkContainerIsHealthy(startedContainer);
-
-      await startedContainer.stop();
-    });
-
-    it("should set build arguments", async () => {
-      const context = path.resolve(fixtures, "docker-with-buildargs");
-      const container = await GenericContainer.fromDockerfile(context).withBuildArgs({ VERSION: "10-alpine" }).build();
-      const startedContainer = await container.withExposedPorts(8080).start();
-
-      await checkContainerIsHealthy(startedContainer);
-
-      await startedContainer.stop();
-    });
-
-    it("should exit immediately and stop without exception", async () => {
-      const message = "This container will exit immediately.";
-      const context = path.resolve(fixtures, "docker-exit-immediately");
-      const container = await GenericContainer.fromDockerfile(context).build();
-      const startedContainer = await container.withWaitStrategy(Wait.forLogMessage(message)).start();
-
-      await new Promise<void>((resolve) => setTimeout(resolve, 1000));
-
-      await startedContainer.stop();
-    });
-  });
-
-  describe("restart", () => {
-    it("should restart", async () => {
-      const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-        .withName("restartingContainer")
-        .withExposedPorts(8080)
-        .start();
-      await checkContainerIsHealthy(container);
-
-      await container.restart();
-      await checkContainerIsHealthy(container);
-
-      expect(container.getId()).toStrictEqual(container.getId());
-      expect(container.getName()).toStrictEqual(container.getName());
-
-      await container.stop();
-    });
-
-    it("should restart persisting state", async () => {
-      const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-        .withName("restartingContainer2")
-        .withExposedPorts(8080)
-        .start();
-      await checkContainerIsHealthy(container);
-      await container.exec(["sh", "-c", "echo 'testconfig' >> config.txt"]);
-
-      await container.restart();
-      await checkContainerIsHealthy(container);
-      const result = await container.exec(["cat", "config.txt"]);
-
-      expect(result.output).toEqual(expect.stringContaining("testconfig"));
-
-      await container.stop();
-    });
+    await startedContainer.stop();
   });
 });


### PR DESCRIPTION
66% improvement after splitting the tests.

Before:

![before](https://user-images.githubusercontent.com/10348798/228249448-8788aa0a-9015-4e0f-8239-82702e5a2698.png)

After:

![after](https://user-images.githubusercontent.com/10348798/228249440-1052e8a9-7e99-4806-9302-f5062e3566a2.png)
