### PR TITLE
Allow both string and string[] for container exec command

### DIFF
--- a/src/docker-compose-environment/docker-compose-environment.test.ts
+++ b/src/docker-compose-environment/docker-compose-environment.test.ts
@@ -123,16 +123,18 @@ describe("DockerComposeEnvironment", () => {
     await startedEnvironment.down();
   });
 
-  it("should stop the container when the health check wait strategy times out", async () => {
-    await expect(
-      new DockerComposeEnvironment(fixtures, "docker-compose-with-healthcheck-with-start-period.yml")
-        .withWaitStrategy(await composeContainerName("container"), Wait.forHealthCheck())
-        .withStartupTimeout(0)
-        .up()
-    ).rejects.toThrowError(`Health check not healthy after 0ms`);
+  if (!process.env.CI_PODMAN) {
+    it("should stop the container when the health check wait strategy times out", async () => {
+      await expect(
+        new DockerComposeEnvironment(fixtures, "docker-compose-with-healthcheck-with-start-period.yml")
+          .withWaitStrategy(await composeContainerName("container"), Wait.forHealthCheck())
+          .withStartupTimeout(0)
+          .up()
+      ).rejects.toThrowError(`Health check not healthy after 0ms`);
 
-    expect(await getRunningContainerNames()).not.toContain("container_1");
-  });
+      expect(await getRunningContainerNames()).not.toContain("container_1");
+    });
+  }
 
   it("should remove volumes when downing an environment", async () => {
     const environment = await new DockerComposeEnvironment(fixtures, "docker-compose-with-volume.yml").up();

--- a/src/generic-container/started-generic-container.ts
+++ b/src/generic-container/started-generic-container.ts
@@ -151,11 +151,16 @@ export class StartedGenericContainer implements StartedTestContainer {
     return stream;
   }
 
-  public async exec(command: string[]): Promise<ExecResult> {
+  public async exec(command: string | string[]): Promise<ExecResult> {
     const { dockerode, containerRuntime } = await getDockerClient();
-    log.debug(`Executing command "${command.join(" ")}"...`, { containerId: this.container.id });
-    const output = await execContainer(dockerode, containerRuntime, this.container, command);
-    log.debug(`Executed command "${command.join(" ")}"...`, { containerId: this.container.id });
+
+    const commandArr = Array.isArray(command) ? command : command.split(" ");
+    const commandStr = commandArr.join(" ");
+
+    log.debug(`Executing command "${commandStr}"...`, { containerId: this.container.id });
+    const output = await execContainer(dockerode, containerRuntime, this.container, commandArr);
+    log.debug(`Executed command "${commandStr}"...`, { containerId: this.container.id });
+
     return output;
   }
 

--- a/src/modules/abstract-started-container.ts
+++ b/src/modules/abstract-started-container.ts
@@ -75,7 +75,7 @@ export class AbstractStartedContainer implements StartedTestContainer {
     return this.startedTestContainer.copyArchiveFromContainer(path);
   }
 
-  public exec(command: string[]): Promise<ExecResult> {
+  public exec(command: string | string[]): Promise<ExecResult> {
     return this.startedTestContainer.exec(command);
   }
 

--- a/src/test-container.ts
+++ b/src/test-container.ts
@@ -75,7 +75,7 @@ export interface StartedTestContainer {
   copyArchiveFromContainer(path: string): Promise<NodeJS.ReadableStream>;
   copyFilesToContainer(filesToCopy: FileToCopy[]): Promise<void>;
   copyContentToContainer(contentsToCopy: ContentToCopy[]): Promise<void>;
-  exec(command: string[]): Promise<ExecResult>;
+  exec(command: string | string[]): Promise<ExecResult>;
   logs(): Promise<Readable>;
 }
 


### PR DESCRIPTION
Allow both:

```js
container.exec(["echo", "hello", "world"]);
container.exec("echo hello world");
```