### PR TITLE
Fix wait strategy for older redis versions

### DIFF
--- a/packages/modules/redis/src/redis-container.ts
+++ b/packages/modules/redis/src/redis-container.ts
@@ -13,7 +13,7 @@ export class RedisContainer extends GenericContainer {
     super(image);
     this.withExposedPorts(REDIS_PORT)
       .withStartupTimeout(120_000)
-      .withWaitStrategy(Wait.forLogMessage("Ready to accept connections tcp"));
+      .withWaitStrategy(Wait.forLogMessage("Ready to accept connections"));
   }
 
   public withPassword(password: string): this {


### PR DESCRIPTION
Older versions of Redis log just "ready for connections" without tcp