### PR TITLE
MySQL add `isRoot` parameter to `executeQuery`

### DIFF
--- a/packages/modules/mysql/src/mysql-container.test.ts
+++ b/packages/modules/mysql/src/mysql-container.test.ts
@@ -105,11 +105,11 @@ describe("MySqlContainer", () => {
 
     // Test non-root user
     const queryResult = await container.executeQuery("SELECT CURRENT_USER() as user");
-    expect(queryResult).toEqual(expect.stringContaining("user\ncustomUsername@%\n"));
+    expect(queryResult).toEqual(expect.stringContaining("user\ncustomUsername"));
 
     // Test root user
     const rootQueryResult = await container.executeQuery("SELECT CURRENT_USER() as user", [], true);
-    expect(rootQueryResult).toEqual(expect.stringContaining("user\nroot@%\n"));
+    expect(rootQueryResult).toEqual(expect.stringContaining("user\nroot"));
 
     await container.stop();
   });

--- a/packages/modules/mysql/src/mysql-container.test.ts
+++ b/packages/modules/mysql/src/mysql-container.test.ts
@@ -99,5 +99,19 @@ describe("MySqlContainer", () => {
 
     await container.stop();
   });
+
+  it("should execute a query as root user", async () => {
+    const container = await new MySqlContainer().withUsername("customUsername").start();
+
+    // Test non-root user
+    const queryResult = await container.executeQuery("SELECT CURRENT_USER() as user");
+    expect(queryResult).toEqual(expect.stringContaining("user\ncustomUsername@%\n"));
+
+    // Test root user
+    const rootQueryResult = await container.executeQuery("SELECT CURRENT_USER() as user", [], true);
+    expect(rootQueryResult).toEqual(expect.stringContaining("user\nroot@%\n"));
+
+    await container.stop();
+  });
   // }
 });

--- a/packages/modules/mysql/src/mysql-container.ts
+++ b/packages/modules/mysql/src/mysql-container.ts
@@ -94,14 +94,14 @@ export class StartedMySqlContainer extends AbstractStartedContainer {
     return url.toString();
   }
 
-  public async executeQuery(query: string, additionalFlags: string[] = []): Promise<string> {
+  public async executeQuery(query: string, additionalFlags: string[] = [], isRoot = false): Promise<string> {
     const result = await this.startedTestContainer.exec([
       "mysql",
       "-h",
       "127.0.0.1",
       "-u",
-      this.username,
-      `-p${this.userPassword}`,
+      isRoot ? "root" : this.username,
+      `-p${isRoot ? this.getRootPassword() : this.getUserPassword()}`,
       "-e",
       `${query};`,
       ...additionalFlags,


### PR DESCRIPTION
It's convenient to be able to perform root operations directly on the container. The parameter is optional and defaults to the current behaviour, so it's no breaking change.