### PR TITLE
Fix locations set to None in sitemap

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: Testcontainers for NodeJS
+site_url: https://node.testcontainers.org
 repo_name: 'testcontainers-node'
 repo_url: 'https://github.com/testcontainers/testcontainers-node'
 edit_uri: edit/main/docs/


### PR DESCRIPTION
Fix a bug with the documentation generating a sitemap with `<loc>None</loc>` seamingly caused by not having `site_url` set in the mkdocs config.

e.g. 
```xml
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <url>
    <loc>None</loc>
    <lastmod>2023-06-15</lastmod>
    <changefreq>daily</changefreq>
  </url>
  ...
</urlset>
```