### PR TITLE
Update `DOCKER_AUTH_CONFIG` example in docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,7 +26,7 @@ Configuration of the Docker daemon:
 | DOCKER_TLS_VERIFY  | 1                                                                  | Enable/disable TLS communication with the docker daemon                                 |
 | DOCKER_CERT_PATH   | /some/path                                                         | Configures the path to the files used for TLS verification                              |
 | DOCKER_CONFIG      | /some/path                                                         | Configures the path to the config.json file for authentication                          |
-| DOCKER_AUTH_CONFIG | `{"auths":{"https://registry.example.com":{"user":"","pass":""}}}` | JSON string representation of the config.json file, takes precedence for authentication |
+| DOCKER_AUTH_CONFIG | `{"auths":{"https://registry.example.com":{"username":"","password":""}}}` | JSON string representation of the config.json file, takes precedence for authentication |
 
 ## Testcontainers
 


### PR DESCRIPTION
Fix example for DOCKER_AUTH_CONFIG variable

According to the [code ](https://github.com/testcontainers/testcontainers-node/blob/main/packages/testcontainers/src/container-runtime/auth/types.ts#L18-L23)it is expecting `username` and `password`
