### PR TITLE
Fixing typo in the documentation

### DIFF
--- a/docs/features/containers.md
+++ b/docs/features/containers.md
@@ -528,7 +528,7 @@ const { output, exitCode } = await container.exec(["echo", "hello", "world"], {
 		"VAR2": "/app/debug.log",
 	}
 });
-````
+```
 
 ## Streaming logs
 


### PR DESCRIPTION
This is an extra "quote" sign in the code that makes error in the formating of the documentation.