### PR TITLE
Add support for building a container from context archive

### DIFF
--- a/docs/features/images.md
+++ b/docs/features/images.md
@@ -90,3 +90,27 @@ const container = await GenericContainer
   .withCache(false)
   .build();
 ```
+
+### Dynamic build context
+
+If you would like to send a build context that you created in code (maybe you have a dynamic Dockerfile), you can send 
+the build context as a `NodeJS.ReadableStream` since the Docker Daemon accepts it as a _tar_ file. You can use the 
+[tar-fs](https://www.npmjs.com/package/tar-fs) (or [tar-stream](https://www.npmjs.com/package/tar-stream)) package to 
+create a custom dynamic context.
+
+```javascript
+const tar = require('tar-stream');
+
+const tarStream = tar.pack();
+tarStream.entry({ name: 'alpine.Dockerfile' }, 
+  `
+    FROM alpine:latest
+    CMD ["sleep", "infinity"]
+  `
+);
+tarStream.finalize();
+
+const container = await GenericContainer
+  .fromContextArchive(tarStream, 'alpine.Dockerfile')
+  .build();
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -2240,9 +2240,10 @@
       }
     },
     "node_modules/@types/tar-stream": {
-      "version": "2.2.2",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/tar-stream/-/tar-stream-3.1.3.tgz",
+      "integrity": "sha512-Zbnx4wpkWBMBSu5CytMbrT5ZpMiF55qgM+EpHzR4yIDu7mv52cej8hTkOc6K+LzpkOAbxwn/m7j3iO+/l42YkQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -12083,7 +12084,8 @@
     },
     "node_modules/tar-stream": {
       "version": "3.1.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
+      "integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
       "dependencies": {
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
@@ -13173,7 +13175,9 @@
         "@types/proper-lockfile": "^4.1.3",
         "@types/properties-reader": "^2.1.2",
         "@types/tar-fs": "^2.0.3",
-        "@types/tmp": "^0.2.5"
+        "@types/tar-stream": "^3.1.3",
+        "@types/tmp": "^0.2.5",
+        "tar-stream": "^3.1.6"
       }
     }
   }

--- a/packages/testcontainers/package.json
+++ b/packages/testcontainers/package.json
@@ -55,6 +55,8 @@
     "@types/proper-lockfile": "^4.1.3",
     "@types/properties-reader": "^2.1.2",
     "@types/tar-fs": "^2.0.3",
-    "@types/tmp": "^0.2.5"
+    "@types/tar-stream": "^3.1.3",
+    "@types/tmp": "^0.2.5",
+    "tar-stream": "^3.1.6"
   }
 }

--- a/packages/testcontainers/src/container-runtime/clients/image/image-client.ts
+++ b/packages/testcontainers/src/container-runtime/clients/image/image-client.ts
@@ -2,7 +2,7 @@ import { ImageBuildOptions } from "dockerode";
 import { ImageName } from "../../image-name";
 
 export interface ImageClient {
-  build(context: string, opts: ImageBuildOptions): Promise<void>;
+  build(context: NodeJS.ReadableStream, opts: ImageBuildOptions): Promise<void>;
   pull(imageName: ImageName, opts?: { force: boolean }): Promise<void>;
   exists(imageName: ImageName): Promise<boolean>;
 }

--- a/packages/testcontainers/src/generic-container/generic-container.ts
+++ b/packages/testcontainers/src/generic-container/generic-container.ts
@@ -36,7 +36,26 @@ import { mapInspectResult } from "../utils/map-inspect-result";
 const reusableContainerCreationLock = new AsyncLock();
 
 export class GenericContainer implements TestContainer {
+  /**
+   * Create a docker image from a Dockerfile.
+   *
+   * @param context - The build context directory path.
+   * @param dockerfileName - The name of the Dockerfile. Default is `Dockerfile`.
+   */
   public static fromDockerfile(context: string, dockerfileName = "Dockerfile"): GenericContainerBuilder {
+    return new GenericContainerBuilder(context, dockerfileName);
+  }
+
+  /**
+   * Create a docker image from a context archive stream.
+   *
+   * @param context - The build context archive stream.
+   * @param dockerfileName - The name of the Dockerfile. Default is `Dockerfile`.
+   */
+  public static fromContextArchive(
+    context: NodeJS.ReadableStream,
+    dockerfileName = "Dockerfile"
+  ): GenericContainerBuilder {
     return new GenericContainerBuilder(context, dockerfileName);
   }
 


### PR DESCRIPTION
This PR adds support for building a container image from a tar archive stream (i.e., `NodeJs.ReadableStream`). 

> **Note**
> This functionality is already existing in _testcontainers-go_: [dynamic-build-context](https://golang.testcontainers.org/features/build_from_dockerfile/#dynamic-build-context)

This covers the case where one wants to programmatically create a dynamic `Dockerfile` and context (e.g., using a template engine) without the overhead of writing to disk.

```javascript
const tar = require('tar-stream');

const tarStream = tar.pack();
tarStream.entry({ name: 'alpine.Dockerfile' }, 
  `
    FROM alpine:latest
    CMD ["sleep", "infinity"]
  `
);
tarStream.finalize();

const container = await GenericContainer
  .fromContextArchive(tarStream, 'alpine.Dockerfile')
  .build();
```
