### PR TITLE
Docs - make info about Wait Strategies easier to find

### DIFF
--- a/docs/features/containers.md
+++ b/docs/features/containers.md
@@ -5,7 +5,6 @@
 Create and start any container using a Generic Container:
 
 ```javascript
-
 const { GenericContainer } = require("testcontainers");
 
 const container = await new GenericContainer("alpine").start();

--- a/docs/features/containers.md
+++ b/docs/features/containers.md
@@ -202,6 +202,27 @@ const container = await new GenericContainer("alpine")
   .start();
 ```
 
+### With a wait strategy
+
+A wait strategy will resolve the call to `.start()` only when a start condition is met. This allows you to ensure the container can perform its work before resolving.
+
+There are many built-in wait strategies, supporting varying conditions,  [see here](../wait-strategies).
+
+A strategy can be a single condition or a composition of a few conditions. Here is an example of the latter:
+
+```javascript
+import { GenericContainer, Wait } from "testcontainers";
+
+const container = await new GenericContainer("my-upstream-service")
+  .withExposedPorts(3000)
+  .withWaitStrategy(Wait.forAll([
+    Wait.forListeningPorts(),
+    Wait.forLogMessage(/server started on port/),
+    Wait.forHealthCheck(),
+  ]))
+  .start();
+```
+
 ### With default log driver
 
 May be necessary when the driver of your docker host does not support reading logs, and you want to use the [log output wait strategy](../wait-strategies#log-output).

--- a/docs/features/containers.md
+++ b/docs/features/containers.md
@@ -207,8 +207,6 @@ const container = await new GenericContainer("alpine")
 
 A wait strategy will resolve the call to `.start()` only when a start condition is met. This allows you to ensure the container can perform its work before resolving.
 
-There are many built-in wait strategies, supporting varying conditions,  see [wait Strategies](../wait-strategies).
-
 A strategy can be a single condition or a composition of a few conditions. Here is an example of the latter:
 
 ```javascript
@@ -223,6 +221,8 @@ const container = await new GenericContainer("my-upstream-service")
   ]))
   .start();
 ```
+
+There are many built-in wait strategies, supporting varying conditions. For more info - see [wait Strategies](../wait-strategies).
 
 ### With default log driver
 

--- a/docs/features/containers.md
+++ b/docs/features/containers.md
@@ -5,6 +5,7 @@
 Create and start any container using a Generic Container:
 
 ```javascript
+
 const { GenericContainer } = require("testcontainers");
 
 const container = await new GenericContainer("alpine").start();
@@ -206,7 +207,7 @@ const container = await new GenericContainer("alpine")
 
 A wait strategy will resolve the call to `.start()` only when a start condition is met. This allows you to ensure the container can perform its work before resolving.
 
-There are many built-in wait strategies, supporting varying conditions,  [see here](../wait-strategies).
+There are many built-in wait strategies, supporting varying conditions,  see [wait Strategies](../wait-strategies).
 
 A strategy can be a single condition or a composition of a few conditions. Here is an example of the latter:
 

--- a/docs/features/containers.md
+++ b/docs/features/containers.md
@@ -221,7 +221,7 @@ const container = await new GenericContainer("my-upstream-service")
   .start();
 ```
 
-There are many built-in wait strategies, supporting varying conditions. For more info - see [wait Strategies](../wait-strategies).
+There are many built-in wait strategies, supporting varying conditions, or you can write your own. For more info - see [wait Strategies](../wait-strategies).
 
 ### With default log driver
 

--- a/docs/features/wait-strategies.md
+++ b/docs/features/wait-strategies.md
@@ -238,7 +238,7 @@ const w2 = Wait.forLogMessage("READY");
 const composite = Wait.forAll([w1, w2]).withDeadline(2000);
 ```
 
-## Other startup strategies
+## Custom Wait Strategies
 
 If these options do not meet your requirements, you can subclass `StartupCheckStrategy` and use `Dockerode`, which is the underlying Docker client used by Testcontainers:
 

--- a/docs/features/wait-strategies.md
+++ b/docs/features/wait-strategies.md
@@ -1,5 +1,9 @@
 # Wait Strategies
 
+A wait strategy will resolve the call to `container.start()` only after a condition is met. This allows you to ensure the container can perform its work before resolving.
+
+There are many built-in wait strategies, supporting varying conditions, which are listed below.
+
 Note that the startup timeout of all wait strategies is configurable:
 
 ```javascript


### PR DESCRIPTION
When I was searching for it - I almost missed it, and found it by accident a moment before I gave up.

I believe it's a too important feature to be left only in the advanced-features page.

I tried my best to understand the order by which items appear in the `containers` page and tried to fit in.

I hope you accept this :)
