### PR TITLE
Replace md5 with sha256 to work on FIPS machines

### DIFF
--- a/packages/testcontainers/src/common/hash.test.ts
+++ b/packages/testcontainers/src/common/hash.test.ts
@@ -1,8 +1,8 @@
 import { hash } from "./hash";
 
-test("should return a hash", () => {
+test("should return a consistent hash", () => {
   const str = "Hello, world!";
 
-  expect(hash(str)).toBe("6cd3556deb0da54bca060b4c39479839");
-  expect(hash(str)).toBe("6cd3556deb0da54bca060b4c39479839");
+  expect(hash(str)).toBe("315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3");
+  expect(hash(str)).toBe("315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3");
 });

--- a/packages/testcontainers/src/common/hash.ts
+++ b/packages/testcontainers/src/common/hash.ts
@@ -1,5 +1,5 @@
 import crypto from "crypto";
 
 export function hash(str: string): string {
-  return crypto.createHash("md5").update(str).digest("hex");
+  return crypto.createHash("sha256").update(str).digest("hex");
 }


### PR DESCRIPTION
Fixes #804
