### PR TITLE
Use new sshd:1.2.0 image

### DIFF
--- a/packages/testcontainers/src/port-forwarder/port-forwarder.ts
+++ b/packages/testcontainers/src/port-forwarder/port-forwarder.ts
@@ -9,7 +9,7 @@ import { LABEL_TESTCONTAINERS_SESSION_ID, LABEL_TESTCONTAINERS_SSHD } from "../u
 
 export const SSHD_IMAGE = process.env["SSHD_CONTAINER_IMAGE"]
   ? ImageName.fromString(process.env["SSHD_CONTAINER_IMAGE"]).string
-  : ImageName.fromString("testcontainers/sshd:1.1.0").string;
+  : ImageName.fromString("testcontainers/sshd:1.2.0").string;
 
 class PortForwarder {
   constructor(
@@ -124,11 +124,6 @@ export class PortForwarderInstance {
       .withExposedPorts(containerPort)
       .withEnvironment({ PASSWORD: this.PASSWORD })
       .withLabels({ [LABEL_TESTCONTAINERS_SSHD]: "true" })
-      .withCommand([
-        "sh",
-        "-c",
-        `echo "${this.USERNAME}:$PASSWORD" | chpasswd && /usr/sbin/sshd -D -o PermitRootLogin=yes -o AddressFamily=inet -o GatewayPorts=yes -o AllowAgentForwarding=yes -o AllowTcpForwarding=yes -o KexAlgorithms=+diffie-hellman-group1-sha1 -o HostkeyAlgorithms=+ssh-rsa`,
-      ])
       .start();
 
     const host = client.info.containerRuntime.host;


### PR DESCRIPTION
## What does this PR do?

It uses the newest testcontainers/sshd:1.2.0 docker image, which includes the CMD in the image instead of in the code.

Please see https://github.com/testcontainers/sshd-docker/pull/7 for more details.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Avoid code duplication across testcontainers projects.

<!-- Mandatory
Explain here the WHY, or the rationale / motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Caused by https://github.com/testcontainers/sshd-docker/pull/7
- Relates (java) https://github.com/testcontainers/testcontainers-java/pull/8574
- Relates (.NET) https://github.com/testcontainers/testcontainers-dotnet/pull/1160
- Relates (go) https://github.com/testcontainers/testcontainers-go/pull/2471/commits/8f8a7c2a05854614ea20f040fe98aa26d9698d4f

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
