### PR TITLE
Move module configuration to lifecycle hooks to allow user override

### DIFF
--- a/src/generic-container/generic-container.ts
+++ b/src/generic-container/generic-container.ts
@@ -248,10 +248,6 @@ export class GenericContainer implements TestContainer {
     reused: boolean
   ): Promise<void>;
 
-  protected get hasExposedPorts(): boolean {
-    return this.opts.exposedPorts.length !== 0;
-  }
-
   public withCommand(command: string[]): this {
     this.opts.command = command;
     return this;
@@ -268,32 +264,37 @@ export class GenericContainer implements TestContainer {
   }
 
   public withLabels(labels: Labels): this {
-    this.opts.labels = { ...this.opts.labels, ...labels };
+    this.opts.labels = labels;
     return this;
   }
 
   public withEnvironment(environment: Environment): this {
+    this.opts.environment = environment;
+    return this;
+  }
+
+  public addEnvironment(environment: Environment): this {
     this.opts.environment = { ...this.opts.environment, ...environment };
     return this;
   }
 
   public withTmpFs(tmpFs: TmpFs): this {
-    this.opts.tmpFs = { ...this.opts.tmpFs, ...tmpFs };
+    this.opts.tmpFs = tmpFs;
     return this;
   }
 
   public withUlimits(ulimits: Ulimits): this {
-    this.opts.ulimits = { ...this.opts.ulimits, ...ulimits };
+    this.opts.ulimits = ulimits;
     return this;
   }
 
   public withAddedCapabilities(...capabilities: string[]): this {
-    this.opts.addedCapabilities = [...(this.opts.addedCapabilities ?? []), ...capabilities];
+    this.opts.addedCapabilities = capabilities;
     return this;
   }
 
   public withDroppedCapabilities(...capabilities: string[]): this {
-    this.opts.droppedCapabilities = [...(this.opts.droppedCapabilities ?? []), ...capabilities];
+    this.opts.droppedCapabilities = capabilities;
     return this;
   }
 
@@ -308,16 +309,21 @@ export class GenericContainer implements TestContainer {
   }
 
   public withNetworkAliases(...networkAliases: string[]): this {
-    this.networkAliases = [...this.networkAliases, ...networkAliases];
+    this.networkAliases = networkAliases;
     return this;
   }
 
   public withExtraHosts(extraHosts: ExtraHost[]): this {
-    this.opts.extraHosts = [...this.opts.extraHosts, ...extraHosts];
+    this.opts.extraHosts = extraHosts;
     return this;
   }
 
   public withExposedPorts(...ports: PortWithOptionalBinding[]): this {
+    this.opts.exposedPorts = ports;
+    return this;
+  }
+
+  public addExposedPorts(...ports: PortWithOptionalBinding[]): this {
     this.opts.exposedPorts = [...this.opts.exposedPorts, ...ports];
     return this;
   }
@@ -384,26 +390,27 @@ export class GenericContainer implements TestContainer {
     return this;
   }
 
-  protected getTarToCopy(): archiver.Archiver {
-    if (!this.tarToCopy) {
-      this.tarToCopy = archiver("tar");
-    }
-    return this.tarToCopy;
-  }
-
   public withWorkingDir(workingDir: string): this {
     this.opts.workingDir = workingDir;
     return this;
   }
 
+  /**
+   * Memory and CPU units from here: https://docs.docker.com/engine/api/v1.42/#tag/Container/operation/ContainerCreate
+   */
   public withResourcesQuota({ memory, cpu }: ResourcesQuota): this {
-    // Memory and CPU units from here: https://docs.docker.com/engine/api/v1.42/#tag/Container/operation/ContainerCreate
-    // see Memory, NanoCpus parameters
     const ram = memory !== undefined ? memory * 1024 ** 3 : undefined;
     const cpuQuota = cpu !== undefined ? cpu * 10 ** 9 : undefined;
 
     this.opts.resourcesQuota = { memory: ram, cpu: cpuQuota };
 
     return this;
+  }
+
+  private getTarToCopy(): archiver.Archiver {
+    if (!this.tarToCopy) {
+      this.tarToCopy = archiver("tar");
+    }
+    return this.tarToCopy;
   }
 }

--- a/src/modules/arangodb/arangodb-container.ts
+++ b/src/modules/arangodb/arangodb-container.ts
@@ -10,17 +10,19 @@ export class ArangoDBContainer extends GenericContainer {
     super(image);
   }
 
