### PR TITLE
Add support for targeting a build stage when building a Docker image

### DIFF
--- a/docs/features/images.md
+++ b/docs/features/images.md
@@ -68,8 +68,6 @@ const container = await GenericContainer
 Stop the build at a specific stage by specifying a target:
 
 ```javascript
-const { GenericContainer } = require("testcontainers");
-
 const container = await GenericContainer
   .fromDockerfile("/path/to/build-context")
   .withTarget('my-stage')

--- a/docs/features/images.md
+++ b/docs/features/images.md
@@ -14,17 +14,6 @@ const container = await GenericContainer
 const startedContainer = await container.start();
 ```
 
-If you wanted to stop the build at a specific stage, you can set the target like so:
-
-```javascript
-const { GenericContainer } = require("testcontainers");
-
-const container = await GenericContainer
-  .fromDockerfile("/path/to/build-context")
-  .withTarget('my-stage')
-  .build();
-```
-
 Images are built by default with a randomly generated name and are deleted on exit. If you wish to keep the built images between test runs, you can provide a name and specify not to delete the image:
 
 ```javascript
@@ -71,6 +60,19 @@ const container = await GenericContainer
 const container = await GenericContainer
   .fromDockerfile("/path/to/build-context")
   .withBuildArgs({ ARG: "VALUE" })
+  .build();
+```
+
+### With target
+
+Stop the build at a specific stage by specifying a target:
+
+```javascript
+const { GenericContainer } = require("testcontainers");
+
+const container = await GenericContainer
+  .fromDockerfile("/path/to/build-context")
+  .withTarget('my-stage')
   .build();
 ```
 

--- a/docs/features/images.md
+++ b/docs/features/images.md
@@ -14,6 +14,17 @@ const container = await GenericContainer
 const startedContainer = await container.start();
 ```
 
+If you wanted to stop the build at a specific stage, you can set the target like so:
+
+```javascript
+const { GenericContainer } = require("testcontainers");
+
+const container = await GenericContainer
+  .fromDockerfile("/path/to/build-context")
+  .withTarget('my-stage')
+  .build();
+```
+
 Images are built by default with a randomly generated name and are deleted on exit. If you wish to keep the built images between test runs, you can provide a name and specify not to delete the image:
 
 ```javascript

--- a/src/testcontainers/fixtures/docker/docker-multi-stage/Dockerfile
+++ b/src/testcontainers/fixtures/docker/docker-multi-stage/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:latest AS first
+
+LABEL stage=first
+
+FROM first AS second
+
+LABEL stage=second

--- a/src/testcontainers/fixtures/docker/docker-multi-stage/Dockerfile
+++ b/src/testcontainers/fixtures/docker/docker-multi-stage/Dockerfile
@@ -1,7 +1,5 @@
 FROM alpine:latest AS first
-
 LABEL stage=first
 
 FROM first AS second
-
 LABEL stage=second

--- a/src/testcontainers/src/generic-container/generic-container-builder.ts
+++ b/src/testcontainers/src/generic-container/generic-container-builder.ts
@@ -16,6 +16,7 @@ export class GenericContainerBuilder {
   private buildArgs: BuildArgs = {};
   private pullPolicy: ImagePullPolicy = PullPolicy.defaultPolicy();
   private cache = true;
+  private target?: string;
 
   constructor(
     private readonly context: string,
@@ -35,6 +36,11 @@ export class GenericContainerBuilder {
 
   public withCache(cache: boolean): this {
     this.cache = cache;
+    return this;
+  }
+
+  public withTarget(target: string): this {
+    this.target = target;
     return this;
   }
 
@@ -64,6 +70,7 @@ export class GenericContainerBuilder {
       nocache: !this.cache,
       registryconfig: registryConfig,
       labels,
+      target: this.target,
     });
 
     const container = new GenericContainer(imageName.string);

--- a/src/testcontainers/src/generic-container/generic-container.test.ts
+++ b/src/testcontainers/src/generic-container/generic-container.test.ts
@@ -434,4 +434,26 @@ describe("GenericContainer", () => {
     await expect(stopContainerPromises).resolves.not.toThrow();
     expect(await getRunningContainerNames()).not.toContain(container.getName());
   });
+
+  it("should build a target stage", async () => {
+    const context = path.resolve(fixtures, "docker-multi-stage");
+    const firstContainer = await GenericContainer.fromDockerfile(context).withTarget("first").build();
+    const secondContainer = await GenericContainer.fromDockerfile(context).withTarget("second").build();
+
+    const firstStartedContainer = await firstContainer.start();
+    const secondStartedContainer = await secondContainer.start();
+
+    expect(firstStartedContainer.getLabels().stage).toStrictEqual("first");
+    expect(secondStartedContainer.getLabels().stage).toStrictEqual("second");
+
+    await firstStartedContainer.stop();
+    await secondStartedContainer.stop();
+  });
+
+  // failing to build an image hangs within the DockerImageClient.build method,
+  // that change might be larger so leave it out of this commit but skip the failing test
+  it.skip("should throw an error for a target stage that does not exist", async () => {
+    const context = path.resolve(fixtures, "docker-multi-stage");
+    await GenericContainer.fromDockerfile(context).withTarget("invalid").build();
+  });
 });

--- a/src/testcontainers/src/generic-container/generic-container.test.ts
+++ b/src/testcontainers/src/generic-container/generic-container.test.ts
@@ -443,8 +443,8 @@ describe("GenericContainer", () => {
     const firstStartedContainer = await firstContainer.start();
     const secondStartedContainer = await secondContainer.start();
 
-    expect(firstStartedContainer.getLabels().stage).toStrictEqual("first");
-    expect(secondStartedContainer.getLabels().stage).toStrictEqual("second");
+    expect(firstStartedContainer.getLabels().stage).toEqual("first");
+    expect(secondStartedContainer.getLabels().stage).toEqual("second");
 
     await firstStartedContainer.stop();
     await secondStartedContainer.stop();


### PR DESCRIPTION
allowing a developer the ability to choose a build stage using the `withTarget` method, see [discussion here](https://github.com/testcontainers/testcontainers-node/discussions/619)

fixes [629](https://github.com/testcontainers/testcontainers-node/issues/629)