### PR TITLE
feat(testcontainers): get existing network by id or name

### DIFF
--- a/packages/modules/selenium/src/selenium-container.ts
+++ b/packages/modules/selenium/src/selenium-container.ts
@@ -8,7 +8,7 @@ import {
   GenericContainer,
   log,
   Network,
-  StartedNetwork,
+  StoppableNetwork,
   StartedTestContainer,
   StopOptions,
   StoppedTestContainer,
@@ -76,10 +76,6 @@ export class StoppedSeleniumContainer extends AbstractStoppedContainer {
 }
 
 export class SeleniumRecordingContainer extends SeleniumContainer {
-  constructor(image: string) {
-    super(image);
-  }
-
   public override async start(): Promise<StartedSeleniumRecordingContainer> {
     const network = await new Network().start();
     this.withNetwork(network);
@@ -101,7 +97,7 @@ export class StartedSeleniumRecordingContainer extends StartedSeleniumContainer 
   constructor(
     startedSeleniumContainer: StartedTestContainer,
     private readonly startedFfmpegContainer: StartedTestContainer,
-    private readonly network: StartedNetwork
+    private readonly network: StoppableNetwork
   ) {
     super(startedSeleniumContainer);
   }

--- a/packages/testcontainers/src/index.ts
+++ b/packages/testcontainers/src/index.ts
@@ -16,7 +16,13 @@ export { StartedDockerComposeEnvironment } from "./docker-compose-environment/st
 export { StoppedDockerComposeEnvironment } from "./docker-compose-environment/stopped-docker-compose-environment";
 export { DownedDockerComposeEnvironment } from "./docker-compose-environment/downed-docker-compose-environment";
 
-export { Network, StartedNetwork, StoppedNetwork } from "./network/network";
+export {
+  Network,
+  StartedBridgeNetwork,
+  StoppableNetwork,
+  StartedNetwork,
+  StartedExistingNetwork,
+} from "./network/network";
 
 export { Wait } from "./wait-strategies/wait";
 export { StartupCheckStrategy, StartupStatus } from "./wait-strategies/startup-check-strategy";

--- a/packages/testcontainers/src/network/network.test.ts
+++ b/packages/testcontainers/src/network/network.test.ts
@@ -11,6 +11,51 @@ describe("Network", () => {
     client = await getContainerRuntimeClient();
   });
 
+  it("should create a network and retrieve it by id", async () => {
+    //// Given
+    const preexistingNetwork = await new Network().start();
+    const preexistingNetworkName = preexistingNetwork.getName();
+    const preexistingNetworkId = preexistingNetwork.getId();
+
+    //// When
+    const network = await Network.getNetwork(preexistingNetworkId);
+
+    //// Then
+    expect(network.getName()).toEqual(preexistingNetworkName);
+    expect(network.getId()).toEqual(preexistingNetworkId);
+
+    //// Cleanup
+    await preexistingNetwork.stop();
+  });
+
+  it("should create a network and retrieve it by name", async () => {
+    //// Given
+    const preexistingNetwork = await new Network().start();
+    const preexistingNetworkName = preexistingNetwork.getName();
+    const preexistingNetworkId = preexistingNetwork.getId();
+
+    //// When
+    const network = await Network.getNetwork(preexistingNetworkName);
+
+    //// Then
+    expect(network.getName()).toEqual(preexistingNetworkName);
+    expect(network.getId()).toEqual(preexistingNetworkId);
+
+    //// Cleanup
+    await preexistingNetwork.stop();
+  });
+
+  it("should fail if network does not exist", async () => {
+    //// Given
+    const networkId = "non-existing-network-asdfghkl";
+
+    //// When
+    const network = Network.getNetwork(networkId);
+
+    //// Then
+    await expect(network).rejects.toThrow(/no such network/);
+  });
+
   it("should start container via network mode", async () => {
     const network = await new Network().start();
 

--- a/packages/testcontainers/src/network/network.ts
+++ b/packages/testcontainers/src/network/network.ts
@@ -1,24 +1,83 @@
 import Dockerode from "dockerode";
-import { log, RandomUuid, Uuid } from "../common";
+import { log, RandomUuid } from "../common";
 import { ContainerRuntimeClient, getContainerRuntimeClient } from "../container-runtime";
 import { getReaper } from "../reaper/reaper";
 import { createLabels, LABEL_TESTCONTAINERS_SESSION_ID } from "../utils/labels";
 
+/**
+ * Networks are user-defined networks that containers can be attached to.
+ *
+ * Use:
+ *  - {@link Network.constructor} and {@link Network.start} to create and start a new network instance.
+ *  - {@link Network.getNetwork} to get an already started network instance.
+ *
+ *    @example Using the {@link Network} constructor
+ *    ```ts
+ *    const network = new Network();
+ *    const startedNetwork = await network.start();
+ *    ```
+ *
+ *    @example Using the {@link Network.getNetwork} static method
+ *    ```ts
+ *    const startedNetwork = await Network.getNetwork("my-network");
+ *    ```
+ *
+ * See Docker's {@link https://docs.docker.com/network|networking documentation} for more information.
+ */
 export class Network {
-  constructor(private readonly uuid: Uuid = new RandomUuid()) {}
+  /**
+   * Get an already started network by _Network ID_ (or by _name_).
+   *
+   * The network must be started before it can be fetched. If the network does not exist, an error is thrown.
+   *
+   * @param id - _Network ID_ (or _name_) of the network to get.
+   * @returns A new network instance.
+   */
+  public static async getNetwork(id: string): Promise<StartedExistingNetwork> {
+    const client = await getContainerRuntimeClient();
+    const network = client.network.getById(id);
 
-  public async start(): Promise<StartedNetwork> {
+    // Fetch the network details to get the name actual name of the network.
+    // As an existing network can be fetched by _Network ID_ or by _name_, we
+    // need to get the name of the network. This might be redundant if the
+    // network was fetched by name, but it is needed if the network was fetched
+    // by ID.
+    const networkDetails: Dockerode.NetworkInspectInfo = await network.inspect();
+
+    return new StartedExistingNetwork(client, networkDetails.Id, networkDetails.Name, network);
+  }
+
+  /**
+   * Create a new network instance.
+   *
+   * The new network will be named using a random UUID to avoid name collisions and the following settings:
+   *
+   *  - **Driver**: `bridge`
+   *  - **Internal**: `false` (external access to the network is allowed).
+   *
+   * The network is not created until {@link start} is called. Once the network is started, it can be stopped
+   * by calling {@link stop}.
+   *
+   * The created network will be automatically removed from the container runtime by testcontainers' reaper.
+   */
+  constructor(private readonly name: string = new RandomUuid().nextUuid()) {}
+
+  /**
+   * Start the network.
+   *
+   * This method creates the network in the container runtime.
+   */
+  public async start(): Promise<StartedBridgeNetwork> {
     const client = await getContainerRuntimeClient();
     const reaper = await getReaper(client);
 
-    const name = this.uuid.nextUuid();
-    log.info(`Starting network "${name}"...`);
+    log.info(`Starting network "${this.name}"...`);
 
     const labels = createLabels();
     labels[LABEL_TESTCONTAINERS_SESSION_ID] = reaper.sessionId;
 
     const network = await client.network.create({
-      Name: name,
+      Name: this.name,
       CheckDuplicate: true,
       Driver: "bridge",
       Internal: false,
@@ -27,33 +86,124 @@ export class Network {
       EnableIPv6: false,
       Labels: labels,
     });
-    log.info(`Started network "${name}" with ID "${network.id}"`);
+    log.info(`Started network "${this.name}" with ID "${network.id}"`);
 
-    return new StartedNetwork(client, name, network);
+    return new StartedBridgeNetwork(client, network.id, this.name, network);
   }
 }
 
-export class StartedNetwork {
+/**
+ * A started network.
+ */
+export interface StartedNetwork {
+  getId(): string;
+
+  getName(): string;
+}
+
+/**
+ * A started network that can be stopped.
+ */
+export interface StoppableNetwork {
+  stop(): Promise<void>;
+}
+
+/**
+ * A started bridge network.
+ *
+ * This class is not intended to be instantiated directly. Instead, use:
+ *  - {@link Network.constructor} and {@link Network.start} to create and start a new network instance.
+ *  - {@link Network.getNetwork} to get an already started network instance.
+ *
+ *    @example Using the {@link Network} constructor
+ *    ```ts
+ *    const network = new Network();
+ *    const startedNetwork = await network.start();
+ *    ```
+ *
+ *    @example Using the {@link Network.getNetwork} static method
+ *    ```ts
+ *    const startedNetwork = await Network.getNetwork("my-network");
+ *    ```
+ *
+ * A started network can be stopped (i.e., removed from the container runtime) by calling {@link stop}.
+ */
+export class StartedBridgeNetwork implements StartedNetwork, StoppableNetwork {
   constructor(
     private readonly client: ContainerRuntimeClient,
+    private readonly id: string,
     private readonly name: string,
     private readonly network: Dockerode.Network
   ) {}
 
+  /**
+   * Get the ID of the network.
+   *
+   * @returns The ID of the network.
+   */
   public getId(): string {
-    return this.network.id;
+    return this.id;
   }
 
+  /**
+   * Get the name of the network.
+   *
+   * @returns The name of the network.
+   */
   public getName(): string {
     return this.name;
   }
 
-  public async stop(): Promise<StoppedNetwork> {
-    log.info(`Stopping network with ID "${this.network.id}"...`);
+  /**
+   * Stop the network.
+   *
+   * This method removes the network from the container runtime.
+   *
+   * @returns A promise that resolves when the network has been stopped.
+   */
+  public async stop(): Promise<void> {
+    log.info(`Stopping network with ID "${this.id}"...`);
     await this.client.network.remove(this.network);
-    log.info(`Stopped network with ID "${this.network.id}"`);
-    return new StoppedNetwork();
+    log.info(`Stopped network with ID "${this.id}"`);
   }
 }
 
-export class StoppedNetwork {}
+/**
+ * A started network that already existed in the container runtime.
+ *
+ * This class is not intended to be instantiated directly. Instead, use {@link Network.getNetwork} to get an already
+ * started network instance by _Network ID_ (or by _name_).
+ *
+ *    @example Using the {@link Network.getNetwork} static method
+ *    ```ts
+ *    const startedNetwork = await Network.getNetwork("my-network");
+ *    ```
+ *
+ * To avoid interfering with existing networks, a `StartedExistingNetwork` instance cannot be stopped.
+ */
+export class StartedExistingNetwork implements StartedNetwork {
+  constructor(
+    private readonly client: ContainerRuntimeClient,
+    private readonly id: string,
+    private readonly name: string,
+    private readonly network: Dockerode.Network
+  ) {}
+
+  /**
+   * Get the ID of the network.
+   *
+   * @returns The ID of the network.
+   */
+  public getId(): string {
+    return this.id;
+  }
+
+  /**
+   * Get the name of the network.
+   *
+   * @returns The name of the network.
+   */
+  public getName(): string {
+    return this.name;
+  }
+}


### PR DESCRIPTION
# Context

The current implementation only supports passing a testcontainers-generated network instance to the `GenericContainer` class. This is because the `withNetwork` method only accepts `StartedNetwork` instances. And the `StrtedNetwork` class is not instantiable.

```ts
const network = await new Network().start();

const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14").withNetwork(network).start();
```


# Use cases

* **Scenario:** _Retrieve and Attach Container to a Pre-existent Network_

  The pre-existent network could be a network created by docker-compose.

  ```gherkin
  Given a pre-existent container network identified by name or id
  When a user retrieves the container network
  Then the network should be available for attaching containers
  And the retrieved network instance should not be stoppable
  ```

# Implementation details

The following implementation extends the `Network` facade class and introduces the `StartedExistingNetwork` class covering this scenario.

Leveraging typescript interfaces and applying the _Interface segregation_ SOLID principle:

- The `StartedNetwork` class is renamed to `StartedBridgedNetwork` to avoid clashing with the new interface name.
- Two new interfaces are introduced: `StartedNetwork` and `StoppableNetwork`. 
- The `StartedBridgedNetwork` (previously `StartedNetwork`) implements the `StartedNetwork` and `StoppableNetwork` interfaces.
- The new `StartedExistingNetwork` class only implements the `StartedNetwork` interface since it is not desirable to stop and remove a pre-existing network.

With this approach, both classes can be passed to the generic container's `withNetwork()` method since both implement the `StartedNetwork` interface.
