### PR TITLE
Log docker daemon labels

### DIFF
--- a/packages/testcontainers/src/container-runtime/clients/client.ts
+++ b/packages/testcontainers/src/container-runtime/clients/client.ts
@@ -123,6 +123,7 @@ async function initStrategy(strategy: ContainerRuntimeClientStrategy): Promise<C
     cpus: dockerodeInfo.NCPU,
     memory: dockerodeInfo.MemTotal,
     runtimes: dockerodeInfo.Runtimes ? Object.keys(dockerodeInfo.Runtimes) : [],
+    labels: dockerodeInfo.Labels ? dockerodeInfo.Labels : [],
   };
 
   const composeInfo: ComposeInfo = composeClient.info;

--- a/packages/testcontainers/src/container-runtime/clients/types.ts
+++ b/packages/testcontainers/src/container-runtime/clients/types.ts
@@ -22,6 +22,7 @@ export type ContainerRuntimeInfo = {
   cpus: number;
   memory: number;
   runtimes: string[];
+  labels: string[];
 };
 
 export type ComposeInfo =


### PR DESCRIPTION
Docker Engine can be configured to have labels.

onfigure Docker Desktop: DD settings > Docker daemon

```
{
  "builder": {
    "gc": {
      "defaultKeepStorage": "20GB",
      "enabled": true
    }
  },
  "experimental": false,
  "labels": [
    "who=eddumelendez",
    "from=world"
  ]
}
```

should provide

```
  testcontainers   "containerRuntime": {
  testcontainers     "host": "localhost",
  testcontainers     "hostIps": [
  testcontainers       {
  testcontainers         "address": "::1",
  testcontainers         "family": 6
  testcontainers       },
  testcontainers       {
  testcontainers         "address": "127.0.0.1",
  testcontainers         "family": 4
  testcontainers       }
  testcontainers     ],
  testcontainers     "remoteSocketPath": "/var/run/docker.sock",
  testcontainers     "indexServerAddress": "https://index.docker.io/v1/",
  testcontainers     "serverVersion": "27.1.1",
  testcontainers     "operatingSystem": "Docker Desktop",
  testcontainers     "operatingSystemType": "linux",
  testcontainers     "architecture": "aarch64",
  testcontainers     "cpus": 8,
  testcontainers     "memory": 10421612544,
  testcontainers     "runtimes": [
  testcontainers       "io.containerd.runc.v2",
  testcontainers       "runc"
  testcontainers     ],
  testcontainers     "labels": [
  testcontainers       "who=eddumelendez",
  testcontainers       "from=world",
  testcontainers       "com.docker.desktop.address=unix:///Users/eddumelendez/Library/Containers/com.docker.docker/Data/docker-cli.sock"
  testcontainers     ]
  testcontainers   },
```