### PR TITLE
fix: directConnection flag should be present

### DIFF
--- a/src/modules/mongodb/mongodb-container.ts
+++ b/src/modules/mongodb/mongodb-container.ts
@@ -70,6 +70,6 @@ export class StartedMongoDBContainer extends AbstractStartedContainer {
   }
 
   public getConnectionString(): string {
-    return `mongodb://${this.getHost()}:${this.getMappedPort(MONGODB_PORT)}`;
+    return `mongodb://${this.getHost()}:${this.getMappedPort(MONGODB_PORT)}?directConnection=true`;
   }
 }


### PR DESCRIPTION

Hey! When not using the `directConnection=true`, mongoose (or nestjs mongoose) will not be able to connect.

Also, [mongosh](https://www.mongodb.com/docs/mongodb-shell/connect/#option-2--specify-members-in-connection-string) seems to be adding that automatically.