### PR TITLE
Support restart on 5 containers with previously fixed ports

### DIFF
--- a/packages/modules/cassandra/src/cassandra-container.test.ts
+++ b/packages/modules/cassandra/src/cassandra-container.test.ts
@@ -109,4 +109,23 @@ describe("Cassandra", () => {
     await container.stop();
   });
   // }
+
+  it("should work with restarted container", async () => {
+    const container = await new CassandraContainer("cassandra:5.0.2").start();
+    await container.restart();
+
+    const client = new Client({
+      contactPoints: [container.getContactPoint()],
+      localDataCenter: container.getDatacenter(),
+      keyspace: "system",
+    });
+
+    await client.connect();
+
+    const result = await client.execute("SELECT release_version FROM system.local");
+    expect(result.rows[0].release_version).toBe("5.0.2");
+
+    await client.shutdown();
+    await container.stop();
+  });
 });

--- a/packages/modules/cassandra/src/cassandra-container.ts
+++ b/packages/modules/cassandra/src/cassandra-container.ts
@@ -50,8 +50,6 @@ export class CassandraContainer extends GenericContainer {
 }
 
 export class StartedCassandraContainer extends AbstractStartedContainer {
-  private readonly port: number;
-
   constructor(
     startedTestContainer: StartedTestContainer,
     private readonly dc: string,
@@ -60,11 +58,10 @@ export class StartedCassandraContainer extends AbstractStartedContainer {
     private readonly password: string
   ) {
     super(startedTestContainer);
-    this.port = startedTestContainer.getMappedPort(CASSANDRA_PORT);
   }
 
   public getPort(): number {
-    return this.port;
+    return this.startedTestContainer.getMappedPort(CASSANDRA_PORT);
   }
 
   public getDatacenter(): string {

--- a/packages/modules/elasticsearch/src/elasticsearch-container.test.ts
+++ b/packages/modules/elasticsearch/src/elasticsearch-container.test.ts
@@ -35,4 +35,16 @@ describe("ElasticsearchContainer", () => {
     await container.stop();
   });
   // }
+
+  it("should work with restarted container", async () => {
+    const container = await new ElasticsearchContainer().start();
+    await container.restart();
+
+    const client = new Client({ node: container.getHttpUrl() });
+
+    await client.indices.create({ index: "people" });
+
+    expect((await client.indices.exists({ index: "people" })).statusCode).toBe(200);
+    await container.stop();
+  });
 });

--- a/packages/modules/elasticsearch/src/elasticsearch-container.ts
+++ b/packages/modules/elasticsearch/src/elasticsearch-container.ts
@@ -22,14 +22,15 @@ export class ElasticsearchContainer extends GenericContainer {
 }
 
 export class StartedElasticsearchContainer extends AbstractStartedContainer {
-  private readonly httpPort: number;
-
   constructor(override readonly startedTestContainer: StartedTestContainer) {
     super(startedTestContainer);
-    this.httpPort = this.getMappedPort(ELASTIC_SEARCH_HTTP_PORT);
+  }
+
+  public getPort(): number {
+    return this.getMappedPort(ELASTIC_SEARCH_HTTP_PORT);
   }
 
   public getHttpUrl(): string {
-    return `http://${this.getHost()}:${this.httpPort}`;
+    return `http://${this.getHost()}:${this.getPort()}`;
   }
 }

--- a/packages/modules/mariadb/src/mariadb-container.test.ts
+++ b/packages/modules/mariadb/src/mariadb-container.test.ts
@@ -125,4 +125,23 @@ describe("MariaDb", () => {
     await container.stop();
   });
   // }
+
+  it("should work with restarted container", async () => {
+    const container = await new MariaDbContainer().start();
+    await container.restart();
+
+    const client = await mariadb.createConnection({
+      host: container.getHost(),
+      port: container.getPort(),
+      database: container.getDatabase(),
+      user: container.getUsername(),
+      password: container.getUserPassword(),
+    });
+
+    const rows = await client.query("SELECT 1 as res");
+    expect(rows).toEqual([{ res: 1 }]);
+
+    await client.end();
+    await container.stop();
+  });
 });

