### PR TITLE
Fix race condition where messages are lost between log consumers

### DIFF
--- a/src/generic-container/generic-container.ts
+++ b/src/generic-container/generic-container.ts
@@ -188,14 +188,12 @@ export class GenericContainer implements TestContainer {
     }
 
     if (containerLog.enabled() || this.logConsumer !== undefined) {
-      const logStream = await containerLogs(container);
-
       if (this.logConsumer !== undefined) {
-        this.logConsumer(logStream);
+        this.logConsumer(await containerLogs(container));
       }
 
       if (containerLog.enabled()) {
-        logStream
+        (await containerLogs(container))
           .on("data", (data) => containerLog.trace(data.trim(), { containerId: container.id }))
           .on("err", (data) => containerLog.error(data.trim(), { containerId: container.id }));
       }


### PR DESCRIPTION
When a container starts, a log stream is created. This log stream is consumed between the `DEBUG=testcontainers:containers` logger _and_ the log consumer method. If there is a delay between the creation of these 2 consumers, then the last consumer may miss messages.
