### PR TITLE
feat(file-lock): Added configurable retries for file-lock

### DIFF
--- a/packages/testcontainers/package.json
+++ b/packages/testcontainers/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@balena/dockerignore": "^1.0.2",
     "@types/dockerode": "^3.3.29",
+    "@types/retry": "^0.12.5",
     "archiver": "^7.0.1",
     "async-lock": "^1.4.1",
     "byline": "^5.0.0",

--- a/packages/testcontainers/src/common/index.ts
+++ b/packages/testcontainers/src/common/index.ts
@@ -5,3 +5,4 @@ export { Uuid, RandomUuid } from "./uuid";
 export { streamToString } from "./streams";
 export { withFileLock } from "./file-lock";
 export { Retry, IntervalRetry } from "./retry";
+export { setRetryOptions, getRetryOptions } from "./preferences";

--- a/packages/testcontainers/src/common/preferences.ts
+++ b/packages/testcontainers/src/common/preferences.ts
@@ -1,0 +1,11 @@
+import type { WrapOptions } from "retry";
+
+let retryOptions: WrapOptions = {};
+
+export function setRetryOptions(retryOptionsInput: Omit<WrapOptions, "forever">): void {
+  retryOptions = retryOptionsInput;
+}
+
+export function getRetryOptions(): WrapOptions {
+  return retryOptions;
+}

--- a/packages/testcontainers/src/test-containers.ts
+++ b/packages/testcontainers/src/test-containers.ts
@@ -1,6 +1,7 @@
 import { PortForwarderInstance } from "./port-forwarder/port-forwarder";
 import { getContainerRuntimeClient } from "./container-runtime";
 import { log } from "./common";
+import type { WrapOptions } from "retry";
 
 export class TestContainers {
   public static async exposeHostPorts(...ports: number[]): Promise<void> {
@@ -17,6 +18,10 @@ export class TestContainers {
         })
       )
     );
+  }
+
+  public static setLockFileRetryOptions(retryOptions: Omit<WrapOptions, "forever">): void {
+    retryOptions;
   }
 
   private static async isHostPortExposed(portForwarderContainerId: string, hostPort: number): Promise<boolean> {


### PR DESCRIPTION
When test processes with isolated testcontainers are running in parallel they become very slow to start because of the file-lock retry strategy in testcontainers. 

`proper-filelock` uses `node-retry` ([repo](https://github.com/tim-kos/node-retry/tree/v0.12.0))  and exposes options to configure `node-retry` behavior. The current option is `{ retries: { forever: true } }`. This leaves the rest on defaults (`factor` `2`, `minTimeout` `1000`, `maxTimeout` `infinity`).

This PR allows the user to configure some parts of the file lock retry strategy.

Example

Multiple tests are started in parallel with jest as different processes (default behavior). They start at the same time (default jest behavior). 
Each test uses a `GenericContainer` and tries to start it. Because the process are started at the same time and use the same exponential back-off algorithm (node-retry) most of the time the processes check again on the same moment. This causes exponentially longer tests depending on how many are running in parallel. 

Tweaking the retry strategy to lower the `minTimeout` and `factor` can result in serious speed-up. 