### PR TITLE
fix(testcontainers): new port-forwarder container per test file execution

### DIFF
--- a/packages/testcontainers/src/port-forwarder/port-forwarder.ts
+++ b/packages/testcontainers/src/port-forwarder/port-forwarder.ts
@@ -3,7 +3,6 @@ import { GenericContainer } from "../generic-container/generic-container";
 import { StartedTestContainer } from "../test-container";
 import { log, RandomUuid } from "../common";
 import { getContainerRuntimeClient } from "../container-runtime";
-import { getReaper } from "../reaper/reaper";
 import { PortWithOptionalBinding } from "../utils/port";
 
 export const SSHD_IMAGE = process.env["SSHD_CONTAINER_IMAGE"] ?? "testcontainers/sshd:1.1.0";
@@ -46,9 +45,7 @@ export class PortForwarderInstance {
 
   private static async createInstance(): Promise<PortForwarder> {
     log.debug(`Creating new Port Forwarder...`);
-
     const client = await getContainerRuntimeClient();
-    const reaper = await getReaper(client);
 
     const username = "root";
     const password = new RandomUuid().nextUuid();
@@ -57,8 +54,9 @@ export class PortForwarderInstance {
       ? { container: 22, host: Number(process.env["TESTCONTAINERS_SSHD_PORT"]) }
       : 22;
 
+    const portForwarderId = new RandomUuid().nextUuid();
     const container = await new GenericContainer(SSHD_IMAGE)
-      .withName(`testcontainers-port-forwarder-${reaper.sessionId}`)
+      .withName(`testcontainers-port-forwarder-${portForwarderId}`)
       .withExposedPorts(containerPort)
       .withEnvironment({ PASSWORD: password })
       .withCommand([


### PR DESCRIPTION
## Context

From Jest documentation:

![image](https://github.com/testcontainers/testcontainers-node/assets/3949095/7c4418f5-6ab3-40c8-8184-2a2fba353d3e)

<sup>Source: https://jestjs.io/docs/configuration#resetmodules-boolean</sup>

Since each test file gets its independent module registry (i.e., independent "static" JS module state), the `PortForwarderInstance.instance` singleton field is `undefined` when a test file starts the execution. This causes the `PortForwarderInstance` class to believe that no other port-forwarder container is running and tries to start a new one with the same name.

## Proposed solution

> [!NOTE]
> This PR fixes the limitation found in #677 

A sub-optimal but working solution is to spin up a port-forwarder container per test file with a unique random name. This avoids the container name clash issue reported in #677.

