### PR TITLE
DEBUG mode for single container by name

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,6 +10,7 @@ All possible environment variable configurations for Testcontainers are found he
 | DEBUG    | testcontainers            | Enable testcontainers logs |
 | DEBUG    | testcontainers:containers | Enable container logs      |
 | DEBUG    | testcontainers:exec       | Enable container exec logs |
+| DEBUG    | testcontainers:container:${container-name} | Enable logs for single container by name |
 
 Note that you can enable multiple loggers, e.g: `DEBUG=testcontainers,testcontainers:exec`.
 

--- a/src/generic-container/generic-container.ts
+++ b/src/generic-container/generic-container.ts
@@ -206,9 +206,9 @@ export class GenericContainer implements TestContainer {
     }
 
     if (containerLog.enabled()) {
-      await this.logContainer(container, containerLog, containerName);
+      await this.logContainer(container, containerLog);
     } else if (currentContainerLog?.enabled()) {
-      await this.logContainer(container, currentContainerLog, containerName);
+      await this.logContainer(container, currentContainerLog);
     }
 
     if (this.containerStarting) {
@@ -235,12 +235,10 @@ export class GenericContainer implements TestContainer {
     return startedContainer;
   }
 
-  private async logContainer(container: Dockerode.Container, logger: Logger, name?: string) {
-    const containerName = name ? `${name}, ` : "";
-
+  private async logContainer(container: Dockerode.Container, logger: Logger) {
     (await containerLogs(container))
-      .on("data", (data) => logger.trace(`${containerName}${container.id}: ${data.trim()}`))
-      .on("err", (data) => logger.error(`${containerName}${container.id}: ${data.trim()}`));
+      .on("data", (data) => logger.trace(`${container.id}: ${data.trim()}`))
+      .on("err", (data) => logger.error(`${container.id}: ${data.trim()}`));
   }
 
   /**

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -1,0 +1,11 @@
+import { createContainerLogger } from "./logger";
+import { Debugger } from "debug";
+
+describe("Logger", () => {
+  it("createContainerLogger creating DebugLogger with container namespace", () => {
+    const name = "my-api";
+    const logger = createContainerLogger(name);
+
+    expect((logger["logger"] as Debugger).namespace).toBe(`testcontainers:container:${name}`);
+  });
+});

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -75,6 +75,10 @@ export class FakeLogger implements Logger {
   }
 }
 
+export function createContainerLogger(containerName: string) {
+  return new DebugLogger(`testcontainers:container:${containerName}`);
+}
+
 export const log = new DebugLogger("testcontainers");
 export const containerLog = new DebugLogger("testcontainers:containers");
 export const execLog = new DebugLogger("testcontainers:exec");


### PR DESCRIPTION
Hello!

Made DEBUG mode for logs for single container by its name.
It is convenient if I need logs only from one container instead of logs from all containers.
Also name of container displaying before log line, so it is easier to identify container by its name instead of id.