### PR TITLE
Enable/disable container reuse with an environment variable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,3 +43,4 @@ Configuration of Testcontainers and its behaviours:
 | TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX  | mycompany.com/registry    | Set default image registry               |
 | RYUK_CONTAINER_IMAGE                  | testcontainers/ryuk:0.5.1 | Custom image for ryuk                    |
 | SSHD_CONTAINER_IMAGE                  | testcontainers/sshd:1.1.0 | Custom image for SSHd                    |
+| TESTCONTAINERS_REUSE_ENABLE           | true                      | Enable reusable containers               |

--- a/docs/features/containers.md
+++ b/docs/features/containers.md
@@ -365,6 +365,9 @@ const container2 = await new GenericContainer("alpine")
 expect(container1.getId()).toBe(container2.getId());
 ```
 
+Container re-use can be enabled or disabled globally by setting the `TESTCONTAINERS_REUSE_ENABLE` environment variable to `true` or `false`.
+If this environment variable is not declared, the feature is enabled by default.
+
 ## Creating a custom container
 
 You can create your own Generic Container as follows:

--- a/packages/testcontainers/src/generic-container/generic-container.ts
+++ b/packages/testcontainers/src/generic-container/generic-container.ts
@@ -100,7 +100,7 @@ export class GenericContainer implements TestContainer {
 
     this.createOpts.Labels = { ...createLabels(), ...this.createOpts.Labels };
 
-    if (this.reuse) {
+    if (process.env.TESTCONTAINERS_REUSE_ENABLE !== "false" && this.reuse) {
       return this.reuseOrStartContainer(client);
     }
 


### PR DESCRIPTION
This PR introduces `TESTCONTAINERS_REUSE_ENABLE` environment variable to enable or disable the container re-use feature globally.
If `TESTCONTAINERS_REUSE_ENABLE` is not declared, the feature stays enabled by default to maintain backward compatibility.

Resolves #907.