### PR TITLE
Support custom compose project names

### DIFF
--- a/docs/features/compose.md
+++ b/docs/features/compose.md
@@ -121,6 +121,16 @@ const environment = await new DockerComposeEnvironment(composeFilePath, composeF
   .up();
 ```
 
+### With custom project name
+
+See [project name](https://docs.docker.com/compose/project-name/).
+
+```javascript
+const environment = await new DockerComposeEnvironment(composeFilePath, composeFile)
+  .withProjectName("test")
+  .up();
+```
+
 ## Downing a Docker compose environment
 
 Testcontainers by default will not wait until the environment has downed. It will simply issue the down command and return immediately. This is to save time when running tests.

--- a/packages/testcontainers/src/docker-compose-environment/docker-compose-environment.test.ts
+++ b/packages/testcontainers/src/docker-compose-environment/docker-compose-environment.test.ts
@@ -1,6 +1,7 @@
 import fetch from "node-fetch";
 import path from "path";
 import { DockerComposeEnvironment } from "./docker-compose-environment";
+import { RandomUuid } from "../common";
 import { Wait } from "../wait-strategies/wait";
 import { PullPolicy } from "../utils/pull-policy";
 import {
@@ -252,6 +253,17 @@ describe("DockerComposeEnvironment", () => {
         async (containerName) => await checkEnvironmentContainerIsHealthy(startedEnvironment, containerName)
       )
     );
+
+    await startedEnvironment.down();
+  });
+
+  it("should use a custom project name if set", async () => {
+    const customProjectName = `custom-${new RandomUuid().nextUuid()}`;
+    const startedEnvironment = await new DockerComposeEnvironment(fixtures, "docker-compose.yml")
+      .withProjectName(customProjectName)
+      .up();
+
+    expect(await getRunningContainerNames()).toContain(`${customProjectName}-container-1`);
 
     await startedEnvironment.down();
   });

--- a/packages/testcontainers/src/docker-compose-environment/docker-compose-environment.ts
+++ b/packages/testcontainers/src/docker-compose-environment/docker-compose-environment.ts
@@ -73,6 +73,11 @@ export class DockerComposeEnvironment {
     return this;
   }
 
+  public withProjectName(projectName: string): this {
+    this.projectName = projectName;
+    return this;
+  }
+
   public async up(services?: Array<string>): Promise<StartedDockerComposeEnvironment> {
     log.info(`Starting DockerCompose environment "${this.projectName}"...`);
     const client = await getContainerRuntimeClient();


### PR DESCRIPTION
Allow custom project names for docker compose environments. This can be useful when running tests in CI environment where images may be built separately and loaded into the local docker image cache and consistent image names are needed (without having to specify local image names for each service).