### PR TITLE
Exclude test-helper from package

### DIFF
--- a/src/testcontainers/tsconfig.build.json
+++ b/src/testcontainers/tsconfig.build.json
@@ -3,6 +3,7 @@
   "exclude": [
     "build",
     "jest.config.ts",
-    "src/**/*.test.ts"
+    "src/**/*.test.ts",
+    "src/utils/test-helper.ts",
   ]
 }


### PR DESCRIPTION
Do not include a file used only for tests in the built package.
