### PR TITLE
Add support for reusing stopped containers

### DIFF
--- a/packages/testcontainers/src/container-runtime/clients/container/docker-container-client.ts
+++ b/packages/testcontainers/src/container-runtime/clients/container/docker-container-client.ts
@@ -35,7 +35,6 @@ export class DockerContainerClient implements ContainerClient {
       const containers = await this.dockerode.listContainers({
         limit: 1,
         filters: {
-          status: ["running"],
           label: [`${labelName}=${labelValue}`],
         },
       });

--- a/packages/testcontainers/src/generic-container/generic-container.ts
+++ b/packages/testcontainers/src/generic-container/generic-container.ts
@@ -130,6 +130,11 @@ export class GenericContainer implements TestContainer {
   private async reuseContainer(client: ContainerRuntimeClient, container: Container) {
     const inspectResult = await client.container.inspect(container);
     const mappedInspectResult = mapInspectResult(inspectResult);
+    if (!mappedInspectResult.state.running) {
+      log.debug("Reused container is not running, attempting to start it");
+      await client.container.start(container);
+    }
+
     const boundPorts = BoundPorts.fromInspectResult(client.info.containerRuntime.hostIps, mappedInspectResult).filter(
       this.exposedPorts
     );

--- a/packages/testcontainers/src/generic-container/generic-container.ts
+++ b/packages/testcontainers/src/generic-container/generic-container.ts
@@ -128,13 +128,15 @@ export class GenericContainer implements TestContainer {
   }
 
   private async reuseContainer(client: ContainerRuntimeClient, container: Container) {
-    const inspectResult = await client.container.inspect(container);
-    const mappedInspectResult = mapInspectResult(inspectResult);
-    if (!mappedInspectResult.state.running) {
+    let inspectResult = await client.container.inspect(container);
+    if (!inspectResult.State.Running) {
       log.debug("Reused container is not running, attempting to start it");
       await client.container.start(container);
+      // Refetch the inspect result to get the updated state
+      inspectResult = await client.container.inspect(container);
     }
 
+    const mappedInspectResult = mapInspectResult(inspectResult);
     const boundPorts = BoundPorts.fromInspectResult(client.info.containerRuntime.hostIps, mappedInspectResult).filter(
       this.exposedPorts
     );

--- a/packages/testcontainers/src/utils/map-inspect-result.ts
+++ b/packages/testcontainers/src/utils/map-inspect-result.ts
@@ -7,10 +7,7 @@ export function mapInspectResult(inspectResult: ContainerInspectInfo): InspectRe
   return {
     name: inspectResult.Name,
     hostname: inspectResult.Config.Hostname,
-    ports: {
-      ...mapHostConfigPortBindings(inspectResult),
-      ...mapPorts(inspectResult),
-    },
+    ports: mapPorts(inspectResult),
     healthCheckStatus: mapHealthCheckStatus(inspectResult),
     networkSettings: mapNetworkSettings(inspectResult),
     state: {
@@ -21,27 +18,6 @@ export function mapInspectResult(inspectResult: ContainerInspectInfo): InspectRe
     },
     labels: inspectResult.Config.Labels,
   };
-}
-
-type HostConfigPortBindings = {
-  [port: string]: Array<{
-    HostIp: string;
-    HostPort: string;
-  }>;
-};
-
-function mapHostConfigPortBindings(inspectInfo: ContainerInspectInfo): Ports {
-  return Object.entries(inspectInfo.HostConfig.PortBindings as HostConfigPortBindings)
-    .filter(([, hostPorts]) => hostPorts !== null)
-    .map(([containerPort, hostPorts]) => {
-      return {
-        [parseInt(containerPort)]: hostPorts.map((hostPort) => ({
-          hostIp: hostPort.HostIp,
-          hostPort: parseInt(hostPort.HostPort),
-        })),
-      };
-    })
-    .reduce((acc, curr) => ({ ...acc, ...curr }), {});
 }
 
 function mapPorts(inspectInfo: ContainerInspectInfo): Ports {


### PR DESCRIPTION
Closes #783 

I looked into this a bit and as suggested removing the status-filter in `fetchByLabel` will make it find the exited container. And then I had to check if it is running or not, and start it if not.

But I hit on a problem when using `@testcontainers/postgresql` that it could not find bound ports on an exited container that is being restarted:
```
node_modules/testcontainers/build/utils/bound-ports.js:14  throw new Error(`No port binding found for :${port}`)
```

The bound ports seems to be created from a an [inspection result when trying to reuse the container](https://github.com/testcontainers/testcontainers-node/blob/main/packages/testcontainers/src/generic-container/generic-container.ts#L133-L135).

And the ports in the inspection results seem to be mapped from the [`NetworkSettings.Ports` section when inspecting the container](https://github.com/testcontainers/testcontainers-node/blob/main/packages/testcontainers/src/utils/map-inspect-result.ts#L24).

What seems to be the underlying issue here though is that `NetworkSettings` seems to be reflecting what a running container has as current network settings. Which seems to be empty values when doing `docker inspect` on an exited container:

```
"NetworkSettings": {
    "Ports": {},
}
```


Compared to a running container:


```
"NetworkSettings": {
  "Ports": {
      "5432/tcp": [
          {
              "HostIp": "0.0.0.0",
              "HostPort": "54301"
          },
          {
              "HostIp": "::",
              "HostPort": "54301"
          }
      ]
  },
}
```

So basically I had to inspect the container again after re-starting it to get the correct bound ports and their IPs.