### PR TITLE
Fix OllamaContainer's commitToImage

### DIFF
--- a/packages/modules/ollama/src/ollama-container.test.ts
+++ b/packages/modules/ollama/src/ollama-container.test.ts
@@ -23,13 +23,13 @@ describe("OllamaContainer", () => {
 
     const newImageName: string = "tc-ollama-allminilm-" + (Math.random() + 1).toString(36).substring(4).toLowerCase();
     await container.commitToImage(newImageName);
+    await container.stop();
 
     const newContainer = await new OllamaContainer(newImageName).start();
     const response2 = await fetch(`${newContainer.getEndpoint()}/api/tags`);
     expect(response2.status).toEqual(200);
     const body2 = await response2.json();
     expect(body2.models[0].name).toContain("all-minilm");
-    await container.stop();
     await newContainer.stop();
   });
 });

--- a/packages/modules/ollama/src/ollama-container.ts
+++ b/packages/modules/ollama/src/ollama-container.ts
@@ -49,6 +49,8 @@ export class StartedOllamaContainer extends AbstractStartedContainer {
   public async commitToImage(imageName: string): Promise<NodeJS.ReadableStream> {
     const client = await getContainerRuntimeClient();
     const dockerode = client.container.dockerode;
-    return dockerode.getContainer(this.getId()).commit({ repo: imageName });
+    return dockerode
+      .getContainer(this.getId())
+      .commit({ repo: imageName, Labels: { "org.testcontainers.session-id": "" } });
   }
 }


### PR DESCRIPTION
Currently, the new image created by `commitToImage` is removed by ryuk because it contains the `org.testcontainers.session-id` label. This commit set the label's value to empty, so, ryuk doesn't remove the image. Also, update the test to stop the container once the new image is created.
