### PR TITLE
docs: troubleshooting for docker compose v2

### DIFF
--- a/docs/features/compose.md
+++ b/docs/features/compose.md
@@ -1,5 +1,7 @@
 # Compose
 
+**Note:** Compose currently uses docker-compose (v1). If you are having problems see the [Troubleshooting](#Troubleshooting) section below
+
 ## Starting a Docker compose environment
 
 Create and start a Docker Compose environment:
@@ -141,4 +143,19 @@ Interact with the containers in your compose environment as you would any other 
 
 ```javascript
 const container = environment.getContainer("alpine-1");
+```
+
+## Troubleshooting
+Compose currently uses docker-compose (v1) (see https://docs.docker.com/compose/migrate/). If you are using docker compose (v2), then a workaround is to download [docker-compose v1 standalone](https://docs.docker.com/compose/install/standalone/) and override `process.env.PATH` so it takes precedence over your local installation. Example:
+
+Download standalone version in a local folder:
+```bash
+mkdir bin
+curl -SL https://github.com/docker/compose/releases/download/v2.20.0/docker-compose-linux-x86_64 -o ./bin/docker-compose
+```
+
+Then before using DockerComposeEnvironment setup PATH:
+```javascript
+process.env.PATH=`${__dirname}/bin:${process.env.PATH}`;
+const environment = await new DockerComposeEnvironment(composeFilePath, composeFile).up();
 ```


### PR DESCRIPTION
To support v2 it'd be necessary to change https://github.com/testcontainers/testcontainers-node/blob/f3d896b8e77b7184f0c0ac28a3d1fdad7277571f/src/docker-compose/functions/docker-compose-up.ts#L2 importing v2 functions (see https://github.com/PDMLab/docker-compose#example).

It might be possible to have 2 operation modes, but this documentation should be enough for now