### PR TITLE
Support copying directories to a container

### DIFF
--- a/docs/features/containers.md
+++ b/docs/features/containers.md
@@ -98,6 +98,9 @@ const container = await new GenericContainer("alpine")
   .withCopyFilesToContainer([{ 
     source: "/local/file.txt", 
     target: "/remote/file1.txt"
+  }, {
+    source: "/localdir",
+    target: "/some/nested/remotedir"
   }])
   .withCopyContentToContainer([{ 
     content: "hello world",
@@ -113,6 +116,10 @@ const container = await new GenericContainer("alpine")
   .withCopyFilesToContainer([{ 
     source: "/local/file.txt", 
     target: "/remote/file1.txt",
+    mode: parseInt("0644", 8)
+  }, {
+    source: "/localdir",
+    target: "/some/nested/remotedir",
     mode: parseInt("0644", 8)
   }])
   .withCopyContentToContainer([{ 

--- a/docs/features/containers.md
+++ b/docs/features/containers.md
@@ -91,14 +91,17 @@ const container = await new GenericContainer("alpine")
   .start();
 ```
 
-### With files/content
+### With files/directories/content
+
+Copy files/directories or content to a container before it starts:
 
 ```javascript
 const container = await new GenericContainer("alpine")
   .withCopyFilesToContainer([{ 
     source: "/local/file.txt", 
     target: "/remote/file1.txt"
-  }, {
+  }])
+  .withCopyDirectoriesToContainer([{
     source: "/localdir",
     target: "/some/nested/remotedir"
   }])
@@ -109,7 +112,7 @@ const container = await new GenericContainer("alpine")
   .start();
 ```
 
-An optional `mode` can be specified in octal:
+An optional `mode` can be specified in octal for setting file permissions:
 
 ```javascript
 const container = await new GenericContainer("alpine")
@@ -117,7 +120,8 @@ const container = await new GenericContainer("alpine")
     source: "/local/file.txt", 
     target: "/remote/file1.txt",
     mode: parseInt("0644", 8)
-  }, {
+  }])
+  .withCopyDirectoriesToContainer([{
     source: "/localdir",
     target: "/some/nested/remotedir",
     mode: parseInt("0644", 8)
@@ -135,20 +139,15 @@ const container = await new GenericContainer("alpine")
 Files and directories can be fetched from a started or stopped container as a tar archive. The archive is returned as a readable stream:
 
 ```javascript
-const container = await new GenericContainer("alpine")
-  .start();
-
+const container = await new GenericContainer("alpine").start();
 const tarArchiveStream = await container.copyArchiveFromContainer("/var/log")
 ```
 
 And when a container is stopped but not removed:
 
 ```javascript
-const container = await new GenericContainer("alpine")
-  .start();
-
+const container = await new GenericContainer("alpine").start();
 const stoppedContainer = await container.stop({ remove: false });
-
 const tarArchiveStream = await stoppedContainer.copyArchiveFromContainer("/var/log/syslog")
 ```
 

--- a/src/docker/types.ts
+++ b/src/docker/types.ts
@@ -18,6 +18,8 @@ export type FileToCopy = {
   mode?: number;
 };
 
+export type DirectoryToCopy = FileToCopy;
+
 export type Content = string | Buffer | Readable;
 
 export type ContentToCopy = {

--- a/src/generic-container/generic-container.test.ts
+++ b/src/generic-container/generic-container.test.ts
@@ -298,7 +298,7 @@ describe("GenericContainer", () => {
     const target = "/tmp";
 
     const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-      .withCopyFilesToContainer([{ source, target }])
+      .withCopyDirectoriesToContainer([{ source, target }])
       .withExposedPorts(8080)
       .start();
 
@@ -314,7 +314,7 @@ describe("GenericContainer", () => {
     const mode = parseInt("0777", 8);
 
     const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-      .withCopyFilesToContainer([{ source, target, mode }])
+      .withCopyDirectoriesToContainer([{ source, target, mode }])
       .withExposedPorts(8080)
       .start();
 

--- a/src/generic-container/generic-container.test.ts
+++ b/src/generic-container/generic-container.test.ts
@@ -293,6 +293,36 @@ describe("GenericContainer", () => {
     await container.stop();
   });
 
+  it("should copy directory to container", async () => {
+    const source = path.resolve(fixtures, "docker");
+    const target = "/tmp";
+
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+      .withCopyFilesToContainer([{ source, target }])
+      .withExposedPorts(8080)
+      .start();
+
+    expect((await container.exec("cat /tmp/test.txt")).output).toEqual(expect.stringContaining("hello world"));
+    expect((await container.exec(`stat -c "%a %n" /tmp/test.txt`)).output).toContain("644");
+
+    await container.stop();
+  });
+
+  it("should copy directory to container with permissions", async () => {
+    const source = path.resolve(fixtures, "docker");
+    const target = "/tmp/newdir";
+    const mode = parseInt("0777", 8);
+
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+      .withCopyFilesToContainer([{ source, target, mode }])
+      .withExposedPorts(8080)
+      .start();
+
+    expect((await container.exec(`stat -c "%a %n" /tmp/newdir/test.txt`)).output).toContain("777");
+
+    await container.stop();
+  });
+
   it("should copy content to container", async () => {
     const content = "hello world";
     const target = "/tmp/test.txt";

--- a/src/test-container.ts
+++ b/src/test-container.ts
@@ -5,6 +5,7 @@ import { Readable } from "stream";
 import {
   BindMount,
   ContentToCopy,
+  DirectoryToCopy,
   Environment,
   ExecResult,
   ExtraHost,
@@ -38,6 +39,7 @@ export interface TestContainer {
   withPullPolicy(pullPolicy: PullPolicy): this;
   withReuse(): this;
   withCopyFilesToContainer(filesToCopy: FileToCopy[]): this;
+  withCopyDirectoriesToContainer(directoriesToCopy: DirectoryToCopy[]): this;
   withCopyContentToContainer(contentsToCopy: ContentToCopy[]): this;
   withWorkingDir(workingDir: string): this;
   withResourcesQuota(resourcesQuota: ResourcesQuota): this;


### PR DESCRIPTION
Resolves #602.

Added a new method, `withCopyDirectoriesToContainer`.

Previously the tar archive was updated with each invocation to `withCopyFilesToContainer`/`withCopyContentToContainer`. This has been refactored so the archive is created lazily on container start as this process is now async. This is also more consistent with other container customisation methods.