### PR TITLE
Update docs to demonstrate specifying Qdrant version

### DIFF
--- a/packages/modules/qdrant/src/qdrant-container.test.ts
+++ b/packages/modules/qdrant/src/qdrant-container.test.ts
@@ -42,7 +42,7 @@ describe("QdrantContainer", () => {
       apiKey: "INVALID_KEY_" + crypto.randomUUID(),
     });
 
-    expect(client.getCollections()).rejects.toThrow("Forbidden");
+    expect(client.getCollections()).rejects.toThrow("Unauthorized");
 
     await container.stop();
   });
@@ -71,7 +71,7 @@ describe("QdrantContainer", () => {
       apiKey: "INVALID_KEY_" + crypto.randomUUID(),
     });
 
-    expect(client.getCollections()).rejects.toThrow("Forbidden");
+    expect(client.getCollections()).rejects.toThrow("Unauthorized");
 
     await container.stop();
   });

--- a/packages/modules/qdrant/src/qdrant-container.test.ts
+++ b/packages/modules/qdrant/src/qdrant-container.test.ts
@@ -49,7 +49,9 @@ describe("QdrantContainer", () => {
 
   // connectQdrantWithConfig {
   it("should work with config files - valid API key", async () => {
-    const container = await new QdrantContainer("qdrant/qdrant:v1.13.4").withConfigFile(path.resolve(__dirname, "test_config.yaml")).start();
+    const container = await new QdrantContainer("qdrant/qdrant:v1.13.4")
+      .withConfigFile(path.resolve(__dirname, "test_config.yaml"))
+      .start();
 
     const client = new QdrantClient({ url: `http://${container.getRestHostAddress()}`, apiKey: "SOME_TEST_KEY" });
 
@@ -60,7 +62,9 @@ describe("QdrantContainer", () => {
   // }
 
   it("should work with config files - invalid API key", async () => {
-    const container = await new QdrantContainer("qdrant/qdrant:v1.13.4").withConfigFile(path.resolve(__dirname, "test_config.yaml")).start();
+    const container = await new QdrantContainer("qdrant/qdrant:v1.13.4")
+      .withConfigFile(path.resolve(__dirname, "test_config.yaml"))
+      .start();
 
     const client = new QdrantClient({
       url: `http://${container.getRestHostAddress()}`,

--- a/packages/modules/qdrant/src/qdrant-container.test.ts
+++ b/packages/modules/qdrant/src/qdrant-container.test.ts
@@ -8,7 +8,7 @@ describe("QdrantContainer", () => {
 
   // connectQdrantSimple {
   it("should connect to the client", async () => {
-    const container = await new QdrantContainer().start();
+    const container = await new QdrantContainer("qdrant/qdrant:latest").start();
 
     const client = new QdrantClient({ url: `http://${container.getRestHostAddress()}` });
 
@@ -22,7 +22,7 @@ describe("QdrantContainer", () => {
   it("should work with valid API keys", async () => {
     const apiKey = crypto.randomUUID();
 
-    const container = await new QdrantContainer().withApiKey(apiKey).start();
+    const container = await new QdrantContainer("qdrant/qdrant:latest").withApiKey(apiKey).start();
 
     const client = new QdrantClient({ url: `http://${container.getRestHostAddress()}`, apiKey });
 
@@ -35,7 +35,7 @@ describe("QdrantContainer", () => {
   it("should fail for invalid API keys", async () => {
     const apiKey = crypto.randomUUID();
 
-    const container = await new QdrantContainer().withApiKey(apiKey).start();
+    const container = await new QdrantContainer("qdrant/qdrant:latest").withApiKey(apiKey).start();
 
     const client = new QdrantClient({
       url: `http://${container.getRestHostAddress()}`,
@@ -49,7 +49,7 @@ describe("QdrantContainer", () => {
 
   // connectQdrantWithConfig {
   it("should work with config files - valid API key", async () => {
-    const container = await new QdrantContainer().withConfigFile(path.resolve(__dirname, "test_config.yaml")).start();
+    const container = await new QdrantContainer("qdrant/qdrant:latest").withConfigFile(path.resolve(__dirname, "test_config.yaml")).start();
 
     const client = new QdrantClient({ url: `http://${container.getRestHostAddress()}`, apiKey: "SOME_TEST_KEY" });
 
@@ -60,7 +60,7 @@ describe("QdrantContainer", () => {
   // }
 
   it("should work with config files - invalid API key", async () => {
-    const container = await new QdrantContainer().withConfigFile(path.resolve(__dirname, "test_config.yaml")).start();
+    const container = await new QdrantContainer("qdrant/qdrant:latest").withConfigFile(path.resolve(__dirname, "test_config.yaml")).start();
 
     const client = new QdrantClient({
       url: `http://${container.getRestHostAddress()}`,

--- a/packages/modules/qdrant/src/qdrant-container.test.ts
+++ b/packages/modules/qdrant/src/qdrant-container.test.ts
@@ -8,7 +8,7 @@ describe("QdrantContainer", () => {
 
   // connectQdrantSimple {
   it("should connect to the client", async () => {
-    const container = await new QdrantContainer("qdrant/qdrant:latest").start();
+    const container = await new QdrantContainer("qdrant/qdrant:v1.13.4").start();
 
     const client = new QdrantClient({ url: `http://${container.getRestHostAddress()}` });
 
@@ -22,7 +22,7 @@ describe("QdrantContainer", () => {
   it("should work with valid API keys", async () => {
     const apiKey = crypto.randomUUID();
 
-    const container = await new QdrantContainer("qdrant/qdrant:latest").withApiKey(apiKey).start();
+    const container = await new QdrantContainer("qdrant/qdrant:v1.13.4").withApiKey(apiKey).start();
 
     const client = new QdrantClient({ url: `http://${container.getRestHostAddress()}`, apiKey });
 
@@ -35,7 +35,7 @@ describe("QdrantContainer", () => {
   it("should fail for invalid API keys", async () => {
     const apiKey = crypto.randomUUID();
 
-    const container = await new QdrantContainer("qdrant/qdrant:latest").withApiKey(apiKey).start();
+    const container = await new QdrantContainer("qdrant/qdrant:v1.13.4").withApiKey(apiKey).start();
 
     const client = new QdrantClient({
       url: `http://${container.getRestHostAddress()}`,
@@ -49,7 +49,7 @@ describe("QdrantContainer", () => {
 
   // connectQdrantWithConfig {
   it("should work with config files - valid API key", async () => {
-    const container = await new QdrantContainer("qdrant/qdrant:latest").withConfigFile(path.resolve(__dirname, "test_config.yaml")).start();
+    const container = await new QdrantContainer("qdrant/qdrant:v1.13.4").withConfigFile(path.resolve(__dirname, "test_config.yaml")).start();
 
     const client = new QdrantClient({ url: `http://${container.getRestHostAddress()}`, apiKey: "SOME_TEST_KEY" });
 
@@ -60,7 +60,7 @@ describe("QdrantContainer", () => {
   // }
 
   it("should work with config files - invalid API key", async () => {
-    const container = await new QdrantContainer("qdrant/qdrant:latest").withConfigFile(path.resolve(__dirname, "test_config.yaml")).start();
+    const container = await new QdrantContainer("qdrant/qdrant:v1.13.4").withConfigFile(path.resolve(__dirname, "test_config.yaml")).start();
 
     const client = new QdrantClient({
       url: `http://${container.getRestHostAddress()}`,

--- a/packages/modules/qdrant/src/qdrant-container.ts
+++ b/packages/modules/qdrant/src/qdrant-container.ts
@@ -8,7 +8,7 @@ export class QdrantContainer extends GenericContainer {
   private apiKey: string | undefined;
   private configFilePath: string | undefined;
 
-  constructor(image = "qdrant/qdrant:v1.8.1") {
+  constructor(image = "qdrant/qdrant:v1.13.4") {
     super(image);
     this.withExposedPorts(QDRANT_REST_PORT, QDRANT_GRPC_PORT);
     this.withWaitStrategy(


### PR DESCRIPTION
Hey 👋. Greetings from Qdrant.

`QdrantContainer` defaults to a specific version of Qdrant.

We had users coming from https://node.testcontainers.org/modules/qdrant/ not knowing how to specify a custom version. So this PR helps with demonstrating that.