### PR TITLE
Remove unnecessary ping of container runtime

### DIFF
--- a/packages/testcontainers/src/container-runtime/clients/client.ts
+++ b/packages/testcontainers/src/container-runtime/clients/client.ts
@@ -48,7 +48,7 @@ export async function getContainerRuntimeClient(): Promise<ContainerRuntimeClien
     try {
       log.debug(`Testing container runtime strategy "${strategy.getName()}"...`);
       const client = await initStrategy(strategy);
-      if (client && (await client.container.ping()) === "OK") {
+      if (client) {
         log.debug(`Container runtime strategy "${strategy.getName()}" works`);
         containerRuntimeClient = client;
         return client;

--- a/packages/testcontainers/src/container-runtime/clients/container/container-client.ts
+++ b/packages/testcontainers/src/container-runtime/clients/container/container-client.ts
@@ -11,7 +11,6 @@ import { ExecResult } from "./types";
 
 export interface ContainerClient {
   dockerode: Dockerode;
-  ping(): Promise<string>;
   getById(id: string): Container;
   fetchByLabel(labelName: string, labelValue: string): Promise<Container | undefined>;
   fetchArchive(container: Container, path: string): Promise<NodeJS.ReadableStream>;

--- a/packages/testcontainers/src/container-runtime/clients/container/docker-container-client.ts
+++ b/packages/testcontainers/src/container-runtime/clients/container/docker-container-client.ts
@@ -16,18 +16,6 @@ import { log, execLog, streamToString } from "../../../common";
 export class DockerContainerClient implements ContainerClient {
   constructor(public readonly dockerode: Dockerode) {}
 
-  async ping(): Promise<string> {
-    try {
-      log.debug(`Pinging container runtime...`);
-      const response = await streamToString(Readable.from(await this.dockerode.ping()));
-      log.debug(`Pinged container runtime`);
-      return response;
-    } catch (err) {
-      log.warn(`Failed to ping container runtime: "${err}"`);
-      throw err;
-    }
-  }
-
   getById(id: string): Container {
     try {
       log.debug(`Getting container by ID...`, { containerId: id });

--- a/packages/testcontainers/src/container-runtime/strategies/utils/config.ts
+++ b/packages/testcontainers/src/container-runtime/strategies/utils/config.ts
@@ -58,6 +58,8 @@ async function loadFromFile() {
     if (dockerCertPath !== null) {
       dockerClientConfig.dockerCertPath = dockerCertPath;
     }
+
+    log.debug(`Loaded ".testcontainers.properties" file`);
   }
 
   return dockerClientConfig;
@@ -89,6 +91,6 @@ function logDockerClientConfig(config: ContainerRuntimeConfig) {
     .map(([key, value]) => `${key}: "${value}"`);
 
   if (configurations.length > 0) {
-    log.debug(`Loaded ".testcontainers.properties" file, ${configurations.join(", ")}`);
+    log.debug(`Found custom configuration: ${configurations.join(", ")}`);
   }
 }


### PR DESCRIPTION
Currently we ping the container runtime after it is initialised. Initialisation involves fetching info from Docker which makes the ping unnecessary, as if fetching info worked then so will the ping. If initialising the strategy fails for any reason, the container runtime strategy is skipped, this is already the existing behaviour.
