### PR TITLE
Optimise file-lock retry options

### DIFF
--- a/packages/testcontainers/src/common/file-lock.ts
+++ b/packages/testcontainers/src/common/file-lock.ts
@@ -9,7 +9,9 @@ export async function withFileLock<T>(fileName: string, fn: () => T): Promise<T>
   let releaseLockFn;
   try {
     log.debug(`Acquiring lock file "${file}"...`);
-    releaseLockFn = await lockFile.lock(file, { retries: { forever: true } });
+    releaseLockFn = await lockFile.lock(file, {
+      retries: { forever: true, factor: 1, minTimeout: 500, maxTimeout: 3000, randomize: true },
+    });
     log.debug(`Acquired lock file "${file}"`);
     return await fn();
   } finally {


### PR DESCRIPTION
When processes with testcontainers are running in parallel they become very slow to start because of the file-lock retry strategy in testcontainers.

`proper-filelock` uses `node-retry` ([repo](https://github.com/tim-kos/node-retry/tree/v0.12.0)) and exposes options to configure `node-retry` behavior. The current option is `{ retries: { forever: true } }`. This leaves the rest on defaults (factor 2, minTimeout 1000, maxTimeout infinity).

Set `file-lock` retry options to retry faster and more frequently, avoiding timeouts that become too long. 

```typescript
{
  retries: {
    forever: true,
    factor: 1,
    minTimeout: 500,
    maxTimeout: 3000,
    randomize: true
  }
}
```