### PR TITLE
Disable couchbase module from pipeline

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Install NodeJS ${{ inputs.node-version }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ inputs.node-version }}
+          node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
         run: npm ci --omit=optional

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Install NodeJS ${{ inputs.node-version }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ inputs.node-version }}
 
       - name: Install dependencies
         run: npm ci --omit=optional

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: list_modules
-        run: echo "modules=$(ls packages/modules | jq 'del(.[] | select(. == "couchbase"))' | jq -cnR '[inputs | select(length>0)]'))" >> $GITHUB_OUTPUT
+        run: echo "modules=$(ls packages/modules | jq 'del(. == "couchbase")' | jq -cnR '[inputs | select(length>0)]'))" >> $GITHUB_OUTPUT
 
   test-modules:
     name: Module (${{ matrix.module }})

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,8 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: list_modules
-        run: echo "modules=$(ls packages/modules | jq 'del(. == "couchbase")' | jq -cnR '[inputs | select(length>0)]'))" >> $GITHUB_OUTPUT
-
+        run: echo "modules=$(ls packages/modules | jq -cnR '[inputs | select(length>0) | select(. != "couchbase")]')" >> $GITHUB_OUTPUT
   test-modules:
     name: Module (${{ matrix.module }})
     needs: [ test-testcontainers, list-modules ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: list_modules
-        run: echo "modules=$(ls packages/modules | jq -cnR '[inputs | select(length>0)]'))" >> $GITHUB_OUTPUT
+        run: echo "modules=$(ls packages/modules | jq 'del(.[] | select(. == "couchbase"))' | jq -cnR '[inputs | select(length>0)]'))" >> $GITHUB_OUTPUT
 
   test-modules:
     name: Module (${{ matrix.module }})


### PR DESCRIPTION
# Disable couchbase module from pipeline

## What is doing this PR

Taking into account some  **problems that we found on couchbase module** working with Node 20.x  version,  you can review  this  https://github.com/testcontainers/testcontainers-node/pull/728, @eddumelendez and I decide to disable this module from the CI pipeline in order to allow us set correctly pipelines jobs to Node 20x. without errors.

