### PR TITLE
Export `@types/dockerode` as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2070,7 +2070,6 @@
     },
     "node_modules/@types/docker-modem": {
       "version": "3.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -2081,7 +2080,6 @@
       "version": "3.3.21",
       "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.21.tgz",
       "integrity": "sha512-1d4GSWFpOnqu2rbpz+YR97txVVouHE4/HJm7CU9JTCs/IigNO8AhVOYh+6Rqv/IRznUycMR4MVBnTHrf39Es7g==",
-      "dev": true,
       "dependencies": {
         "@types/docker-modem": "*",
         "@types/node": "*"
@@ -13149,6 +13147,7 @@
       "license": "MIT",
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",
+        "@types/dockerode": "^3.3.21",
         "archiver": "^5.3.2",
         "async-lock": "^1.4.0",
         "byline": "^5.0.0",
@@ -13168,7 +13167,6 @@
         "@types/async-lock": "^1.4.1",
         "@types/byline": "^4.2.35",
         "@types/debug": "^4.1.10",
-        "@types/dockerode": "^3.3.21",
         "@types/node-fetch": "^2.6.7",
         "@types/proper-lockfile": "^4.1.3",
         "@types/properties-reader": "^2.1.2",

--- a/packages/testcontainers/package.json
+++ b/packages/testcontainers/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@balena/dockerignore": "^1.0.2",
+    "@types/dockerode": "^3.3.21",
     "archiver": "^5.3.2",
     "async-lock": "^1.4.0",
     "byline": "^5.0.0",
@@ -50,7 +51,6 @@
     "@types/async-lock": "^1.4.1",
     "@types/byline": "^4.2.35",
     "@types/debug": "^4.1.10",
-    "@types/dockerode": "^3.3.21",
     "@types/node-fetch": "^2.6.7",
     "@types/proper-lockfile": "^4.1.3",
     "@types/properties-reader": "^2.1.2",


### PR DESCRIPTION
Regression of #77 in https://github.com/testcontainers/testcontainers-node/commit/c97e2942f047814a5d80835402cf2fcf3d944913. Resolves #667 