### PR TITLE
Add CockroachDB module

### DIFF
--- a/docs/modules/cockroachdb.md
+++ b/docs/modules/cockroachdb.md
@@ -1,0 +1,28 @@
+# CockroachDB Module
+
+[CockroachDB](https://github.com/cockroachdb/cockroach) is a cloud-native, postgresql compatible, distributed SQL database designed to build, scale, and manage modern, data-intensive applications.
+
+
+## Install
+
+```bash
+npm install @testcontainers/cockroachdb --save-dev
+```
+
+## Examples
+
+<!--codeinclude-->
+[Connect and execute query:](../../packages/modules/cockroachdb/src/cockroachdb-container.test.ts) inside_block:connect
+<!--/codeinclude-->
+
+<!--codeinclude-->
+[Connect and execute query using URI:](../../packages/modules/cockroachdb/src/cockroachdb-container.test.ts) inside_block:uriConnect
+<!--/codeinclude-->
+
+<!--codeinclude-->
+[Set database:](../../packages/modules/cockroachdb/src/cockroachdb-container.test.ts) inside_block:setDatabase
+<!--/codeinclude-->
+
+<!--codeinclude-->
+[Set username:](../../packages/modules/cockroachdb/src/cockroachdb-container.test.ts) inside_block:setUsername
+<!--/codeinclude-->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
       - Cassandra: modules/cassandra.md
       - ChromaDB: modules/chromadb.md
       - Couchbase: modules/couchbase.md
+      - CockroachDB: modules/cockroachdb.md
       - Elasticsearch: modules/elasticsearch.md
       - EventStoreDB: modules/eventstoredb.md
       - GCloud: modules/gcloud.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -5754,6 +5754,10 @@
       "resolved": "packages/modules/chromadb",
       "link": true
     },
+    "node_modules/@testcontainers/cockroachdb": {
+      "resolved": "packages/modules/cockroachdb",
+      "link": true
+    },
     "node_modules/@testcontainers/couchbase": {
       "resolved": "packages/modules/couchbase",
       "link": true
@@ -21192,6 +21196,18 @@
         "openai": {
           "optional": true
         }
+      }
+    },
+    "packages/modules/cockroachdb": {
+      "name": "@testcontainers/cockroachdb",
+      "version": "10.18.0",
+      "license": "MIT",
+      "dependencies": {
+        "testcontainers": "^10.18.0"
+      },
+      "devDependencies": {
+        "@types/pg": "^8.11.6",
+        "pg": "^8.12.0"
       }
     },
     "packages/modules/couchbase": {

--- a/packages/modules/cockroachdb/jest.config.ts
+++ b/packages/modules/cockroachdb/jest.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from "jest";
+import * as path from "path";
+
+const config: Config = {
+  preset: "ts-jest",
+  moduleNameMapper: {
+    "^testcontainers$": path.resolve(__dirname, "../../testcontainers/src"),
+  },
+};
+
+export default config;

--- a/packages/modules/cockroachdb/package.json
+++ b/packages/modules/cockroachdb/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@testcontainers/cockroachdb",
+  "version": "10.18.0",
+  "license": "MIT",
+  "keywords": [
+    "cockroachdb",
+    "crdb",
+    "testing",
+    "docker",
+    "testcontainers"
+  ],
+  "description": "CockroachDB module for Testcontainers",
+  "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/testcontainers/testcontainers-node"
+  },
+  "bugs": {
+    "url": "https://github.com/testcontainers/testcontainers-node/issues"
+  },
+  "main": "build/index.js",
+  "files": [
+    "build"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "prepack": "shx cp ../../../README.md . && shx cp ../../../LICENSE .",
+    "build": "tsc --project tsconfig.build.json"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.11.6",
+    "pg": "^8.12.0"
+  },
+  "dependencies": {
+    "testcontainers": "^10.18.0"
+  }
+}

