### PR TITLE
Fix CI's podman apt-get repo url

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Podman setup
         if: ${{ inputs.container-runtime == 'podman' }}
         run: |
-          curl -fsSL https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_$(lsb_release -rs)/Release.key | gpg --dearmor | sudo tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg > /dev/null
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg] https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_$(lsb_release -rs)/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null
+          curl -fsSL "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_$(lsb_release -rs)/Release.key" | gpg --dearmor | sudo tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg > /dev/null
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg] https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_$(lsb_release -rs)/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null
           sudo apt-get update
           sudo apt-get -y install podman
           systemctl enable --now --user podman podman.socket


### PR DESCRIPTION
This PR fixes the CI issue related to the podman package installation step.

### Context

The CI test job has consistently failed with a 404 error in the _Podman setup_ step.

```console
[...]
Ign:35 https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_22.04  InRelease
Err:36 https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_22.04  Release
  Redirection from https to 'http://download.opensuse.org/repositories/devel:kubic:libcontainers:/unstable/xUbuntu_22.04/Release' is forbidden [IP: 195.135.223.226 443]
Reading package lists...
E: The repository 'https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_22.04  Release' does not have a Release file.
Error: Process completed with exit code 100.

```

Issuing a GET request to that endpoint reveals that the path has changed (and the podman documentation has not been updated accordingly).

```bash
curl -fsSL -kv https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_22.04/Release  
```

Multiple redirections (301 Moved permanently) happen before the final URL is queried:

```console
[...]
* Ignoring the response-body
* Connection #1 to host download.opensuse.org left intact
* Issue another request to this URL: 'http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_22.04/Release'
* Found bundle for host: 0x5589f0eef300 [serially]
* Can not multiplex, even if we wanted to
* Re-using existing connection with host download.opensuse.org
> GET /repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_22.04/Release HTTP/1.1
> Host: download.opensuse.org
> User-Agent: curl/8.4.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< date: Wed, 15 Nov 2023 15:49:46 GMT
< server: Mojolicious (Perl)
< cache-control: public, max-age=101
< content-disposition: inline;filename="Release"
< content-length: 732
< content-type: application/x-download;name="Release"
< 
[...]
```

So, the new URL should contain `/` after the `:`:

```
http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_22.04/Release
```