### PR TITLE
Add `autoUpdateExternalUrl` to `CloudStorageEmulatorContainer`

### DIFF
--- a/packages/modules/gcloud/package.json
+++ b/packages/modules/gcloud/package.json
@@ -8,6 +8,7 @@
     "firestore",
     "pubsub",
     "cloudstorage",
+    "gcs",
     "testing",
     "docker",
     "testcontainers"


### PR DESCRIPTION
Previously discussed here: https://github.com/testcontainers/testcontainers-node/pull/805#issuecomment-2308886117

Defaulting to `true` because it's very likely that the container will be used locally, and that it's desired for the emulator to return valid URLs. If an `externalUrl` is provided then the update is skipped.

Can't get tests to work with Colima (I added `forListeningPorts` but it hangs in `InternalPortCheck.isBound`, [here](https://github.com/testcontainers/testcontainers-node/blob/9f7fd4eff5e6f05440016010964a78aa80557cb1/packages/testcontainers/src/wait-strategies/utils/port-check.ts#L48-L50)), so need a CI run to check.