### PR TITLE
Add support for setting `user`, `workingDir` and `env` when executing a command in a container

### DIFF
--- a/docs/features/containers.md
+++ b/docs/features/containers.md
@@ -495,6 +495,9 @@ const container = await new GenericContainer("alpine")
 
 ## Running commands
 
+To run a command inside an already started container use the `exec` method. The command will be run in the container's 
+working directory, returning the command output and exit code:
+
 ```javascript
 const container = await new GenericContainer("alpine")
   .withCommand(["sleep", "infinity"])
@@ -502,6 +505,30 @@ const container = await new GenericContainer("alpine")
 
 const { output, exitCode } = await container.exec(["echo", "hello", "world"]);
 ```
+
+The following options can be provided to modify the command execution:
+
+1. **`user`:** The user, and optionally, group to run the exec process inside the container. Format is one of: `user`, `user:group`, `uid`, or `uid:gid`.
+
+2. **`workingDir`:** The working directory for the exec process inside the container.
+
+3. **`env`:** A map of environment variables to set inside the container.
+
+
+```javascript
+const container = await new GenericContainer("alpine")
+  .withCommand(["sleep", "infinity"])
+  .start();
+
+const { output, exitCode } = await container.exec(["echo", "hello", "world"], {
+	workingDir: "/app/src/",
+	user: "1000:1000",
+	env: {
+		"VAR1": "enabled",
+		"VAR2": "/app/debug.log",
+	}
+});
+````
 
 ## Streaming logs
 

--- a/packages/testcontainers/src/container-runtime/clients/container/container-client.ts
+++ b/packages/testcontainers/src/container-runtime/clients/container/container-client.ts
@@ -7,7 +7,7 @@ import Dockerode, {
   Network,
 } from "dockerode";
 import { Readable } from "stream";
-import { ExecResult } from "./types";
+import { ExecOptions, ExecResult } from "./types";
 
 export interface ContainerClient {
   dockerode: Dockerode;
@@ -22,7 +22,7 @@ export interface ContainerClient {
   stop(container: Container, opts?: { timeout: number }): Promise<void>;
   attach(container: Container): Promise<Readable>;
   logs(container: Container, opts?: ContainerLogsOptions): Promise<Readable>;
-  exec(container: Container, command: string[], opts?: { log: boolean }): Promise<ExecResult>;
+  exec(container: Container, command: string[], opts?: Partial<ExecOptions>): Promise<ExecResult>;
   restart(container: Container, opts?: { timeout: number }): Promise<void>;
   remove(container: Container, opts?: { removeVolumes: boolean }): Promise<void>;
   connectToNetwork(container: Container, network: Network, networkAliases: string[]): Promise<void>;

--- a/packages/testcontainers/src/container-runtime/clients/container/types.ts
+++ b/packages/testcontainers/src/container-runtime/clients/container/types.ts
@@ -1,1 +1,5 @@
+export type Environment = { [key in string]: string };
+
+export type ExecOptions = { workingDir: string; user: string; env: Environment; log: boolean };
+
 export type ExecResult = { output: string; exitCode: number };

--- a/packages/testcontainers/src/generic-container/abstract-started-container.ts
+++ b/packages/testcontainers/src/generic-container/abstract-started-container.ts
@@ -1,5 +1,5 @@
 import { RestartOptions, StartedTestContainer, StopOptions, StoppedTestContainer } from "../test-container";
-import { ContentToCopy, DirectoryToCopy, ExecResult, FileToCopy, Labels } from "../types";
+import { ContentToCopy, DirectoryToCopy, ExecOptions, ExecResult, FileToCopy, Labels } from "../types";
 import { Readable } from "stream";
 
 export class AbstractStartedContainer implements StartedTestContainer {
@@ -79,8 +79,8 @@ export class AbstractStartedContainer implements StartedTestContainer {
     return this.startedTestContainer.copyArchiveFromContainer(path);
   }
 
-  public exec(command: string | string[]): Promise<ExecResult> {
-    return this.startedTestContainer.exec(command);
+  public exec(command: string | string[], opts?: Partial<ExecOptions>): Promise<ExecResult> {
+    return this.startedTestContainer.exec(command, opts);
   }
 
   public logs(): Promise<Readable> {

--- a/packages/testcontainers/src/generic-container/generic-container.test.ts
+++ b/packages/testcontainers/src/generic-container/generic-container.test.ts
@@ -51,6 +51,40 @@ describe("GenericContainer", () => {
     await container.stop();
   });
 
+  it("should execute a command in a different working directory", async () => {
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14").withExposedPorts(8080).start();
+
+    const { output, exitCode } = await container.exec(["pwd"], { workingDir: "/var/log" });
+
+    expect(exitCode).toBe(0);
+    expect(output).toEqual(expect.stringContaining("/var/log"));
+
+    await container.stop();
+  });
+
+  it("should execute a command with custom environment variables", async () => {
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14").withExposedPorts(8080).start();
+
+    const { output, exitCode } = await container.exec(["env"], { env: { TEST_ENV: "test" } });
+
+    expect(exitCode).toBe(0);
+    expect(output).toEqual(expect.stringContaining("TEST_ENV=test"));
+
+    await container.stop();
+  });
+
+  it("should execute a command with a different user", async () => {
+    // By default, node:alpine runs as root
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14").withExposedPorts(8080).start();
+
+    const { output, exitCode } = await container.exec("whoami", { user: "node" });
+
+    expect(exitCode).toBe(0);
+    expect(output).toEqual(expect.stringContaining("node"));
+
+    await container.stop();
+  });
+
   it("should set environment variables", async () => {
     const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
       .withEnvironment({ customKey: "customValue" })

--- a/packages/testcontainers/src/generic-container/started-generic-container.ts
+++ b/packages/testcontainers/src/generic-container/started-generic-container.ts
@@ -1,6 +1,6 @@
 import { RestartOptions, StartedTestContainer, StopOptions, StoppedTestContainer } from "../test-container";
 import Dockerode, { ContainerInspectInfo } from "dockerode";
-import { ContentToCopy, DirectoryToCopy, ExecResult, FileToCopy, Labels } from "../types";
+import { ContentToCopy, DirectoryToCopy, ExecOptions, ExecResult, FileToCopy, Labels } from "../types";
 import { Readable } from "stream";
 import { StoppedGenericContainer } from "./stopped-generic-container";
 import { WaitStrategy } from "../wait-strategies/wait-strategy";
@@ -170,12 +170,12 @@ export class StartedGenericContainer implements StartedTestContainer {
     return stream;
   }
 
-  public async exec(command: string | string[]): Promise<ExecResult> {
+  public async exec(command: string | string[], opts?: Partial<ExecOptions>): Promise<ExecResult> {
     const commandArr = Array.isArray(command) ? command : command.split(" ");
     const commandStr = commandArr.join(" ");
     const client = await getContainerRuntimeClient();
     log.debug(`Executing command "${commandStr}"...`, { containerId: this.container.id });
-    const output = await client.container.exec(this.container, commandArr);
+    const output = await client.container.exec(this.container, commandArr, opts);
     log.debug(`Executed command "${commandStr}"...`, { containerId: this.container.id });
 
     return output;

--- a/packages/testcontainers/src/index.ts
+++ b/packages/testcontainers/src/index.ts
@@ -19,7 +19,7 @@ export { Network, StartedNetwork, StoppedNetwork } from "./network/network";
 export { Wait } from "./wait-strategies/wait";
 export { StartupCheckStrategy, StartupStatus } from "./wait-strategies/startup-check-strategy";
 export { PullPolicy, ImagePullPolicy } from "./utils/pull-policy";
-export { InspectResult, Content, ExecResult } from "./types";
+export { InspectResult, Content, ExecOptions, ExecResult } from "./types";
 
 export { AbstractStartedContainer } from "./generic-container/abstract-started-container";
 export { AbstractStoppedContainer } from "./generic-container/abstract-stopped-container";

--- a/packages/testcontainers/src/test-container.ts
+++ b/packages/testcontainers/src/test-container.ts
@@ -5,6 +5,7 @@ import {
   ContentToCopy,
   DirectoryToCopy,
   Environment,
+  ExecOptions,
   ExecResult,
   ExtraHost,
   FileToCopy,
@@ -73,7 +74,7 @@ export interface StartedTestContainer {
   copyDirectoriesToContainer(directoriesToCopy: DirectoryToCopy[]): Promise<void>;
   copyFilesToContainer(filesToCopy: FileToCopy[]): Promise<void>;
   copyContentToContainer(contentsToCopy: ContentToCopy[]): Promise<void>;
-  exec(command: string | string[]): Promise<ExecResult>;
+  exec(command: string | string[], opts?: Partial<ExecOptions>): Promise<ExecResult>;
   logs(): Promise<Readable>;
 }
 

--- a/packages/testcontainers/src/types.ts
+++ b/packages/testcontainers/src/types.ts
@@ -81,6 +81,8 @@ export type RegistryConfig = {
 
 export type BuildArgs = { [key in string]: string };
 
+export type ExecOptions = { workingDir: string; user: string; env: Environment };
+
 export type ExecResult = { output: string; exitCode: number };
 
 export type HealthCheckStatus = "none" | "starting" | "unhealthy" | "healthy";


### PR DESCRIPTION
This pull request introduces support for specifying `User`, `WorkingDir`, and `Env` options during container execution in both Docker ([API docs](https://docs.docker.com/engine/api/v1.43/#tag/Exec)) and Podman ([API docs](https://docs.podman.io/en/latest/_static/api.html#tag/exec-(compat))), enhancing customization.

#### Changes:

Added support to `StartedTestContainer.exec(command, opts)` function to provide the following options:

1. **`user`:**
   - Users can set the user, and optionally, group to run the exec process inside the container. Format is one of: `user`, `user:group`, `uid`, or `uid:gid`.

2. **`workingDir`:**
   - The `WorkingDir` option allows users to define the working directory for the exec process inside the container.

3. **`env`:**
   - Users can now include the `Env` option when executing commands, allowing for environment variable customization.


#### Example:

```Typescript
const container = await new GenericContainer("alpine")
  .withCommand(["sleep", "infinity"])
  .start();

const { output, exitCode } = await container.exec(["echo", "hello", "world"], {
	workingDir: "/app/src/",
	user: "alpine",
	env: {
		"VAR1": "enabled",
		"VAR2": "full",
	}
});
```

---

Your feedback and testing contributions are appreciated.