### PR TITLE
Fix Kafka module imports

### DIFF
--- a/packages/modules/kafka/src/kafka-container.ts
+++ b/packages/modules/kafka/src/kafka-container.ts
@@ -1,5 +1,6 @@
 import {
   AbstractStartedContainer,
+  BoundPorts,
   Content,
   GenericContainer,
   InspectResult,
@@ -7,11 +8,10 @@ import {
   StartedTestContainer,
   Uuid,
   Wait,
+  WaitStrategy,
   getContainerRuntimeClient,
+  waitForContainer,
 } from "testcontainers";
-import { waitForContainer } from "testcontainers/src/wait-strategies/wait-for-container";
-import { BoundPorts } from "testcontainers/src/utils/bound-ports";
-import { WaitStrategy } from "testcontainers/src/wait-strategies/wait-strategy";
 
 const KAFKA_PORT = 9093;
 const KAFKA_BROKER_PORT = 9092;

--- a/packages/testcontainers/src/index.ts
+++ b/packages/testcontainers/src/index.ts
@@ -11,6 +11,7 @@ export { TestContainers } from "./test-containers";
 export { ContainerRuntimeClient, getContainerRuntimeClient, ImageName } from "./container-runtime";
 export { Uuid, RandomUuid, log } from "./common";
 export { getContainerPort, PortWithOptionalBinding, PortWithBinding, hasHostBinding } from "./utils/port";
+export { BoundPorts } from "./utils/bound-ports";
 
 export { DockerComposeEnvironment } from "./docker-compose-environment/docker-compose-environment";
 export { StartedDockerComposeEnvironment } from "./docker-compose-environment/started-docker-compose-environment";
@@ -20,6 +21,8 @@ export { DownedDockerComposeEnvironment } from "./docker-compose-environment/dow
 export { Network, StartedNetwork, StoppedNetwork } from "./network/network";
 
 export { Wait } from "./wait-strategies/wait";
+export { waitForContainer } from "./wait-strategies/wait-for-container";
+export { WaitStrategy } from "./wait-strategies/wait-strategy";
 export { HttpWaitStrategyOptions } from "./wait-strategies/http-wait-strategy";
 export { StartupCheckStrategy, StartupStatus } from "./wait-strategies/startup-check-strategy";
 export { PullPolicy, ImagePullPolicy } from "./utils/pull-policy";


### PR DESCRIPTION
Fixes an issue where the kafka module was using direct imports under /src/ and it would not work in the built version.