### PR TITLE
Retry strategy should enforce timeout when operation is long running

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,5 +5,6 @@ module.exports = {
   extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended", "plugin:prettier/recommended"],
   rules: {
     "prettier/prettier": "error",
+    "no-empty": 0,
   },
 };

--- a/fixtures/docker-compose/docker-compose-with-healthcheck-with-start-period.yml
+++ b/fixtures/docker-compose/docker-compose-with-healthcheck-with-start-period.yml
@@ -9,5 +9,5 @@ services:
       test: "curl -f http://localhost:8080/hello-world || exit 1"
       interval: 1s
       timeout: 3s
-      retries: 10
+      retries: 3
       start_period: 10s

--- a/src/retry-strategy.test.ts
+++ b/src/retry-strategy.test.ts
@@ -9,7 +9,7 @@ describe("RetryStrategy", () => {
         () => fnMock(),
         (result) => result,
         () => new Error(),
-        10
+        100
       );
 
       expect(result).toEqual(true);
@@ -23,7 +23,7 @@ describe("RetryStrategy", () => {
         () => fnMock(),
         (result) => result,
         () => new Error(),
-        10
+        100
       );
 
       expect(result).toEqual(true);
@@ -38,7 +38,7 @@ describe("RetryStrategy", () => {
         () => fnMock(),
         (result) => result,
         () => timeoutMock(),
-        10
+        100
       );
 
       expect(result).toEqual(new Error());
@@ -53,7 +53,7 @@ describe("RetryStrategy", () => {
         () => slowPromise,
         (result) => result,
         () => timeoutMock(),
-        10
+        100
       );
 
       expect(timeoutMock).toHaveBeenCalledTimes(1);

--- a/src/retry-strategy.test.ts
+++ b/src/retry-strategy.test.ts
@@ -44,5 +44,19 @@ describe("RetryStrategy", () => {
       expect(result).toEqual(new Error());
       expect(timeoutMock).toHaveBeenCalledTimes(1);
     });
+
+    it("should invoke timeout handler on timeout while function is running", async () => {
+      const timeoutMock = jest.fn().mockReturnValue(new Error());
+      const slowPromise = new Promise<boolean>((resolve) => setTimeout(() => resolve(true), 10_000).unref());
+
+      await new IntervalRetryStrategy<boolean, Error>(1).retryUntil(
+        () => slowPromise,
+        (result) => result,
+        () => timeoutMock(),
+        10
+      );
+
+      expect(timeoutMock).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/retry-strategy.ts
+++ b/src/retry-strategy.ts
@@ -53,6 +53,7 @@ export class IntervalRetryStrategy<T, U> extends AbstractRetryStrategy<T, U> {
           return result;
         }
       } catch {}
+
       await this.wait(this.interval);
       return doRetry(attemptCount);
     };

--- a/src/retry-strategy.ts
+++ b/src/retry-strategy.ts
@@ -19,8 +19,8 @@ abstract class AbstractRetryStrategy<T, U> implements RetryStrategy<T, U> {
     timeout: number
   ): Promise<T | U>;
 
-  protected getTimeRemaining(startTime: Time, timeout: number): number {
-    return timeout - (this.clock.getTime() - startTime);
+  protected hasTimedOut(timeout: number, startTime: Time): boolean {
+    return this.clock.getTime() - startTime > timeout;
   }
 
   protected wait(duration: number): Promise<void> {
@@ -43,7 +43,7 @@ export class IntervalRetryStrategy<T, U> extends AbstractRetryStrategy<T, U> {
     const timeoutPromise = new Promise<T>((resolve, reject) => setTimeout(() => reject(), timeout).unref());
 
     const doRetry = async (attemptCount = 0): Promise<T | U> => {
-      if (this.getTimeRemaining(startTime, timeout) < 0) {
+      if (this.hasTimedOut(timeout, startTime)) {
         return onTimeout();
       }
 

--- a/src/retry-strategy.ts
+++ b/src/retry-strategy.ts
@@ -51,7 +51,7 @@ export class IntervalRetryStrategy<T, U> extends AbstractRetryStrategy<T, U> {
     let attemptNumber = 0;
 
     // eslint-disable-next-line no-constant-condition
-    while (true) {
+    while (!timedOut) {
       try {
         result = await Promise.race<T>([fn(attemptNumber++), timeoutPromise]);
         if (await predicate(result)) {
@@ -59,13 +59,13 @@ export class IntervalRetryStrategy<T, U> extends AbstractRetryStrategy<T, U> {
         }
       } catch {}
 
-      if (timedOut) {
-        return onTimeout();
-      }
-
       await this.wait(this.interval);
     }
 
-    return result;
+    if (!result) {
+      return onTimeout();
+    } else {
+      return result;
+    }
   }
 }

--- a/src/retry-strategy.ts
+++ b/src/retry-strategy.ts
@@ -39,6 +39,7 @@ export class IntervalRetryStrategy<T, U> extends AbstractRetryStrategy<T, U> {
     onTimeout: () => U,
     timeout: number
   ): Promise<T | U> {
+    const startTime = this.clock.getTime();
     const timeoutPromise = new Promise<T>((resolve, reject) => setTimeout(() => reject(), timeout).unref());
 
     const doRetry = async (attemptCount = 0): Promise<T | U> => {
@@ -47,7 +48,9 @@ export class IntervalRetryStrategy<T, U> extends AbstractRetryStrategy<T, U> {
         if (await predicate(result)) {
           return result;
         }
-      } catch {
+      } catch {}
+
+      if (this.hasTimedOut(timeout, startTime)) {
         return onTimeout();
       }
 

--- a/src/wait-strategy/host-port-wait-strategy.test.ts
+++ b/src/wait-strategy/host-port-wait-strategy.test.ts
@@ -22,7 +22,7 @@ describe("HostPortWaitStrategy", () => {
         .withExposedPorts(8081)
         .withStartupTimeout(0)
         .start()
-    ).rejects.toThrowError("Port 8081 not bound after 0ms");
+    ).rejects.toThrowError(/Port \d+ not bound after 0ms/);
 
     expect(await getRunningContainerNames()).not.toContain(containerName);
   });


### PR DESCRIPTION
A test which checks that the health check strategy fails when the startup timeout is zero is flaking. The interval retry strategy will execute a function, and then check if it has timed out. The issue is where executing the function takes a long time. Indeed at the moment it can far exceed the timeout.

This PR adds a timeout and races it with the function.