--- a/packages/modules/mariadb/src/mariadb-container.ts
+++ b/packages/modules/mariadb/src/mariadb-container.ts
@@ -51,8 +51,6 @@ export class MariaDbContainer extends GenericContainer {
 }
 
 export class StartedMariaDbContainer extends AbstractStartedContainer {
-  private readonly port: number;
-
   constructor(
     startedTestContainer: StartedTestContainer,
     private readonly database: string,
@@ -61,11 +59,10 @@ export class StartedMariaDbContainer extends AbstractStartedContainer {
     private readonly rootPassword: string
   ) {
     super(startedTestContainer);
-    this.port = startedTestContainer.getMappedPort(MARIADB_PORT);
   }
 
   public getPort(): number {
-    return this.port;
+    return this.startedTestContainer.getMappedPort(MARIADB_PORT);
   }
 
   public getDatabase(): string {

--- a/packages/modules/mysql/src/mysql-container.test.ts
+++ b/packages/modules/mysql/src/mysql-container.test.ts
@@ -114,4 +114,23 @@ describe("MySqlContainer", () => {
     await container.stop();
   });
   // }
+
+  it("should work with restarted container", async () => {
+    const container = await new MySqlContainer().start();
+    await container.restart();
+
+    const client = await createConnection({
+      host: container.getHost(),
+      port: container.getPort(),
+      database: container.getDatabase(),
+      user: container.getUsername(),
+      password: container.getUserPassword(),
+    });
+
+    const [rows] = await client.execute("SELECT 1 as res");
+    expect(rows).toEqual([{ res: 1 }]);
+
+    await client.end();
+    await container.stop();
+  });
 });

--- a/packages/modules/mysql/src/mysql-container.ts
+++ b/packages/modules/mysql/src/mysql-container.ts
@@ -51,8 +51,6 @@ export class MySqlContainer extends GenericContainer {
 }
 
 export class StartedMySqlContainer extends AbstractStartedContainer {
-  private readonly port: number;
-
   constructor(
     startedTestContainer: StartedTestContainer,
     private readonly database: string,
@@ -61,11 +59,10 @@ export class StartedMySqlContainer extends AbstractStartedContainer {
     private readonly rootPassword: string
   ) {
     super(startedTestContainer);
-    this.port = startedTestContainer.getMappedPort(3306);
   }
 
   public getPort(): number {
-    return this.port;
+    return this.startedTestContainer.getMappedPort(MYSQL_PORT);
   }
 
   public getDatabase(): string {

--- a/packages/modules/scylladb/src/scylladb-container.test.ts
+++ b/packages/modules/scylladb/src/scylladb-container.test.ts
@@ -64,4 +64,23 @@ describe("ScyllaDB", () => {
     await container.stop();
   });
   // }
+
+  it("should work with restarted container", async () => {
+    const container = await new ScyllaContainer("scylladb/scylla:6.2.0").start();
+    await container.restart();
+
+    const client = new Client({
+      contactPoints: [container.getContactPoint()],
+      localDataCenter: container.getDatacenter(),
+      keyspace: "system",
+    });
+
+    await client.connect();
+
+    const result = await client.execute("SELECT cql_version FROM system.local");
+    expect(result.rows[0].cql_version).toBe("3.3.1");
+
+    await client.shutdown();
+    await container.stop();
+  });
 });

--- a/packages/modules/scylladb/src/scylladb-container.ts
+++ b/packages/modules/scylladb/src/scylladb-container.ts
@@ -21,15 +21,12 @@ export class ScyllaContainer extends GenericContainer {
 }
 
 export class StartedScyllaContainer extends AbstractStartedContainer {
-  private readonly port: number;
-
   constructor(startedTestContainer: StartedTestContainer) {
     super(startedTestContainer);
-    this.port = startedTestContainer.getMappedPort(SCYLLA_PORT);
   }
 
   public getPort(): number {
-    return this.port;
+    return this.startedTestContainer.getMappedPort(SCYLLA_PORT);
   }
 
   public getDatacenter(): string {


### PR DESCRIPTION
As pointed out in https://github.com/testcontainers/testcontainers-node/pull/893#discussion_r1911422351, individual testcontainers should not store their mapped ports in class members, as the mapped port will change in restart.

There are many test containers that currently use that pattern of port mapping, meaning they wont work after a restart. This PR fixes five of them:

- MariaDB
- MySQL
- ScyllaDB
- Cassandra
- ElasticSearch

There are few others that have similar port mapping (Neo4j, ArangoDB, PostgreSQL etc...), but they utilize wait strategies that do not currently work with restarts. For example, Neo4j expects a certain log message to appear before it is "ready", but that log message only appears on initial start, not on restart. This seems a bit more complex to solve, so I left them outside of scope of this PR for now. Will probably take another look at it later in separate PR, as there were previous commits solving this very issue, but they were later overwritten in another fix.

For successful CI run, see [PR in this fork](https://github.com/stscoundrel/testcontainers-node/pull/7)