### PR TITLE
Allow building with BuildKit

### DIFF
--- a/docs/features/images.md
+++ b/docs/features/images.md
@@ -91,6 +91,15 @@ const container = await GenericContainer
   .build();
 ```
 
+### Using BuildKit
+
+```javascript
+const container = await GenericContainer
+  .fromDockerfile("/path/to/build-context")
+  .withBuildKit()
+  .build();
+```
+
 ## Image name substitution
 
 Testcontainers supports automatic substitution of Docker image names.

--- a/packages/testcontainers/fixtures/docker/docker-with-buildkit-features/Dockerfile
+++ b/packages/testcontainers/fixtures/docker/docker-with-buildkit-features/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:10-alpine
+
+MAINTAINER Cristian Greco
+
+EXPOSE 8080
+
+RUN --mount=type=cache,target=/var/cache/apk apk add --no-cache curl dumb-init libcap openssl
+
+RUN openssl req -x509 -nodes -days 36500 \
+    -subj  "/C=CA/ST=QC/O=Company Inc/CN=localhost" \
+    -newkey rsa:2048 -keyout /etc/ssl/private/cert.key \
+    -out /etc/ssl/certs/cert.crt \
+    && chmod 666 /etc/ssl/private/cert.key
+
+RUN npm init -y \
+    && npm install express@4.16.4
+
+COPY index.js .
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["node", "index.js"]

--- a/packages/testcontainers/fixtures/docker/docker-with-buildkit-features/index.js
+++ b/packages/testcontainers/fixtures/docker/docker-with-buildkit-features/index.js
@@ -1,0 +1,62 @@
+const fs = require("fs");
+const http = require("http");
+const https = require("https");
+const express = require("express");
+
+const app = express();
+
+app.get("/hello-world", (req, res) => {
+  res.status(200).send("hello-world");
+});
+
+app.get("/hello-world-delay", (req, res) => {
+  setTimeout(() => {
+    res.status(200).send("hello-world");
+  }, 3000);
+});
+
+app.post("/hello-world-post", (req, res) => {
+  res.status(200).send("hello-world");
+});
+
+app.get("/env", (req, res) => {
+  res.status(200).json(process.env);
+});
+
+app.get("/cmd", (req, res) => {
+  res.status(200).json(process.argv);
+});
+
+app.get("/auth", (req, res) => {
+  const auth = req.headers.authorization;
+  const [, base64Encoded] = auth.split(" ");
+  const credentials = Buffer.from(base64Encoded, "base64").toString("ascii");
+  const [username, password] = credentials.split(":");
+  if (username === "user" && password === "pass") {
+    res.status(200).end();
+  } else {
+    res.status(401).end();
+  }
+});
+
+app.get("/header-or-400/:headerName", (req, res) => {
+  if (req.headers[req.params["headerName"]] !== undefined) {
+    res.status(200).end();
+  } else {
+    res.status(400).end();
+  }
+});
+
+const PORT = 8080;
+const TLS_PORT = 8443;
+
+http.createServer(app).listen(PORT, () => console.log(`Listening on port ${PORT}`));
+https
+  .createServer(
+    {
+      key: fs.readFileSync("/etc/ssl/private/cert.key", "utf8"),
+      cert: fs.readFileSync("/etc/ssl/certs/cert.crt", "utf8"),
+    },
+    app
+  )
+  .listen(TLS_PORT, () => console.log(`Listening on secure port ${TLS_PORT}`));

--- a/packages/testcontainers/fixtures/docker/docker-with-buildkit-features/test.txt
+++ b/packages/testcontainers/fixtures/docker/docker-with-buildkit-features/test.txt
@@ -1,0 +1,1 @@
+hello world

--- a/packages/testcontainers/src/generic-container/generic-container-builder.ts
+++ b/packages/testcontainers/src/generic-container/generic-container-builder.ts
@@ -78,7 +78,7 @@ export class GenericContainerBuilder {
       registryconfig: registryConfig,
       labels,
       target: this.target,
-      version: this.useBuildKit ? "2" : "1",
+      version: this.useBuildKit ? "2" : undefined,
     } as ImageBuildOptions);
 
     const container = new GenericContainer(imageName.string);

--- a/packages/testcontainers/src/generic-container/generic-container-dockerfile.test.ts
+++ b/packages/testcontainers/src/generic-container/generic-container-dockerfile.test.ts
@@ -102,4 +102,14 @@ describe("GenericContainer Dockerfile", () => {
 
     await startedContainer.stop();
   });
+
+  it("should work with buildKit", async () => {
+    const context = path.resolve(fixtures, "docker-with-buildkit-features");
+    const container = await GenericContainer.fromDockerfile(context).withBuildKit().build();
+    const startedContainer = await container.withExposedPorts(8080).start();
+
+    await checkContainerIsHealthy(startedContainer);
+
+    await startedContainer.stop();
+  });
 });


### PR DESCRIPTION
Adds a `withBuildKit` option. With the option enabled, a build will be done using BuildKit - within a docker container.
This should be relatively independent on the host system's BuildKit support.

Questions:
- Should the env var `DOCKER_BUILDKIT=1` enabled the setting by default?
- Should it be enabled by default in general? For a "just works" for newer dockerfile features like mounts?

Solves #571 