### PR TITLE
Support Kraft mode for Kafka container

### DIFF
--- a/docs/modules/kafka.md
+++ b/docs/modules/kafka.md
@@ -21,3 +21,7 @@ npm install @testcontainers/kafka --save-dev
 <!--codeinclude-->
 [Connect to Kafka using SSL:](../../packages/modules/kafka/src/kafka-container.test.ts) inside_block:ssl
 <!--/codeinclude-->
+
+<!--codeinclude-->
+[Connect to Kafka using Kraft:](../../packages/modules/kafka/src/kafka-container.test.ts) inside_block:connectKraft
+<!--/codeinclude-->

--- a/packages/modules/kafka/src/kafka-container.test.ts
+++ b/packages/modules/kafka/src/kafka-container.test.ts
@@ -189,6 +189,7 @@ describe("KafkaContainer", () => {
     });
   });
 
+  // connectKraft {
   it("should connect using kraft", async () => {
     const kafkaContainer = await new KafkaContainer().withKraft().withExposedPorts(9093).start();
 
@@ -196,6 +197,7 @@ describe("KafkaContainer", () => {
 
     await kafkaContainer.stop();
   });
+  // }
 
   it("should throw an error when using kraft and and confluence platfom below 7.0.0", async () => {
     expect(() => new KafkaContainer("confluentinc/cp-kafka:6.2.14").withKraft()).toThrow(

--- a/packages/modules/kafka/src/kafka-container.test.ts
+++ b/packages/modules/kafka/src/kafka-container.test.ts
@@ -180,6 +180,14 @@ describe("KafkaContainer", () => {
     });
   });
 
+  it("should work in kraft mode", async () => {
+    const kafkaContainer = await new KafkaContainer().withKraft().withExposedPorts(9093).start();
+
+    await testPubSub(kafkaContainer);
+
+    await kafkaContainer.stop();
+  })
+
   const testPubSub = async (kafkaContainer: StartedTestContainer, additionalConfig: Partial<KafkaConfig> = {}) => {
     const kafka = new Kafka({
       logLevel: logLevel.NOTHING,

--- a/packages/modules/kafka/src/kafka-container.ts
+++ b/packages/modules/kafka/src/kafka-container.ts
@@ -276,7 +276,12 @@ export class KafkaContainer extends GenericContainer {
       return false;
     }
     const parts = this.imageName.tag.split(".");
-    return !(parts.length > 2 && Number(parts[0]) >= max && Number(parts[1]) >= min && Number(parts[2]) >= patch);
+    return !(
+      parts.length > 2 &&
+      (Number(parts[0]) > max ||
+        (Number(parts[0]) === max &&
+          (Number(parts[1]) > min || (Number(parts[1]) === min && Number(parts[2]) >= patch))))
+    );
   }
 
   private commandKraftCreateUser(saslOptions: SaslSslListenerOptions): string {

--- a/packages/modules/kafka/src/kafka-container.ts
+++ b/packages/modules/kafka/src/kafka-container.ts
@@ -179,7 +179,7 @@ export class KafkaContainer extends GenericContainer {
 
     // Run the original command
     command += "/etc/confluent/docker/run \n";
-    container.copyContentToContainer([{ content: command, target: STARTER_SCRIPT, mode: 0o777 }]);
+    await container.copyContentToContainer([{ content: command, target: STARTER_SCRIPT, mode: 0o777 }]);
 
     const client = await getContainerRuntimeClient();
     const dockerContainer = client.container.getById(container.getId());

--- a/packages/modules/kafka/src/kafka-container.ts
+++ b/packages/modules/kafka/src/kafka-container.ts
@@ -6,12 +6,20 @@ import {
   RandomUuid,
   StartedTestContainer,
   Uuid,
+  Wait,
+  getContainerRuntimeClient,
 } from "testcontainers";
+import { waitForContainer } from "testcontainers/src/wait-strategies/wait-for-container";
+import { BoundPorts } from "testcontainers/src/utils/bound-ports";
+import { WaitStrategy } from "testcontainers/src/wait-strategies/wait-strategy";
 
 const KAFKA_PORT = 9093;
 const KAFKA_BROKER_PORT = 9092;
+const KAFKA_CONTROLLER_PORT = 9094;
 const DEFAULT_ZOOKEEPER_PORT = 2181;
 const DEFAULT_CLUSTER_ID = "4L6g3nShT-eMCtK--X86sw";
+const STARTER_SCRIPT = "/testcontainers_start.sh";
+const WAIT_FOR_SCRIPT_MESSAGE = "Waiting for script...";
 
 // https://docs.confluent.io/platform/7.0.0/release-notes/index.html#ak-raft-kraft
 const MIN_KRAFT_VERSION = "7.0.0";
@@ -53,6 +61,7 @@ export class KafkaContainer extends GenericContainer {
   private zooKeeperHost?: string;
   private zooKeeperPort?: number;
   private saslSslConfig?: SaslSslListenerOptions;
+  private originalWaitinStrategy: WaitStrategy;
 
   constructor(image = KAFKA_IMAGE) {
     super(image);
@@ -68,6 +77,7 @@ export class KafkaContainer extends GenericContainer {
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: "0",
       KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE: "false",
     });
+    this.originalWaitinStrategy = this.waitStrategy;
   }
 
   public withZooKeeper(host: string, port: number): this {
@@ -79,7 +89,7 @@ export class KafkaContainer extends GenericContainer {
   }
 
   public withKraft(): this {
-    this.verifyMinKraftVersion()
+    this.verifyMinKraftVersion();
     this.mode = KafkaMode.KRAFT;
     this.zooKeeperHost = undefined;
     this.zooKeeperPort = undefined;
@@ -101,7 +111,6 @@ export class KafkaContainer extends GenericContainer {
       this.addPlaintextListener();
     }
 
-    let command = "#!/bin/bash\n";
     if (this.mode === KafkaMode.PROVIDED_ZOOKEEPER) {
       this.withEnvironment({ KAFKA_ZOOKEEPER_CONNECT: `${this.zooKeeperHost}:${this.zooKeeperPort}` });
     } else if (this.mode === KafkaMode.EMBEDDED_ZOOKEEPER) {
@@ -109,33 +118,31 @@ export class KafkaContainer extends GenericContainer {
       this.zooKeeperPort = DEFAULT_ZOOKEEPER_PORT;
       this.withExposedPorts(this.zooKeeperPort);
       this.withEnvironment({ KAFKA_ZOOKEEPER_CONNECT: `localhost:${this.zooKeeperPort}` });
-      command += "echo 'clientPort=" + this.zooKeeperPort + "' > zookeeper.properties\n";
-      command += "echo 'dataDir=/var/lib/zookeeper/data' >> zookeeper.properties\n";
-      command += "echo 'dataLogDir=/var/lib/zookeeper/log' >> zookeeper.properties\n";
-      command += "zookeeper-server-start zookeeper.properties &\n";
-    } else { // Kraft
+    } else {
+      // Kraft
       const firstNetworkAlias = this.networkAliases[0];
-      const networkAlias = Boolean(this.networkMode) ? firstNetworkAlias : "localhost";
+      const networkAlias = this.networkMode ? firstNetworkAlias : "localhost";
       this.withEnvironment({
         CLUSTER_ID: DEFAULT_CLUSTER_ID,
         KAFKA_NODE_ID: this.environment["KAFKA_BROKER_ID"],
-        KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: this.environment["KAFKA_LISTENER_SECURITY_PROTOCOL_MAP"] + ",CONTROLLER:PLAINTEXT",
-        KAFKA_LISTENERS: this.environment["KAFKA_LISTENERS"] + "CONTROLLER://0.0.0.0:9094",
+        KAFKA_LISTENER_SECURITY_PROTOCOL_MAP:
+          this.environment["KAFKA_LISTENER_SECURITY_PROTOCOL_MAP"] + ",CONTROLLER:PLAINTEXT",
+        KAFKA_LISTENERS: `${this.environment["KAFKA_LISTENERS"]},CONTROLLER://0.0.0.0:${KAFKA_CONTROLLER_PORT}`,
         KAFKA_PROCESS_ROLES: "broker,controller",
-        KAFKA_CONTROLLER_QUORUM_VOTERS: `${this.environment["KAFKA_BROKER_ID"]}@${networkAlias}:9094`,
+        KAFKA_CONTROLLER_QUORUM_VOTERS: `${this.environment["KAFKA_BROKER_ID"]}@${networkAlias}:${KAFKA_CONTROLLER_PORT}`,
         KAFKA_CONTROLLER_LISTENER_NAMES: "CONTROLLER",
       });
-      command += "sed -i '/KAFKA_ZOOKEEPER_CONNECT/d' /etc/confluent/docker/configure\n";
-      command +=  "echo 'kafka-storage format --ignore-formatted -t \"" +
-            this.environment["CLUSTER_ID"] +
-            "\" -c /etc/kafka/kafka.properties' >> /etc/confluent/docker/configure\n";
     }
 
-    if (this.mode != KafkaMode.KRAFT || this.isLessThanCP740()) {
-      command += "echo '' > /etc/confluent/docker/ensure \n";
-    }
-    command += "/etc/confluent/docker/run \n";
-    this.withCommand(["sh", "-c", command]);
+    // Change the wait strategy to wait for a log message from a fake starter script
+    // so that we can put a real starter script in place at that moment
+    this.originalWaitinStrategy = this.waitStrategy;
+    this.waitStrategy = Wait.forLogMessage(WAIT_FOR_SCRIPT_MESSAGE);
+    this.withEntrypoint(["sh"]);
+    this.withCommand([
+      "-c",
+      `echo '${WAIT_FOR_SCRIPT_MESSAGE}'; while [ ! -f ${STARTER_SCRIPT} ]; do sleep 0.1; done; ${STARTER_SCRIPT}`,
+    ]);
   }
 
   public override async start(): Promise<StartedKafkaContainer> {
@@ -146,8 +153,34 @@ export class KafkaContainer extends GenericContainer {
     container: StartedTestContainer,
     inspectResult: InspectResult
   ): Promise<void> {
-    await this.updateAdvertisedListeners(container, inspectResult);
+    let command = "#!/bin/bash\n";
+    const advertisedListeners = this.updateAdvertisedListeners(container, inspectResult);
+    // exporting KAFKA_ADVERTISED_LISTENERS with the container hostname
+    command += `export KAFKA_ADVERTISED_LISTENERS=${advertisedListeners}\n`;
+
+    if (this.mode !== KafkaMode.KRAFT || this.isLessThanCP740()) {
+      // Optimization: skip the checks
+      command += "echo '' > /etc/confluent/docker/ensure \n";
+    }
+    if (this.mode === KafkaMode.KRAFT && this.isLessThanCP740()) {
+      command += this.commandKraft();
+    } else if (this.mode === KafkaMode.EMBEDDED_ZOOKEEPER) {
+      command += this.commandZookeeper();
+    }
+
+    // Run the original command
+    command += "/etc/confluent/docker/run \n";
+    container.copyContentToContainer([{ content: command, target: STARTER_SCRIPT, mode: 0o777 }]);
+
+    const client = await getContainerRuntimeClient();
+    const dockerContainer = client.container.getById(container.getId());
+    const boundPorts = BoundPorts.fromInspectResult(client.info.containerRuntime.hostIps, inspectResult).filter(
+      this.exposedPorts
+    );
+    await waitForContainer(client, dockerContainer, this.originalWaitinStrategy, boundPorts);
+
     if (this.saslSslConfig) {
+      // TODO this should happen before start in kraft case
       await this.createUser(container, this.saslSslConfig.sasl);
     }
   }
@@ -184,8 +217,8 @@ export class KafkaContainer extends GenericContainer {
     }).withExposedPorts(KAFKA_PORT);
   }
 
-  private async updateAdvertisedListeners(container: StartedTestContainer, inspectResult: InspectResult) {
-    const brokerAdvertisedListener = `BROKER://${inspectResult.hostname}:${KAFKA_BROKER_PORT}`;
+  private updateAdvertisedListeners(container: StartedTestContainer, inspectResult: InspectResult): string {
+    let advertisedListeners = `BROKER://${inspectResult.hostname}:${KAFKA_BROKER_PORT}`;
 
     let bootstrapServers = `PLAINTEXT://${container.getHost()}:${container.getMappedPort(KAFKA_PORT)}`;
     if (this.saslSslConfig) {
@@ -197,23 +230,8 @@ export class KafkaContainer extends GenericContainer {
         )}`;
       }
     }
-
-    const { output, exitCode } = await container.exec([
-      "kafka-configs",
-      "--alter",
-      "--bootstrap-server",
-      brokerAdvertisedListener,
-      "--entity-type",
-      "brokers",
-      "--entity-name",
-      this.environment["KAFKA_BROKER_ID"],
-      "--add-config",
-      `advertised.listeners=[${bootstrapServers},${brokerAdvertisedListener}]`,
-    ]);
-
-    if (exitCode !== 0) {
-      throw new Error(`Kafka container configuration failed with exit code ${exitCode}: ${output}`);
-    }
+    advertisedListeners += `,${bootstrapServers}`;
+    return advertisedListeners;
   }
 
   private async createUser(container: StartedTestContainer, { user: { name, password }, mechanism }: SaslOptions) {
@@ -239,11 +257,13 @@ export class KafkaContainer extends GenericContainer {
 
   private verifyMinKraftVersion() {
     if (this.imageName.tag === "latest") {
-      return
+      return;
     }
-    const parts = this.imageName.tag.split(".")
+    const parts = this.imageName.tag.split(".");
     if (parts.length == 1 || Number(parts[0]) < 7) {
-      throw new Error(`Provided Confluent Platform's version ${this.imageName.tag} is not supported in Kraft mode (must be ${MIN_KRAFT_VERSION} or above)`)
+      throw new Error(
+        `Provided Confluent Platform's version ${this.imageName.tag} is not supported in Kraft mode (must be ${MIN_KRAFT_VERSION} or above)`
+      );
     }
   }
 
@@ -253,6 +273,31 @@ export class KafkaContainer extends GenericContainer {
     }
     const parts = this.imageName.tag.split(".");
     return !(parts.length > 1 && Number(parts[0]) >= 7 && Number(parts[1]) > 4);
+  }
+
+  private commandKraft(): string {
+    let command = "sed -i '/KAFKA_ZOOKEEPER_CONNECT/d' /etc/confluent/docker/configure\n";
+    command +=
+      "echo 'kafka-storage format --ignore-formatted -t \"" +
+      this.environment["CLUSTER_ID"] +
+      "\" -c /etc/kafka/kafka.properties' >> /etc/confluent/docker/configure\n";
+    if (this.saslSslConfig) {
+      command +=
+        "kafka-storage format [-h] --config CONFIG " +
+        "--cluster-id CLUSTER_ID " +
+        "--add-scram SCRAM_CREDENTIAL " +
+        "--release-version RELEASE_VERSION] " +
+        "--ignore-formatted]";
+    }
+    return command;
+  }
+
+  private commandZookeeper(): string {
+    let command = "echo 'clientPort=" + DEFAULT_ZOOKEEPER_PORT + "' > zookeeper.properties\n";
+    command += "echo 'dataDir=/var/lib/zookeeper/data' >> zookeeper.properties\n";
+    command += "echo 'dataLogDir=/var/lib/zookeeper/log' >> zookeeper.properties\n";
+    command += "zookeeper-server-start zookeeper.properties &\n";
+    return command;
   }
 }
 

--- a/packages/testcontainers/src/generic-container/started-generic-container.ts
+++ b/packages/testcontainers/src/generic-container/started-generic-container.ts
@@ -156,7 +156,7 @@ export class StartedGenericContainer implements StartedTestContainer {
     log.debug(`Copying content to container...`, { containerId: this.container.id });
     const client = await getContainerRuntimeClient();
     const tar = archiver("tar");
-    contentsToCopy.forEach(({ content, target }) => tar.append(content, { name: target }));
+    contentsToCopy.forEach(({ content, target, mode }) => tar.append(content, { name: target, mode: mode }));
     tar.finalize();
     await client.container.putArchive(this.container, tar, "/");
     log.debug(`Copied content to container`, { containerId: this.container.id });


### PR DESCRIPTION
Kraft is out of beta for some time now and and soon zookeeper support will be completely removed so it's useful to prepare for kraft support. It was also possible to use testcontainers-java without Zookeeper since 1.18.0.

This PR ports the solution to enable usage of Kafka without Zookeeper from testcontainers-java.

Unrelated changes:
- fixed `copyContentToContainer` not setting the correct mode for the file inside the container.