+  protected override async beforeContainerStarted(): Promise<void> {
+    this.withExposedPorts(ARANGODB_PORT)
+      .withWaitStrategy(Wait.forLogMessage("Have fun!"))
+      .withEnvironment({ ARANGO_ROOT_PASSWORD: this.password })
+      .withStartupTimeout(120_000);
+  }
+
   public withPassword(password: string): this {
     this.password = password;
     return this;
   }
 
   public override async start(): Promise<StartedArangoContainer> {
-    this.withExposedPorts(...(this.hasExposedPorts ? this.opts.exposedPorts : [ARANGODB_PORT]))
-      .withWaitStrategy(Wait.forLogMessage("Have fun!"))
-      .withEnvironment({ ARANGO_ROOT_PASSWORD: this.password })
-      .withStartupTimeout(120_000);
-
     return new StartedArangoContainer(await super.start(), this.password);
   }
 }

--- a/src/modules/elasticsearch/elasticsearch-container.ts
+++ b/src/modules/elasticsearch/elasticsearch-container.ts
@@ -8,8 +8,8 @@ export class ElasticsearchContainer extends GenericContainer {
     super(image);
   }
 
-  public override async start(): Promise<StartedElasticsearchContainer> {
-    this.withExposedPorts(...(this.hasExposedPorts ? this.opts.exposedPorts : [ELASTIC_SEARCH_HTTP_PORT]))
+  protected override async beforeContainerStarted(): Promise<void> {
+    this.withExposedPorts(ELASTIC_SEARCH_HTTP_PORT)
       .withEnvironment({ "discovery.type": "single-node" })
       .withCopyContentToContainer([
         {
@@ -18,7 +18,9 @@ export class ElasticsearchContainer extends GenericContainer {
         },
       ])
       .withStartupTimeout(120_000);
+  }
 
+  public override async start(): Promise<StartedElasticsearchContainer> {
     return new StartedElasticsearchContainer(await super.start());
   }
 }

--- a/src/modules/kafka/kafka-container.test.ts
+++ b/src/modules/kafka/kafka-container.test.ts
@@ -11,7 +11,7 @@ describe("KafkaContainer", () => {
 
   // connectBuiltInZK {
   it("should connect using in-built zoo-keeper", async () => {
-    const kafkaContainer = await new KafkaContainer().withExposedPorts(9093).start();
+    const kafkaContainer = await new KafkaContainer().start();
 
     await testPubSub(kafkaContainer);
 
@@ -20,7 +20,7 @@ describe("KafkaContainer", () => {
   // }
 
   it("should connect using in-built zoo-keeper and custom images", async () => {
-    const kafkaContainer = await new KafkaContainer(KAFKA_IMAGE).withExposedPorts(9093).start();
+    const kafkaContainer = await new KafkaContainer(KAFKA_IMAGE).start();
 
     await testPubSub(kafkaContainer);
 
@@ -30,7 +30,7 @@ describe("KafkaContainer", () => {
   it("should connect using in-built zoo-keeper and custom network", async () => {
     const network = await new Network().start();
 
-    const kafkaContainer = await new KafkaContainer().withNetwork(network).withExposedPorts(9093).start();
+    const kafkaContainer = await new KafkaContainer().withNetwork(network).start();
 
     await testPubSub(kafkaContainer);
 
@@ -54,7 +54,7 @@ describe("KafkaContainer", () => {
     const kafkaContainer = await new KafkaContainer()
       .withNetwork(network)
       .withZooKeeper(zooKeeperHost, zooKeeperPort)
-      .withExposedPorts(9093)
+
       .start();
 
     await testPubSub(kafkaContainer);

--- a/src/modules/mongodb/mongodb-container.ts
+++ b/src/modules/mongodb/mongodb-container.ts
@@ -14,11 +14,14 @@ export class MongoDBContainer extends GenericContainer {
     this.dockerImageName = DockerImageName.fromString(this.image);
   }
 
-  public override async start(): Promise<StartedMongoDBContainer> {
+  protected override async beforeContainerStarted(): Promise<void> {
     this.withExposedPorts(MONGODB_PORT)
       .withCommand(["--replSet", "rs0"])
       .withWaitStrategy(Wait.forLogMessage(/.*waiting for connections.*/i))
       .withStartupTimeout(120_000);
+  }
+
+  public override async start(): Promise<StartedMongoDBContainer> {
     return new StartedMongoDBContainer(await super.start());
   }
 

--- a/src/modules/mysql/mysql-container.ts
+++ b/src/modules/mysql/mysql-container.ts
@@ -14,6 +14,17 @@ export class MySqlContainer extends GenericContainer {
     super(image);
   }
 
+  protected override async beforeContainerStarted(): Promise<void> {
+    this.withExposedPorts(MYSQL_PORT)
+      .withEnvironment({
+        MYSQL_DATABASE: this.database,
+        MYSQL_ROOT_PASSWORD: this.rootPassword,
+        MYSQL_USER: this.username,
+        MYSQL_PASSWORD: this.userPassword,
+      })
+      .withStartupTimeout(120_000);
+  }
+
   public withDatabase(database: string): this {
     this.database = database;
     return this;
@@ -35,15 +46,6 @@ export class MySqlContainer extends GenericContainer {
   }
 
   public override async start(): Promise<StartedMySqlContainer> {
-    this.withExposedPorts(...(this.hasExposedPorts ? this.opts.exposedPorts : [MYSQL_PORT]))
-      .withEnvironment({
-        MYSQL_DATABASE: this.database,
-        MYSQL_ROOT_PASSWORD: this.rootPassword,
-        MYSQL_USER: this.username,
-        MYSQL_PASSWORD: this.userPassword,
-      })
-      .withStartupTimeout(120_000);
-
     return new StartedMySqlContainer(
       await super.start(),
       this.database,

--- a/src/modules/nats/nats-container.ts
+++ b/src/modules/nats/nats-container.ts
@@ -19,6 +19,24 @@ export class NatsContainer extends GenericContainer {
     this.args[PASS_ARGUMENT_KEY] = "test";
   }
 
+  protected override async beforeContainerStarted(): Promise<void> {
+    function buildCmdsFromArgs(args: { [p: string]: string }): string[] {
+      const result: string[] = [];
+      result.push("nats-server");
+
+      for (const argsKey in args) {
+        result.push(argsKey);
+        result.push(args[argsKey]);
+      }
+      return result;
+    }
+
+    this.withCommand(buildCmdsFromArgs(this.args))
+      .withExposedPorts(CLIENT_PORT, ROUTING_PORT_FOR_CLUSTERING, HTTP_MANAGEMENT_PORT)
+      .withWaitStrategy(Wait.forLogMessage(/.*Server is ready.*/))
+      .withStartupTimeout(120_000);
+  }
+
   public withUsername(user: string): this {
     this.args[USER_ARGUMENT_KEY] = user;
     return this;
@@ -48,26 +66,6 @@ export class NatsContainer extends GenericContainer {
   }
 
   public override async start(): Promise<StartedNatsContainer> {
-    function buildCmdsFromArgs(args: { [p: string]: string }): string[] {
-      const result: string[] = [];
-      result.push("nats-server");
-
-      for (const argsKey in args) {
-        result.push(argsKey);
-        result.push(args[argsKey]);
-      }
-      return result;
-    }
-
-    this.withCommand(buildCmdsFromArgs(this.args))
-      .withExposedPorts(
-        ...(this.hasExposedPorts
-          ? this.opts.exposedPorts
-          : [CLIENT_PORT, ROUTING_PORT_FOR_CLUSTERING, HTTP_MANAGEMENT_PORT])
-      )
-      .withWaitStrategy(Wait.forLogMessage(/.*Server is ready.*/))
-      .withStartupTimeout(120_000);
-
     return new StartedNatsContainer(await super.start(), this.getUser(), this.getPass());
   }
 

--- a/src/test-container.ts
+++ b/src/test-container.ts
@@ -21,6 +21,8 @@ export interface TestContainer {
 
   withEnvironment(environment: Environment): this;
 
+  addEnvironment(environment: Environment): this;
+
   withCommand(command: string[]): this;
 
   withEntrypoint(entrypoint: string[]): this;
@@ -34,6 +36,8 @@ export interface TestContainer {
   withDroppedCapabilities(...capabilities: string[]): this;
 
   withExposedPorts(...ports: PortWithOptionalBinding[]): this;
+
+  addExposedPorts(...ports: PortWithOptionalBinding[]): this;
 
   withBindMounts(bindMounts: BindMount[]): this;
 


### PR DESCRIPTION
**BREAKING CHANGES**

The behaviour of container methods `withX()` has changed from being additive to replacing. For example:

Previously:
```
.withExposedPorts(80)
.withExposedPorts(8080)

// exposedPorts = [80,8080]
```

After:
```
.withExposedPorts(80)
.withExposedPorts(8080)

// exposedPorts = [8080]
```

To provide the previous behaviour, additional methods have been added:

```
.addExposedPorts(...)
.addEnvironment(...)
```

For example:
```
.withExposedPorts(80)
.addExposedPorts(8080)

// exposedPorts = [80,8080]
```

**WHY**

This is needed so that users can override container lifecycles and set their own configuration if needed. Previously, a user could not for example overwrite the environment or exposed ports set by the module, now you can:

```ts
class PostgreSqlContainer extends GenericContainer {
  protected override async beforeContainerCreated(): Promise<void> {
    this.withExposedPorts(POSTGRES_PORT);
  }
}

class CustomPostgreSqlContainer extends PostgreSqlContainer {
  override async beforeContainerCreated() {
    this.withExposedPorts(CUSTOM_EXPOSED_PORT);
  }
}
```