### PR TITLE
feat: make repear wait strategy compatible with new ryuk version

### DIFF
--- a/packages/testcontainers/src/reaper/reaper.ts
+++ b/packages/testcontainers/src/reaper/reaper.ts
@@ -75,7 +75,7 @@ async function createNewReaper(sessionId: string, remoteSocketPath: string): Pro
     )
     .withBindMounts([{ source: remoteSocketPath, target: "/var/run/docker.sock" }])
     .withLabels({ [LABEL_TESTCONTAINERS_SESSION_ID]: sessionId })
-    .withWaitStrategy(Wait.forLogMessage(/.+ Started!/));
+    .withWaitStrategy(Wait.forLogMessage(/.*Started.*/));
 
   if (process.env.TESTCONTAINERS_RYUK_PRIVILEGED === "true") {
     container.withPrivilegedMode();

--- a/packages/testcontainers/src/reaper/reaper.ts
+++ b/packages/testcontainers/src/reaper/reaper.ts
@@ -8,7 +8,7 @@ import { Wait } from "../wait-strategies/wait";
 
 export const REAPER_IMAGE = process.env["RYUK_CONTAINER_IMAGE"]
   ? ImageName.fromString(process.env["RYUK_CONTAINER_IMAGE"]).string
-  : ImageName.fromString("testcontainers/ryuk:0.5.1").string;
+  : ImageName.fromString("testcontainers/ryuk:0.11.0").string;
 
 export interface Reaper {
   sessionId: string;


### PR DESCRIPTION
Changes the wait strategy regex of the reaper container to be compatible with newer version of the ryuk image.
The regex is align with what [testcontainer-java](https://github.com/testcontainers/testcontainers-java/blob/ad2e8b1415b00a4b984e8efecdf2ca787aceb7a0/core/src/main/java/org/testcontainers/utility/RyukContainer.java#L30) uses.