### PR TITLE
Update MongoDB docs about `directConnection`

### DIFF
--- a/packages/modules/mongodb/src/mongodb-container.test.ts
+++ b/packages/modules/mongodb/src/mongodb-container.test.ts
@@ -1,4 +1,4 @@
-import { MongoDBContainer, StartedMongoDBContainer } from "./mongodb-container";
+import { MongoDBContainer } from "./mongodb-container";
 import mongoose from "mongoose";
 
 describe("MongodbContainer", () => {
@@ -8,26 +8,13 @@ describe("MongodbContainer", () => {
   it("should work using default version 4.0.1", async () => {
     const mongodbContainer = await new MongoDBContainer().start();
 
-    await checkMongo(mongodbContainer);
-
-    await mongoose.disconnect();
-    await mongodbContainer.stop();
-  });
-  // }
-
-  // connect6 {
-  it("should work using version 6.0.1", async () => {
-    const mongodbContainer = await new MongoDBContainer("mongo:6.0.1").start();
-
-    await checkMongo(mongodbContainer);
-
-    await mongoose.disconnect();
-    await mongodbContainer.stop();
-  });
-  // }
-
-  async function checkMongo(mongodbContainer: StartedMongoDBContainer) {
+    // directConnection: true is required as the testcontainer is created as a MongoDB Replica Set.
     const db = mongoose.createConnection(mongodbContainer.getConnectionString(), { directConnection: true });
+
+    // You can also add the default connection flag as a query parameter
+    // const connectionString = `${mongodbContainer.getConnectionString()}?directConnection=true`;
+    // const db = mongoose.createConnection(connectionString);
+
     const fooCollection = db.collection("foo");
     const obj = { value: 1 };
 
@@ -39,7 +26,41 @@ describe("MongodbContainer", () => {
     expect(
       await fooCollection.findOne({
         value: 1,
-      })
+      }),
     ).toEqual(obj);
-  }
+
+    await mongoose.disconnect();
+    await mongodbContainer.stop();
+  });
+  // }
+
+  // connect6 {
+  it("should work using version 6.0.1", async () => {
+    const mongodbContainer = await new MongoDBContainer("mongo:6.0.1").start();
+
+    // directConnection: true is required as the testcontainer is created as a MongoDB Replica Set.
+    const db = mongoose.createConnection(mongodbContainer.getConnectionString(), { directConnection: true });
+
+    // You can also add the default connection flag as a query parameter
+    // const connectionString = `${mongodbContainer.getConnectionString()}?directConnection=true`;
+    // const db = mongoose.createConnection(connectionString);
+
+    const fooCollection = db.collection("foo");
+    const obj = { value: 1 };
+
+    const session = await db.startSession();
+    await session.withTransaction(async () => {
+      await fooCollection.insertOne(obj);
+    });
+
+    expect(
+      await fooCollection.findOne({
+        value: 1,
+      }),
+    ).toEqual(obj);
+
+    await mongoose.disconnect();
+    await mongodbContainer.stop();
+  });
+  // }
 });


### PR DESCRIPTION
When playing around with the mongodb testcontainers today, we ran into an issue where the tests were unable to connect to the mongodb database. After a bit of debugging, we found that this was due to `directConnection` not being set to `true`. 

This PR is simply to update the documentation to make it explicit that you will need to set `directionConnection: true` either as an option when connecting, or directly as part of the connection string.

Addresses https://github.com/testcontainers/testcontainers-node/issues/697 