### PR TITLE
Update elasticsearch module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -638,17 +638,33 @@
       }
     },
     "node_modules/@elastic/elasticsearch": {
-      "version": "7.17.12",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-8.9.0.tgz",
+      "integrity": "sha512-UyolnzjOYTRL2966TYS3IoJP4tQbvak/pmYmbP3JdphD53RjkyVDdxMpTBv+2LcNBRrvYPTzxQbpRW/nGSXA9g==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "debug": "^4.3.1",
-        "hpagent": "^0.1.1",
-        "ms": "^2.1.3",
-        "secure-json-parse": "^2.4.0"
+        "@elastic/transport": "^8.3.2",
+        "tslib": "^2.4.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
+      }
+    },
+    "node_modules/@elastic/transport": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/@elastic/transport/-/transport-8.3.3.tgz",
+      "integrity": "sha512-g5nc//dq/RQUTMkJUB8Ui8KJa/WflWmUa7yLl4SRZd67PPxIp3cn+OvGMNIhpiLRcfz1upanzgZHb/7Po2eEdQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "hpagent": "^1.0.0",
+        "ms": "^2.1.3",
+        "secure-json-parse": "^2.4.0",
+        "tslib": "^2.4.0",
+        "undici": "^5.22.1"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3210,6 +3226,18 @@
       "license": "MIT",
       "dependencies": {
         "semver": "^7.0.0"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dev": true,
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/byline": {
@@ -6253,9 +6281,13 @@
       }
     },
     "node_modules/hpagent": {
-      "version": "0.1.2",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
       "dev": true,
-      "license": "MIT"
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -10919,8 +10951,9 @@
     },
     "node_modules/secure-json-parse": {
       "version": "2.7.0",
-      "dev": true,
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "dev": true
     },
     "node_modules/selenium-webdriver": {
       "version": "4.11.1",
@@ -11352,6 +11385,15 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/streamx": {
       "version": "2.15.0",
@@ -12090,6 +12132,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.23.0.tgz",
+      "integrity": "sha512-1D7w+fvRsqlQ9GscLBwcAJinqcZGHUKjbOmXdlE/v8BvEGXjeWAax+341q44EuTcHXXnfyKNbKRq4Lg7OzhMmg==",
+      "dev": true,
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/unique-filename": {
       "version": "3.0.0",
       "dev": true,
@@ -12664,7 +12718,7 @@
         "testcontainers": "^10.2.1"
       },
       "devDependencies": {
-        "@elastic/elasticsearch": "^7.17.12"
+        "@elastic/elasticsearch": "^8.9.0"
       }
     },
     "packages/modules/hivemq": {

--- a/packages/modules/elasticsearch/package.json
+++ b/packages/modules/elasticsearch/package.json
@@ -29,7 +29,7 @@
     "build": "tsc --project tsconfig.build.json"
   },
   "devDependencies": {
-    "@elastic/elasticsearch": "^7.17.12"
+    "@elastic/elasticsearch": "^8.9.0"
   },
   "dependencies": {
     "testcontainers": "^10.2.1"

--- a/packages/modules/elasticsearch/src/elasticsearch-container.test.ts
+++ b/packages/modules/elasticsearch/src/elasticsearch-container.test.ts
@@ -5,19 +5,19 @@ describe("ElasticsearchContainer", () => {
   jest.setTimeout(180_000);
 
   // createIndex {
-  it("should create an index", async () => {
+  it("should allow creating an index", async () => {
     const container = await new ElasticsearchContainer().start();
     const client = new Client({ node: container.getHttpUrl() });
 
     await client.indices.create({ index: "people" });
 
-    expect((await client.indices.exists({ index: "people" })).statusCode).toBe(200);
+    expect(await client.indices.exists({ index: "people" })).toEqual(true);
     await container.stop();
   });
   // }
 
   // indexDocument {
-  it("should index a document", async () => {
+  it("should allow indexing the document", async () => {
     const container = await new ElasticsearchContainer().start();
     const client = new Client({ node: container.getHttpUrl() });
 
@@ -27,11 +27,11 @@ describe("ElasticsearchContainer", () => {
     };
     await client.index({
       index: "people",
-      body: document,
+      document,
       id: document.id,
     });
 
-    expect((await client.get({ index: "people", id: document.id })).body._source).toStrictEqual(document);
+    expect((await client.get({ index: "people", id: document.id }))._source).toStrictEqual(document);
     await container.stop();
   });
   // }

--- a/packages/modules/elasticsearch/src/elasticsearch-container.ts
+++ b/packages/modules/elasticsearch/src/elasticsearch-container.ts
@@ -3,13 +3,13 @@ import { AbstractStartedContainer, GenericContainer, StartedTestContainer } from
 export const ELASTIC_SEARCH_HTTP_PORT = 9200;
 
 export class ElasticsearchContainer extends GenericContainer {
-  constructor(image = "elasticsearch:7.17.7") {
+  constructor(image = "elasticsearch:8.9.1") {
     super(image);
   }
 
   public override async start(): Promise<StartedElasticsearchContainer> {
     this.withExposedPorts(...(this.hasExposedPorts ? this.exposedPorts : [ELASTIC_SEARCH_HTTP_PORT]))
-      .withEnvironment({ "discovery.type": "single-node" })
+      .withEnvironment({ "discovery.type": "single-node", "xpack.security.enabled": "false" })
       .withCopyContentToContainer([
         {
           content: "-Xmx2G\n",

--- a/packages/modules/elasticsearch/src/elasticsearch-container.ts
+++ b/packages/modules/elasticsearch/src/elasticsearch-container.ts
@@ -1,6 +1,6 @@
 import { AbstractStartedContainer, GenericContainer, StartedTestContainer } from "testcontainers";
 
-const ELASTIC_SEARCH_HTTP_PORT = 9200;
+export const ELASTIC_SEARCH_HTTP_PORT = 9200;
 
 export class ElasticsearchContainer extends GenericContainer {
   constructor(image = "elasticsearch:7.17.7") {

--- a/packages/modules/elasticsearch/src/index.ts
+++ b/packages/modules/elasticsearch/src/index.ts
@@ -1,1 +1,5 @@
-export { ElasticsearchContainer, StartedElasticsearchContainer } from "./elasticsearch-container";
+export {
+  ELASTIC_SEARCH_HTTP_PORT,
+  ElasticsearchContainer,
+  StartedElasticsearchContainer,
+} from "./elasticsearch-container";


### PR DESCRIPTION
Hello,

Thank you for such a great tool!

I would appreciate it if you could check if the changes suggested in this PR are useful to add.

1. The useful constant `ELASTIC_SEARCH_HTTP_PORT` was exported. This change may make the interface of the @testcontainers/elasticsearch package a little more convenient. I found out that in order to allow a microservice (inside a docker container) to communicate with Elasticsearch in the other docker container, it is necessary to use port 9200, not the one published to the host.
2. I spent some time figuring out the smallest change to run the elasticsearch v8 test container. In short, it's `this.withEnvironment({ "xpack.security.enabled": "false" });` I want to share this knowledge with this PR. I can add it to the README.md instead.
3. The @elastic/elasticsearch dependency was updated to the latest version.