### PR TITLE
Update java docs domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ See [contributors](https://github.com/testcontainers/testcontainers-node/graphs/
 
 ----
 
-Join our [Slack workspace](https://slack.testcontainers.org/) | [Testcontainers OSS](https://www.testcontainers.org/) | [Testcontainers Cloud](https://www.testcontainers.cloud/)
+Join our [Slack workspace](https://slack.testcontainers.org/) | [Testcontainers OSS](https://java.testcontainers.org/) | [Testcontainers Cloud](https://www.testcontainers.cloud/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@
 
 <p style="text-align: center"><strong>Not using NodeJS? Here are other supported languages!</strong></p>
 <div class="card-grid">
-    <a href="https://testcontainers.org/" class="card-grid-item"><img src="site/language-logos/java.svg"/>Java</a>
+    <a href="https://java.testcontainers.org/" class="card-grid-item"><img src="site/language-logos/java.svg"/>Java</a>
     <a href="https://golang.testcontainers.org/" class="card-grid-item"><img src="site/language-logos/go.svg"/>Go</a>
     <a href="https://dotnet.testcontainers.org/" class="card-grid-item"><img src="site/language-logos/dotnet.svg"/>.NET</a>
     <a class="card-grid-item"><img src="site/language-logos/nodejs.svg"/>Node.js</a>
@@ -30,4 +30,4 @@ See [contributors](https://github.com/testcontainers/testcontainers-node/graphs/
 
 ---
 
-Join our [Slack workspace](https://slack.testcontainers.org/) | [Testcontainers OSS](https://www.testcontainers.org/) | [Testcontainers Cloud](https://www.testcontainers.cloud/)
+Join our [Slack workspace](https://slack.testcontainers.org/) | [Testcontainers OSS](https://java.testcontainers.org/) | [Testcontainers Cloud](https://www.testcontainers.cloud/)


### PR DESCRIPTION
The Java docs are migrating subdomain from `www` to `java`. This updates the domain of the Java docs in any links in the docs. 