### PR TITLE
Retire Node 16 (End-of-life) from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         runner: [ ubuntu-22.04 ]
-        node-version: [ 16.x, 18.x, 20.x ]
+        node-version: [ 18.x, 20.x ]
     steps:
       - name: Code checkout
         uses: actions/checkout@v3
@@ -49,7 +49,7 @@ jobs:
     needs: smoke-test
     strategy:
       matrix:
-        node-version: [ 16.x, 18.x, 20.x ]
+        node-version: [ 18.x, 20.x ]
         container-runtime: [ docker, docker-rootless, podman ]
         include:
           - container-runtime: docker
@@ -70,7 +70,7 @@ jobs:
     needs: test-testcontainers
     strategy:
       matrix:
-        node-version: [ 16.x, 18.x, 20.x ]
+        node-version: [ 18.x, 20.x ]
         container-runtime: [ docker, docker-rootless, podman ]
         include:
           - container-runtime: docker


### PR DESCRIPTION
### Context

Node 16 is End-of-life since September 11th, 2023 (see [EOL statement](https://nodejs.org/en/blog/announcements/nodejs16-eol)).

![schedule](https://github.com/testcontainers/testcontainers-node/assets/3949095/0ac0ead5-e157-44bf-b5c4-366bf2c410a0)
<sup>Source: https://nodejs.org/en/about/previous-releases#release-schedule</sup>

Based on the diagram above, the only LTS versions are **Node 18** and **Node 20**.

### Changes description

- [x] Remove Node 16.x from the GitHub actions CI's test matrix.