### PR TITLE
Fix checking Reaper and the SSHd containers when `_HUB_IMAGE_NAME_PREFIX` provided

### DIFF
--- a/packages/testcontainers/src/container-runtime/image-name.test.ts
+++ b/packages/testcontainers/src/container-runtime/image-name.test.ts
@@ -167,6 +167,7 @@ describe("ContainerImage", () => {
     { customRegistry: "custom.com/registry", expectedRegistry: "custom.com", expectedImagePrefix: "registry/" },
     { customRegistry: "custom.com/registry/", expectedRegistry: "custom.com", expectedImagePrefix: "registry/" },
     { customRegistry: "custom.com", expectedRegistry: "custom.com", expectedImagePrefix: "" },
+    { customRegistry: "custom.com/", expectedRegistry: "custom.com", expectedImagePrefix: "" },
     {
       customRegistry: "custom.com/registry/with/slashes",
       expectedRegistry: "custom.com",

--- a/packages/testcontainers/src/container-runtime/image-name.ts
+++ b/packages/testcontainers/src/container-runtime/image-name.ts
@@ -20,7 +20,7 @@ export class ImageName {
       // If the registry is defined, then the imagePrefix is the rest of the prefix.
       let imagePrefix = parsedRegistry ? prefix.substring(prefix.indexOf("/") + 1) : "";
       if (imagePrefix) {
-        imagePrefix = imagePrefix.replace(/\/$/, "/");
+        imagePrefix = imagePrefix.replace(/\/?$/, "/");
       }
       const originalImage = this.image;
       this.image = `${imagePrefix}${this.image}`;

--- a/packages/testcontainers/src/container-runtime/image-name.ts
+++ b/packages/testcontainers/src/container-runtime/image-name.ts
@@ -14,11 +14,14 @@ export class ImageName {
       const prefix = process.env.TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX;
 
       // Parse the registry. If it's undefined - then the whole prefix is a registry.
-      const registry = ImageName.getRegistry(prefix);
-      this.registry = registry ?? prefix;
+      const parsedRegistry = ImageName.getRegistry(prefix);
+      this.registry = parsedRegistry ?? prefix;
 
       // If the registry is defined, then the imagePrefix is the rest of the prefix.
-      const imagePrefix = registry ? prefix.substring(prefix.indexOf("/") + 1).replace(/\/?$/, "/") : "";
+      let imagePrefix = parsedRegistry ? prefix.substring(prefix.indexOf("/") + 1) : "";
+      if (imagePrefix) {
+        imagePrefix = imagePrefix.replace(/\/$/, "/");
+      }
       const originalImage = this.image;
       this.image = `${imagePrefix}${this.image}`;
 

--- a/packages/testcontainers/src/port-forwarder/port-forwarder.ts
+++ b/packages/testcontainers/src/port-forwarder/port-forwarder.ts
@@ -1,13 +1,15 @@
 import { createSshConnection, SshConnection } from "ssh-remote-port-forward";
 import { GenericContainer } from "../generic-container/generic-container";
 import { log, withFileLock } from "../common";
-import { ContainerRuntimeClient, getContainerRuntimeClient } from "../container-runtime";
+import { ContainerRuntimeClient, getContainerRuntimeClient, ImageName } from "../container-runtime";
 import { getReaper } from "../reaper/reaper";
 import { PortWithOptionalBinding } from "../utils/port";
 import Dockerode, { ContainerInfo } from "dockerode";
 import { LABEL_TESTCONTAINERS_SESSION_ID, LABEL_TESTCONTAINERS_SSHD } from "../utils/labels";
 
-export const SSHD_IMAGE = process.env["SSHD_CONTAINER_IMAGE"] ?? "testcontainers/sshd:1.1.0";
+export const SSHD_IMAGE = process.env["SSHD_CONTAINER_IMAGE"]
+  ? ImageName.fromString(process.env["SSHD_CONTAINER_IMAGE"]).string
+  : ImageName.fromString("testcontainers/sshd:1.1.0").string;
 
 class PortForwarder {
   constructor(

--- a/packages/testcontainers/src/reaper/reaper.ts
+++ b/packages/testcontainers/src/reaper/reaper.ts
@@ -2,11 +2,13 @@ import { ContainerInfo } from "dockerode";
 import { GenericContainer } from "../generic-container/generic-container";
 import { Wait } from "../wait-strategies/wait";
 import { Socket } from "net";
-import { ContainerRuntimeClient } from "../container-runtime";
+import { ContainerRuntimeClient, ImageName } from "../container-runtime";
 import { IntervalRetry, log, RandomUuid, withFileLock } from "../common";
 import { LABEL_TESTCONTAINERS_SESSION_ID } from "../utils/labels";
 
-export const REAPER_IMAGE = process.env["RYUK_CONTAINER_IMAGE"] ?? "testcontainers/ryuk:0.5.1";
+export const REAPER_IMAGE = process.env["RYUK_CONTAINER_IMAGE"]
+  ? ImageName.fromString(process.env["RYUK_CONTAINER_IMAGE"]).string
+  : ImageName.fromString("testcontainers/ryuk:0.5.1").string;
 
 export interface Reaper {
   sessionId: string;


### PR DESCRIPTION
Additional fix for the issue https://github.com/testcontainers/testcontainers-node/issues/747.

Thanks to @joyrex2001 for pointing to ruyk image name comparison problems.

The changes were tested with specifying `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX=docker.io` for the test run.