### PR TITLE
Fix lambda container is dropped by ryuk (#848)

### DIFF
--- a/packages/modules/localstack/src/localstack-container.test.ts
+++ b/packages/modules/localstack/src/localstack-container.test.ts
@@ -1,6 +1,7 @@
-import { LOCALSTACK_PORT, LocalstackContainer } from "./localstack-container";
-import { HeadBucketCommand, S3Client, CreateBucketCommand } from "@aws-sdk/client-s3";
+import { CreateBucketCommand, HeadBucketCommand, S3Client } from "@aws-sdk/client-s3";
 import { GenericContainer, log, Network, StartedTestContainer } from "testcontainers";
+import { LABEL_TESTCONTAINERS_SESSION_ID } from "testcontainers/src/utils/labels";
+import { LocalstackContainer, LOCALSTACK_PORT } from "./localstack-container";
 
 const runAwsCliAgainstDockerNetworkContainer = async (
   command: string,
@@ -102,5 +103,14 @@ describe("LocalStackContainer", () => {
     expect(output).toContain("localhost");
 
     await container.stop();
+  });
+
+  it("should add LAMBDA_DOCKER_FLAGS with sessionId label", async () => {
+    const container = await new LocalstackContainer().start();
+    const sessionId = container.getLabels()[LABEL_TESTCONTAINERS_SESSION_ID];
+
+    const { output, exitCode } = await container.exec(["printenv", "LAMBDA_DOCKER_FLAGS"]);
+    expect(exitCode).toBe(0);
+    expect(output).toContain(`${LABEL_TESTCONTAINERS_SESSION_ID}=${sessionId}`);
   });
 });

--- a/packages/modules/localstack/src/localstack-container.ts
+++ b/packages/modules/localstack/src/localstack-container.ts
@@ -1,10 +1,20 @@
-import { AbstractStartedContainer, GenericContainer, log, StartedTestContainer, Wait } from "testcontainers";
+import {
+  AbstractStartedContainer,
+  GenericContainer,
+  getContainerRuntimeClient,
+  log,
+  StartedTestContainer,
+  Wait,
+} from "testcontainers";
+import { getReaper } from "testcontainers/src/reaper/reaper";
+import { LABEL_TESTCONTAINERS_SESSION_ID } from "testcontainers/src/utils/labels";
 
 export const LOCALSTACK_PORT = 4566;
 
 export class LocalstackContainer extends GenericContainer {
   constructor(image = "localstack/localstack:2.2.0") {
     super(image);
+
     this.withExposedPorts(LOCALSTACK_PORT).withWaitStrategy(Wait.forLogMessage("Ready", 1)).withStartupTimeout(120_000);
   }
 
@@ -25,8 +35,19 @@ export class LocalstackContainer extends GenericContainer {
     log.info(`${envVar} environment variable set to "${this.environment[envVar]}" (${hostnameExternalReason})`);
   }
 
+  /**
+   * Configure the LocalStack container to add sessionId when starting lambda container.
+   * This allows the lambda container to be identified by the {@link Reaper} and cleaned up on exit.
+   */
+  private async flagLambdaSessionId(): Promise<void> {
+    const client = await getContainerRuntimeClient();
+    const reaper = await getReaper(client);
+    this.withEnvironment({ LAMBDA_DOCKER_FLAGS: `-l ${LABEL_TESTCONTAINERS_SESSION_ID}=${reaper.sessionId}` });
+  }
+
   protected override async beforeContainerCreated(): Promise<void> {
     this.resolveHostname();
+    await this.flagLambdaSessionId();
   }
 
   public override async start(): Promise<StartedLocalStackContainer> {


### PR DESCRIPTION
Fixes #848 

Configure the LocalStack container to add sessionId when starting lambda container.
This allows the lambda container to be identified by the reaper and cleaned up on exit.

See [Localstack documentation](https://docs.localstack.cloud/references/configuration/) for more details about LAMBDA_DOCKER_FLAGS