### PR TITLE
Fix extra backtick in docs

### DIFF
--- a/docs/features/containers.md
+++ b/docs/features/containers.md
@@ -129,7 +129,7 @@ container.copyContentToContainer([{
   content: "hello world",
   target: "/remote/file2.txt"
 }])
-````
+```
 
 An optional `mode` can be specified in octal for setting file permissions:
 


### PR DESCRIPTION
Fix issue that makes the docs render like
![image](https://github.com/testcontainers/testcontainers-node/assets/5686641/9372e015-d47f-4ab4-b9c3-28f0e6a0d397)
