### PR TITLE
Fix Neo4j default password to support v5

### DIFF
--- a/packages/modules/neo4j/src/neo4j-container.test.ts
+++ b/packages/modules/neo4j/src/neo4j-container.test.ts
@@ -25,6 +25,27 @@ describe("Neo4jContainer", () => {
   });
   // }
 
+  // v5DefaultPassword {
+  it("should connect with custom password", async () => {
+    const container = await new Neo4jContainer("neo4j:5.23.0").start();
+    const driver = neo4j.driver(
+      container.getBoltUri(),
+      neo4j.auth.basic(container.getUsername(), container.getPassword())
+    );
+
+    const session = driver.session();
+    const personName = "Chris";
+    const result = await session.run("CREATE (a:Person {name: $name}) RETURN a", { name: personName });
+    const singleRecord = result.records[0];
+    const node = singleRecord.get(0);
+    expect(node.properties.name).toBe(personName);
+
+    await session.close();
+    await driver.close();
+    await container.stop();
+  });
+  // }
+  
   // setPassword {
   it("should connect with custom password", async () => {
     const container = await new Neo4jContainer().withPassword("xyz1234@!").start();

--- a/packages/modules/neo4j/src/neo4j-container.test.ts
+++ b/packages/modules/neo4j/src/neo4j-container.test.ts
@@ -26,7 +26,7 @@ describe("Neo4jContainer", () => {
   // }
 
   // v5DefaultPassword {
-  it("should connect with custom password", async () => {
+  it("should connect to neo4j:v5 with default password", async () => {
     const container = await new Neo4jContainer("neo4j:5.23.0").start();
     const driver = neo4j.driver(
       container.getBoltUri(),

--- a/packages/modules/neo4j/src/neo4j-container.test.ts
+++ b/packages/modules/neo4j/src/neo4j-container.test.ts
@@ -45,7 +45,7 @@ describe("Neo4jContainer", () => {
     await container.stop();
   });
   // }
-  
+
   // setPassword {
   it("should connect with custom password", async () => {
     const container = await new Neo4jContainer().withPassword("xyz1234@!").start();

--- a/packages/modules/neo4j/src/neo4j-container.ts
+++ b/packages/modules/neo4j/src/neo4j-container.ts
@@ -5,7 +5,7 @@ const HTTP_PORT = 7474;
 const USERNAME = "neo4j";
 
 export class Neo4jContainer extends GenericContainer {
-  private password = "test";
+  private password = "pass123!@#WORD";
   private apoc = false;
   private ttl?: number;
 


### PR DESCRIPTION
Fixes #831 

I've considered adding a test against `neo4j:latest` tag, but it would inevitably start catching unrelated issues. It might be a good addition after all.