### PR TITLE
Rename Elastic Search to Elasticsearch in docs

### DIFF
--- a/docs/modules/elasticsearch.md
+++ b/docs/modules/elasticsearch.md
@@ -1,4 +1,4 @@
-# Elastic Search Module
+# Elasticsearch Module
 
 [Elasticsearch](https://www.elastic.co/elasticsearch/) is a search engine based on the Lucene library. It provides a distributed, multitenant-capable full-text search engine with an HTTP web interface and schema-free JSON documents.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,7 +41,7 @@ nav:
       - Wait strategies: features/wait-strategies.md
   - Modules:
       - ArangoDB: modules/arangodb.md
-      - Elastic Search: modules/elasticsearch.md
+      - Elasticsearch: modules/elasticsearch.md
       - HiveMQ: modules/hivemq.md
       - Kafka: modules/kafka.md
       - MongoDB: modules/mongodb.md


### PR DESCRIPTION
## What does this PR do?
It renames the occurrences of Elastic Search to Elasticsearch, in the docs and the mkdocs nav items.

## Why is it important?
Consistency with the product name :sweat_smile:
