### PR TITLE
Fix missing documentation reference for localstack module

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,13 +47,13 @@ nav:
       - Elasticsearch: modules/elasticsearch.md
       - HiveMQ: modules/hivemq.md
       - Kafka: modules/kafka.md
+      - Localstack: modules/localstack.md
       - MongoDB: modules/mongodb.md
-      - MySQL: modules/mysql.md
       - MSSQLServer: modules/mssqlserver.md
+      - MySQL: modules/mysql.md
       - Nats: modules/nats.md
       - Neo4J: modules/neo4j.md
       - PostgreSQL: modules/postgresql.md
-      - Selenium: modules/selenium.md
       - Redis: modules/redis.md
-      - Localstack: modules/localstack.md
+      - Selenium: modules/selenium.md
   - Configuration: configuration.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,4 +55,5 @@ nav:
       - PostgreSQL: modules/postgresql.md
       - Selenium: modules/selenium.md
       - Redis: modules/redis.md
+      - Localstack: modules/localstack.md
   - Configuration: configuration.md


### PR DESCRIPTION
The module Localstack was added in PR https://github.com/testcontainers/testcontainers-node/pull/640. But the documentation reference was forgotten. That's the reason why localstack module actually not viable on the documentation page. 

![grafik](https://github.com/testcontainers/testcontainers-node/assets/52488859/4fcafa07-3911-4bbd-a42e-48b21e20f4ec)