### PR TITLE
Add ability to copy archives into containers

### DIFF
--- a/docs/features/containers.md
+++ b/docs/features/containers.md
@@ -133,6 +133,10 @@ const container = await new GenericContainer("alpine")
     content: "hello world",
     target: "/remote/file2.txt"
   }])
+  .withCopyArchivesToContainer([{
+    tar: nodeReadable,
+    target: "/some/nested/remotedir"
+  }])
   .start();
 ```
 
@@ -153,6 +157,7 @@ container.copyContentToContainer([{
   content: "hello world",
   target: "/remote/file2.txt"
 }])
+container.copyArchiveToContainer(nodeReadable, "/some/nested/remotedir");
 ```
 
 An optional `mode` can be specified in octal for setting file permissions:

--- a/packages/testcontainers/src/generic-container/abstract-started-container.ts
+++ b/packages/testcontainers/src/generic-container/abstract-started-container.ts
@@ -83,6 +83,10 @@ export class AbstractStartedContainer implements StartedTestContainer {
     return this.startedTestContainer.copyContentToContainer(contentsToCopy);
   }
 
+  public copyArchiveToContainer(tar: Readable, target = "/"): Promise<void> {
+    return this.startedTestContainer.copyArchiveToContainer(tar, target);
+  }
+
   public copyArchiveFromContainer(path: string): Promise<NodeJS.ReadableStream> {
     return this.startedTestContainer.copyArchiveFromContainer(path);
   }

--- a/packages/testcontainers/src/generic-container/generic-container.ts
+++ b/packages/testcontainers/src/generic-container/generic-container.ts
@@ -10,6 +10,7 @@ import { PortForwarderInstance, SSHD_IMAGE } from "../port-forwarder/port-forwar
 import { getReaper, REAPER_IMAGE } from "../reaper/reaper";
 import { StartedTestContainer, TestContainer } from "../test-container";
 import {
+  ArchiveToCopy,
   BindMount,
   ContentToCopy,
   DirectoryToCopy,
@@ -57,6 +58,7 @@ export class GenericContainer implements TestContainer {
   protected filesToCopy: FileToCopy[] = [];
   protected directoriesToCopy: DirectoryToCopy[] = [];
   protected contentsToCopy: ContentToCopy[] = [];
+  protected archivesToCopy: ArchiveToCopy[] = [];
   protected healthCheck?: HealthCheck;
 
   constructor(image: string) {
@@ -178,6 +180,10 @@ export class GenericContainer implements TestContainer {
       const archive = this.createArchiveToCopyToContainer();
       archive.finalize();
       await client.container.putArchive(container, archive, "/");
+    }
+
+    for (const archive of this.archivesToCopy) {
+      await client.container.putArchive(container, archive.tar, archive.target);
     }
 
     log.info(`Starting container for image "${this.createOpts.Image}"...`, { containerId: container.id });
@@ -455,6 +461,11 @@ export class GenericContainer implements TestContainer {
 
   public withCopyContentToContainer(contentsToCopy: ContentToCopy[]): this {
     this.contentsToCopy = [...this.contentsToCopy, ...contentsToCopy];
+    return this;
+  }
+
+  public withCopyArchivesToContainer(archivesToCopy: ArchiveToCopy[]): this {
+    this.archivesToCopy = [...this.archivesToCopy, ...archivesToCopy];
     return this;
   }
 

--- a/packages/testcontainers/src/generic-container/started-generic-container.ts
+++ b/packages/testcontainers/src/generic-container/started-generic-container.ts
@@ -200,6 +200,13 @@ export class StartedGenericContainer implements StartedTestContainer {
     log.debug(`Copied content to container`, { containerId: this.container.id });
   }
 
+  public async copyArchiveToContainer(tar: Readable, target = "/"): Promise<void> {
+    log.debug(`Copying archive to container...`, { containerId: this.container.id });
+    const client = await getContainerRuntimeClient();
+    await client.container.putArchive(this.container, tar, target);
+    log.debug(`Copied archive to container`, { containerId: this.container.id });
+  }
+
   public async copyArchiveFromContainer(path: string): Promise<NodeJS.ReadableStream> {
     log.debug(`Copying archive "${path}" from container...`, { containerId: this.container.id });
     const client = await getContainerRuntimeClient();

--- a/packages/testcontainers/src/test-container.ts
+++ b/packages/testcontainers/src/test-container.ts
@@ -1,6 +1,7 @@
 import { Readable } from "stream";
 import { StartedNetwork } from "./network/network";
 import {
+  ArchiveToCopy,
   BindMount,
   CommitOptions,
   ContentToCopy,
@@ -44,6 +45,7 @@ export interface TestContainer {
   withCopyFilesToContainer(filesToCopy: FileToCopy[]): this;
   withCopyDirectoriesToContainer(directoriesToCopy: DirectoryToCopy[]): this;
   withCopyContentToContainer(contentsToCopy: ContentToCopy[]): this;
+  withCopyArchivesToContainer(archivesToCopy: ArchiveToCopy[]): this;
 
   withWorkingDir(workingDir: string): this;
   withResourcesQuota(resourcesQuota: ResourcesQuota): this;
@@ -77,6 +79,7 @@ export interface StartedTestContainer {
   getNetworkId(networkName: string): string;
   getIpAddress(networkName: string): string;
   copyArchiveFromContainer(path: string): Promise<NodeJS.ReadableStream>;
+  copyArchiveToContainer(tar: Readable, target?: string): Promise<void>;
   copyDirectoriesToContainer(directoriesToCopy: DirectoryToCopy[]): Promise<void>;
   copyFilesToContainer(filesToCopy: FileToCopy[]): Promise<void>;
   copyContentToContainer(contentsToCopy: ContentToCopy[]): Promise<void>;

--- a/packages/testcontainers/src/types.ts
+++ b/packages/testcontainers/src/types.ts
@@ -39,6 +39,11 @@ export type ContentToCopy = {
   mode?: number;
 };
 
+export type ArchiveToCopy = {
+  tar: Readable;
+  target: string;
+};
+
 export type TmpFs = { [dir in string]: string };
 
 export type Ulimits = { [name: string]: { hard: number | undefined; soft: number | undefined } };


### PR DESCRIPTION
Adds `copyArchiveToContainer` and `withCopyArchivesToContainer` to mirror the existing `copyArchiveFromContainer`, allowing files to be copied from one container to another.

Builds on https://github.com/testcontainers/testcontainers-node/pull/923, since docker commits don't copy mounts, to allow complete duplication of a container

Would be nice eventually to have some kind of all-in-one `duplicate()` function on `StoppedTestContainer`..

Note: this is my first time making a github PR so hopefully I've done this right...  Ran the linter and formatter, but many tests are failing for me even in the provided dev container, but they're also failing when I checkout `main` so I don't think it's related to my changes