--- a/packages/modules/cockroachdb/src/cockroachdb-container.test.ts
+++ b/packages/modules/cockroachdb/src/cockroachdb-container.test.ts
@@ -8,8 +8,6 @@ describe("CockroachDbContainer", () => {
   it("should connect and return a query result", async () => {
     const container = await new CockroachDbContainer().start();
 
-    console.log(container.getDatabase(), container.getHost(), container.getPort());
-
     const client = new Client({
       host: container.getHost(),
       port: container.getPort(),

--- a/packages/modules/cockroachdb/src/cockroachdb-container.test.ts
+++ b/packages/modules/cockroachdb/src/cockroachdb-container.test.ts
@@ -101,4 +101,15 @@ describe("CockroachDbContainer", () => {
     await client.end();
     await container.stop();
   });
+
+  it("should allow custom healthcheck", async () => {
+    const container = new CockroachDbContainer().withHealthCheck({
+      test: ["CMD-SHELL", "exit 1"],
+      interval: 100,
+      retries: 0,
+      timeout: 0,
+    });
+
+    await expect(() => container.start()).rejects.toThrow();
+  });
 });

--- a/packages/modules/cockroachdb/src/cockroachdb-container.test.ts
+++ b/packages/modules/cockroachdb/src/cockroachdb-container.test.ts
@@ -1,0 +1,108 @@
+import { Client } from "pg";
+import { CockroachDbContainer } from "./cockroachdb-container";
+
+describe("CockroachDbContainer", () => {
+  jest.setTimeout(180_000);
+
+  // connect {
+  it("should connect and return a query result", async () => {
+    const container = await new CockroachDbContainer().start();
+
+    console.log(container.getDatabase(), container.getHost(), container.getPort());
+
+    const client = new Client({
+      host: container.getHost(),
+      port: container.getPort(),
+      database: container.getDatabase(),
+      user: container.getUsername(),
+      ssl: false,
+    });
+
+    await client.connect();
+
+    const result = await client.query("SELECT 1");
+    expect(result.rows[0]).toEqual({ "?column?": "1" });
+
+    await client.end();
+    await container.stop();
+  });
+  // }
+
+  // uriConnect {
+  it("should work with database URI", async () => {
+    const container = await new CockroachDbContainer().start();
+
+    const client = new Client({
+      connectionString: container.getConnectionUri(),
+    });
+    await client.connect();
+
+    const result = await client.query("SELECT 1");
+    expect(result.rows[0]).toEqual({ "?column?": "1" });
+
+    await client.end();
+    await container.stop();
+  });
+  // }
+
+  // setDatabase {
+  it("should set database", async () => {
+    const container = await new CockroachDbContainer().withDatabase("custom_database").start();
+
+    const client = new Client({
+      host: container.getHost(),
+      port: container.getPort(),
+      database: container.getDatabase(),
+      user: container.getUsername(),
+    });
+    await client.connect();
+
+    const result = await client.query("SELECT current_database()");
+    expect(result.rows[0]).toEqual({ current_database: "custom_database" });
+
+    await client.end();
+    await container.stop();
+  });
+  // }
+
+  // setUsername {
+  it("should set username", async () => {
+    const container = await new CockroachDbContainer().withUsername("custom_username").start();
+
+    const client = new Client({
+      host: container.getHost(),
+      port: container.getPort(),
+      database: container.getDatabase(),
+      user: container.getUsername(),
+    });
+    await client.connect();
+
+    const result = await client.query("SELECT current_user");
+    expect(result.rows[0]).toEqual({ current_user: "custom_username" });
+
+    await client.end();
+    await container.stop();
+  });
+  // }
+
+  it("should work with restarted container", async () => {
+    const container = await new CockroachDbContainer().start();
+    const port = container.getFirstMappedPort();
+    await container.restart();
+    expect(port).not.toEqual(container.getFirstMappedPort());
+
+    const client = new Client({
+      host: container.getHost(),
+      port: container.getPort(),
+      database: container.getDatabase(),
+      user: container.getUsername(),
+    });
+    await client.connect();
+
+    const result = await client.query("SELECT 1");
+    expect(result.rows[0]).toEqual({ "?column?": "1" });
+
+    await client.end();
+    await container.stop();
+  });
+});

--- a/packages/modules/cockroachdb/src/cockroachdb-container.test.ts
+++ b/packages/modules/cockroachdb/src/cockroachdb-container.test.ts
@@ -85,9 +85,7 @@ describe("CockroachDbContainer", () => {
 
   it("should work with restarted container", async () => {
     const container = await new CockroachDbContainer().start();
-    const port = container.getFirstMappedPort();
     await container.restart();
-    expect(port).not.toEqual(container.getFirstMappedPort());
 
     const client = new Client({
       host: container.getHost(),

--- a/packages/modules/cockroachdb/src/cockroachdb-container.ts
+++ b/packages/modules/cockroachdb/src/cockroachdb-container.ts
@@ -1,0 +1,75 @@
+import { AbstractStartedContainer, GenericContainer, StartedTestContainer, Wait } from "testcontainers";
+
+const COCKROACH_PORT = 26257;
+const COCKROACH_HTTP_PORT = 26258;
+
+export class CockroachDbContainer extends GenericContainer {
+  private database = "test";
+  private username = "test";
+
+  constructor(image = "cockroachdb/cockroach:v24.3.5") {
+    super(image);
+    this.withExposedPorts(COCKROACH_PORT, COCKROACH_HTTP_PORT)
+      .withCommand(["start-single-node", "--insecure", "--http-addr=0.0.0.0:" + COCKROACH_HTTP_PORT])
+      .withHealthCheck({
+        test: ["CMD-SHELL", "curl -f http://localhost:" + COCKROACH_HTTP_PORT + " || exit 1"],
+        interval: 1000,
+        timeout: 3000,
+        retries: 5,
+        startPeriod: 1000,
+      })
+      .withWaitStrategy(Wait.forHealthCheck());
+  }
+
+  public withDatabase(database: string): this {
+    this.database = database;
+    return this;
+  }
+
+  public withUsername(username: string): this {
+    this.username = username;
+    return this;
+  }
+
+  public override async start(): Promise<StartedCockroachDbContainer> {
+    this.withEnvironment({
+      COCKROACH_DATABASE: this.database,
+      COCKROACH_USER: this.username,
+    });
+    return new StartedCockroachDbContainer(await super.start(), this.database, this.username);
+  }
+}
+
+export class StartedCockroachDbContainer extends AbstractStartedContainer {
+  constructor(
+    startedTestContainer: StartedTestContainer,
+    private readonly database: string,
+    private readonly username: string
+  ) {
+    super(startedTestContainer);
+  }
+
+  public getPort(): number {
+    return this.startedTestContainer.getMappedPort(COCKROACH_PORT);
+  }
+
+  public getDatabase(): string {
+    return this.database;
+  }
+
+  public getUsername(): string {
+    return this.username;
+  }
+
+  /**
+   * @returns A connection URI in the form of `postgres[ql]://[username[:password]@][host[:port],]/database`
+   */
+  public getConnectionUri(): string {
+    const url = new URL("", "postgres://");
+    url.hostname = this.getHost();
+    url.port = this.getPort().toString();
+    url.pathname = this.getDatabase();
+    url.username = this.getUsername();
+    return url.toString();
+  }
+}

--- a/packages/modules/cockroachdb/src/index.ts
+++ b/packages/modules/cockroachdb/src/index.ts
@@ -1,0 +1,1 @@
+export { CockroachDbContainer, StartedCockroachDbContainer } from "./cockroachdb-container";

--- a/packages/modules/cockroachdb/tsconfig.build.json
+++ b/packages/modules/cockroachdb/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "build",
+    "jest.config.ts",
+    "src/**/*.test.ts"
+  ],
+  "references": [
+    {
+      "path": "../../testcontainers"
+    }
+  ]
+}

--- a/packages/modules/cockroachdb/tsconfig.json
+++ b/packages/modules/cockroachdb/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build",
+    "paths": {
+      "testcontainers": [
+        "../../testcontainers/src"
+      ]
+    }
+  },
+  "exclude": [
+    "build",
+    "jest.config.ts"
+  ],
+  "references": [
+    {
+      "path": "../../testcontainers"
+    }
+  ]
+}


### PR DESCRIPTION
# Adds CockroachDB Support

This is mainly the same as the postgres container, with a few minor details:

* It uses CRDB's `--insecure` flag to avoid needing to deal with certs for local testing/connections
* Due to the above, no password is set 