### PR TITLE
Switch docker compose defaults from v1 to v2

### DIFF
--- a/packages/testcontainers/src/container-runtime/clients/compose/compose-client.ts
+++ b/packages/testcontainers/src/container-runtime/clients/compose/compose-client.ts
@@ -29,14 +29,14 @@ export async function getComposeClient(environment: NodeJS.ProcessEnv): Promise<
 async function getComposeInfo(): Promise<ComposeInfo | undefined> {
   try {
     return {
-      version: (await dockerComposeV1.version()).data.version,
-      compatability: "v1",
+      version: (await dockerComposeV2.version()).data.version,
+      compatability: "v2",
     };
   } catch (err) {
     try {
       return {
-        version: (await dockerComposeV2.version()).data.version,
-        compatability: "v2",
+        version: (await dockerComposeV1.version()).data.version,
+        compatability: "v1",
       };
     } catch {
       return undefined;


### PR DESCRIPTION
Initial work to fix [the issue mentioned here](https://github.com/testcontainers/testcontainers-node/issues/659).
Since V1 is deprecated, testcontainers should probably default to V2. could probably override the defaults if we pass it through the process env but not sure if its the right way. 
couldn't find related tests that failed because of this change or documentation related change needed.. @cristianrgreco can you help with the review / guide me on further changes?