### PR TITLE
chore: cache NPM dependencies in the smoke-test phase

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,17 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
         run: npm ci --omit=optional
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        shell: bash
+        run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
+      - uses: actions/cache@v4
+        id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-node-{{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-{{ matrix.node-version }}-
       - name: Build workspaces
         run: npm run build -ws
       - name: Remove dev dependencies


### PR DESCRIPTION
It caches the NPM dependencies using the official GH action for caching.

See https://github.com/actions/cache/blob/main/examples.md#node---npm for more info.


