### PR TITLE
Add Node 22 to CI version matrix

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Install NodeJS
       uses: actions/setup-node@v4
       with:
-        node-version: 18.x
+        node-version: 22.x
     - name: Install dependencies
       run: npm ci --omit=optional
     - name: Code linting

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           registry-url: "https://registry.npmjs.org"
 
       - name: Configure Git

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         runner: [ ubuntu-22.04 ]
-        node-version: [ 18.x, 20.x ]
+        node-version: [ 18.x, 20.x, 22.x ]
     steps:
       - name: Code checkout
         uses: actions/checkout@v4
@@ -49,7 +49,7 @@ jobs:
     needs: smoke-test
     strategy:
       matrix:
-        node-version: [ 18.x, 20.x ]
+        node-version: [ 18.x, 20.x, 22.x ]
         container-runtime: [ docker, podman ]
         include:
           - container-runtime: docker
@@ -78,7 +78,7 @@ jobs:
     needs: [ test-testcontainers, list-modules ]
     strategy:
       matrix:
-        node-version: [ 18.x, 20.x ]
+        node-version: [ 18.x, 20.x, 22.x ]
         container-runtime: [ docker, podman ]
         include:
           - container-runtime: docker


### PR DESCRIPTION
Add Node.js 22 to CI version matrix, as it is the "current" version and LTS. Also moves single version actions to run in 22 instead of the older 18, which will be end-of-life in six months.

I've been running TestContainers in 22 for a while now without issue, but would be nice to have them in official test battery too. For successful CI run, see [PR in this fork.](https://github.com/stscoundrel/testcontainers-node/pull/4)