### PR TITLE
MSSQL Docker image, 2022-latest -> 2022-CU13-ubuntu-22.04

### DIFF
--- a/packages/modules/mssqlserver/src/mssqlserver-container.ts
+++ b/packages/modules/mssqlserver/src/mssqlserver-container.ts
@@ -9,7 +9,7 @@ export class MSSQLServerContainer extends GenericContainer {
   private acceptEula = "N";
   private message: string | RegExp = /.*Recovery is complete.*/;
 
-  constructor(image = "mcr.microsoft.com/mssql/server:2022-latest") {
+  constructor(image = "mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04") {
     super(image);
     this.withExposedPorts(MSSQL_PORT).withWaitStrategy(Wait.forLogMessage(this.message, 1)).withStartupTimeout(120_000);
   }


### PR DESCRIPTION
Looks like the test for express edition has suddenly started failing. Looks like there was a new release for 2022-latest (2022-CU14-ubuntu-22.04). Let's explicitly set the tag to the previous version 2022-CU13-ubuntu-22.04 in case the issue is coming from the new version.