### PR TITLE
Add cosmos db emulator module

### DIFF
--- a/docs/modules/cosmosdb.md
+++ b/docs/modules/cosmosdb.md
@@ -1,0 +1,32 @@
+# Cosmos DB Emulator Module (Linux-based)
+
+[Azure Cosmos DB](https://azure.microsoft.com/en-GB/products/cosmos-db) is a globally distributed, multi-model database service provided by Microsoft.
+
+## Install
+
+```bash
+npm install @testcontainers/azurecosmosdb --save-dev
+```
+
+## Examples
+<!--codeinclude-->
+[Connect to emulator and create a database:](../../packages/modules/azurecosmosdb/src/azure-cosmosdb-emulator-container.test.ts) inside_block:httpCreateDB
+<!--/codeinclude-->
+
+<!--codeinclude-->
+[Using HTTPS:](../../packages/modules/azurecosmosdb/src/azure-cosmosdb-emulator-container.test.ts) inside_block:httpsCreateDB
+<!--/codeinclude-->
+
+<!--codeinclude-->
+[Create and read items:](../../packages/modules/azurecosmosdb/src/azure-cosmosdb-emulator-container.test.ts) inside_block:createAndRead
+<!--/codeinclude-->
+
+## Caveats
+### Compatibility
+This testcontainer uses the [linux-based](https://learn.microsoft.com/en-us/azure/cosmos-db/emulator-linux) version. In general, it:
+
+- Provides better compatibility on a variety of systems
+- Consumes significantly less resources
+- Comes with much faster startup times
+
+However, not all features of a full CosmosDB are implemented yet - please refer to [this overview](https://learn.microsoft.com/en-us/azure/cosmos-db/emulator-linux#feature-support) for a detailed list.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
       - Azurite: modules/azurite.md
       - Cassandra: modules/cassandra.md
       - ChromaDB: modules/chromadb.md
+      - CosmosDB: modules/cosmosdb.md
       - Couchbase: modules/couchbase.md
       - CockroachDB: modules/cockroachdb.md
       - Elasticsearch: modules/elasticsearch.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,12 +91,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@aws-crypto/crc32c": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
@@ -107,12 +101,6 @@
         "@aws-sdk/types": "^3.222.0",
         "tslib": "^2.6.2"
       }
-    },
-    "node_modules/@aws-crypto/crc32c/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@aws-crypto/sha1-browser": {
       "version": "5.2.0",
@@ -165,12 +153,6 @@
       "engines": {
         "node": ">=14.0.0"
       }
-    },
-    "node_modules/@aws-crypto/sha1-browser/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "5.2.0",
@@ -225,12 +207,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@aws-crypto/sha256-js": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
@@ -245,12 +221,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@aws-crypto/supports-web-crypto": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
@@ -259,12 +229,6 @@
       "dependencies": {
         "tslib": "^2.6.2"
       }
-    },
-    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@aws-crypto/util": {
       "version": "5.2.0",
@@ -314,12 +278,6 @@
       "engines": {
         "node": ">=14.0.0"
       }
-    },
-    "node_modules/@aws-crypto/util/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@aws-sdk/client-s3": {
       "version": "3.623.0",
@@ -389,12 +347,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
     },
     "node_modules/@aws-sdk/client-sso": {
       "version": "3.623.0",
@@ -498,18 +450,6 @@
         "@aws-sdk/client-sts": "^3.623.0"
       }
     },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@aws-sdk/client-sts": {
       "version": "3.623.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.623.0.tgz",
@@ -561,12 +501,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sts/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@aws-sdk/core": {
       "version": "3.623.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.623.0.tgz",
@@ -587,12 +521,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/core/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.620.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
@@ -607,12 +535,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/@aws-sdk/credential-provider-env/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@aws-sdk/credential-provider-http": {
       "version": "3.622.0",
@@ -633,12 +555,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/@aws-sdk/credential-provider-http/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
       "version": "3.623.0",
@@ -665,12 +581,6 @@
         "@aws-sdk/client-sts": "^3.623.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-ini/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@aws-sdk/credential-provider-node": {
       "version": "3.623.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.623.0.tgz",
@@ -694,12 +604,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-node/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@aws-sdk/credential-provider-process": {
       "version": "3.620.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
@@ -715,12 +619,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/@aws-sdk/credential-provider-process/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.623.0",
@@ -740,12 +638,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-sso/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
       "version": "3.621.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
@@ -763,12 +655,6 @@
       "peerDependencies": {
         "@aws-sdk/client-sts": "^3.621.0"
       }
-    },
-    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
       "version": "3.620.0",
@@ -788,12 +674,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@aws-sdk/middleware-expect-continue": {
       "version": "3.620.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.620.0.tgz",
@@ -808,12 +688,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/@aws-sdk/middleware-expect-continue/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
       "version": "3.620.0",
@@ -834,12 +708,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.620.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
@@ -855,12 +723,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-host-header/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@aws-sdk/middleware-location-constraint": {
       "version": "3.609.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.609.0.tgz",
@@ -874,12 +736,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/@aws-sdk/middleware-location-constraint/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@aws-sdk/middleware-logger": {
       "version": "3.609.0",
@@ -895,12 +751,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-logger/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
       "version": "3.620.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
@@ -915,12 +765,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
       "version": "3.622.0",
@@ -944,12 +788,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@aws-sdk/middleware-signing": {
       "version": "3.620.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.620.0.tgz",
@@ -968,12 +806,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-signing/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@aws-sdk/middleware-ssec": {
       "version": "3.609.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.609.0.tgz",
@@ -987,12 +819,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/@aws-sdk/middleware-ssec/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
       "version": "3.620.0",
@@ -1009,12 +835,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@aws-sdk/region-config-resolver": {
       "version": "3.614.0",
@@ -1033,12 +853,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/region-config-resolver/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
       "version": "3.622.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.622.0.tgz",
@@ -1055,12 +869,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@aws-sdk/token-providers": {
       "version": "3.614.0",
@@ -1081,12 +889,6 @@
         "@aws-sdk/client-sso-oidc": "^3.614.0"
       }
     },
-    "node_modules/@aws-sdk/token-providers/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@aws-sdk/types": {
       "version": "3.609.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
@@ -1100,12 +902,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/types/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@aws-sdk/util-arn-parser": {
       "version": "3.568.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.568.0.tgz",
@@ -1117,12 +913,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/@aws-sdk/util-arn-parser/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@aws-sdk/util-endpoints": {
       "version": "3.614.0",
@@ -1139,12 +929,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-endpoints/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@aws-sdk/util-locate-window": {
       "version": "3.568.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.568.0.tgz",
@@ -1157,12 +941,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-locate-window/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@aws-sdk/util-user-agent-browser": {
       "version": "3.609.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
@@ -1174,12 +952,6 @@
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
-    },
-    "node_modules/@aws-sdk/util-user-agent-browser/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
       "version": "3.614.0",
@@ -1204,12 +976,6 @@
         }
       }
     },
-    "node_modules/@aws-sdk/util-user-agent-node/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@aws-sdk/xml-builder": {
       "version": "3.609.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.609.0.tgz",
@@ -1223,12 +989,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/xml-builder/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@azure/abort-controller": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
@@ -1241,31 +1001,33 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/@azure/abort-controller/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
     "node_modules/@azure/core-auth": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.5.0.tgz",
-      "integrity": "sha512-udzoBuYG1VBoHVohDTrvKjyzel34zt77Bhp7dQntVGGD0ehVq48owENbBG8fIgkHRNUBQH5k1r0hpoMu5L8+kw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.9.0.tgz",
+      "integrity": "sha512-FPwHpZywuyasDSLMqJ6fhbOK3TqUdviZNF8OqRGA4W5Ewib2lEEZ+pBsYcBa88B2NGO/SEnYPGhyBqNlE8ilSw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "@azure/core-util": "^1.1.0",
-        "tslib": "^2.2.0"
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-util": "^1.11.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       }
     },
-    "node_modules/@azure/core-auth/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
+    "node_modules/@azure/core-auth/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@azure/core-client": {
       "version": "1.7.3",
@@ -1284,12 +1046,6 @@
       "engines": {
         "node": ">=14.0.0"
       }
-    },
-    "node_modules/@azure/core-client/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
     },
     "node_modules/@azure/core-http-compat": {
       "version": "1.3.0",
@@ -1320,12 +1076,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@azure/core-lro/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
     "node_modules/@azure/core-paging": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.5.0.tgz",
@@ -1338,36 +1088,76 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@azure/core-paging/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
     "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.13.0.tgz",
-      "integrity": "sha512-a62aP/wppgmnfIkJLfcB4ssPBcH94WzrzPVJ3tlJt050zX4lfmtnvy95D3igDo3f31StO+9BgPrzvkj4aOxnoA==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.19.1.tgz",
+      "integrity": "sha512-zHeoI3NCs53lLBbWNzQycjnYKsA1CVKlnzSNuSFcUDwBp8HHVObePxrM7HaX+Ha5Ks639H7chNC9HOaIhNS03w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^1.1.0",
-        "@azure/core-auth": "^1.4.0",
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.8.0",
         "@azure/core-tracing": "^1.0.1",
-        "@azure/core-util": "^1.3.0",
+        "@azure/core-util": "^1.11.0",
         "@azure/logger": "^1.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "tslib": "^2.2.0"
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@azure/core-rest-pipeline/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
+    "node_modules/@azure/core-rest-pipeline/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline/node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/@azure/core-tracing": {
       "version": "1.2.0",
@@ -1381,30 +1171,32 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@azure/core-tracing/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
     "node_modules/@azure/core-util": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.6.1.tgz",
-      "integrity": "sha512-h5taHeySlsV9qxuK64KZxy4iln1BtMYlNt5jbuEFN3UFSAd1EwKg/Gjl5a6tZ/W8t6li3xPnutOx7zbDyXnPmQ==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.11.0.tgz",
+      "integrity": "sha512-DxOSLua+NdpWoSqULhjDyAZTXFdP/LKkqtYuxxz1SCN289zk3OG8UOpnCQAz/tygyACBtWp/BoO72ptK7msY8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "tslib": "^2.2.0"
+        "@azure/abort-controller": "^2.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
-    "node_modules/@azure/core-util/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
+    "node_modules/@azure/core-util/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@azure/core-xml": {
       "version": "1.4.4",
@@ -1419,11 +1211,40 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@azure/core-xml/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
+    "node_modules/@azure/cosmos": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/cosmos/-/cosmos-4.2.0.tgz",
+      "integrity": "sha512-acfAQTYLxgB/iZK7XvTVYe9NPk6DECEgcIXDQhyn7Uo4dGxeeW5D3YqLjLJrrzND5Iawer3eUQ5/iiLWvTGAxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.7.1",
+        "@azure/core-rest-pipeline": "^1.15.1",
+        "@azure/core-tracing": "^1.1.1",
+        "@azure/core-util": "^1.8.1",
+        "fast-json-stable-stringify": "^2.1.0",
+        "jsbi": "^4.3.0",
+        "priorityqueuejs": "^2.0.0",
+        "semaphore": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/cosmos/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@azure/data-tables": {
       "version": "13.2.2",
@@ -1444,12 +1265,6 @@
       "engines": {
         "node": ">=14.0.0"
       }
-    },
-    "node_modules/@azure/data-tables/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
     },
     "node_modules/@azure/identity": {
       "version": "3.4.2",
@@ -1476,12 +1291,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@azure/identity/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
     "node_modules/@azure/keyvault-keys": {
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/@azure/keyvault-keys/-/keyvault-keys-4.7.2.tgz",
@@ -1504,12 +1313,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@azure/keyvault-keys/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
     "node_modules/@azure/logger": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.4.tgz",
@@ -1521,12 +1324,6 @@
       "engines": {
         "node": ">=14.0.0"
       }
-    },
-    "node_modules/@azure/logger/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
     },
     "node_modules/@azure/msal-browser": {
       "version": "3.7.0",
@@ -1613,12 +1410,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@azure/storage-blob/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
-    },
     "node_modules/@azure/storage-queue": {
       "version": "12.24.0",
       "resolved": "https://registry.npmjs.org/@azure/storage-queue/-/storage-queue-12.24.0.tgz",
@@ -1666,12 +1457,6 @@
       "engines": {
         "node": ">=18.0.0"
       }
-    },
-    "node_modules/@azure/storage-queue/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.25.9",
@@ -2541,12 +2326,6 @@
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/@firebase/component/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
     "node_modules/@firebase/database": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.3.tgz",
@@ -2576,12 +2355,6 @@
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/@firebase/database-compat/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
     "node_modules/@firebase/database-types": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.1.tgz",
@@ -2592,12 +2365,6 @@
         "@firebase/util": "1.9.4"
       }
     },
-    "node_modules/@firebase/database/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
     "node_modules/@firebase/logger": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.0.tgz",
@@ -2607,12 +2374,6 @@
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/@firebase/logger/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
     "node_modules/@firebase/util": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.9.4.tgz",
@@ -2621,12 +2382,6 @@
       "dependencies": {
         "tslib": "^2.1.0"
       }
-    },
-    "node_modules/@firebase/util/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
@@ -3401,12 +3156,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/@kubernetes/client-node/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
     },
     "node_modules/@kubernetes/client-node/node_modules/undici-types": {
       "version": "6.19.8",
@@ -4601,12 +4350,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/abort-controller/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@smithy/chunked-blob-reader": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-3.0.0.tgz",
@@ -4626,18 +4369,6 @@
         "tslib": "^2.6.2"
       }
     },
-    "node_modules/@smithy/chunked-blob-reader-native/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
-    "node_modules/@smithy/chunked-blob-reader/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@smithy/config-resolver": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
@@ -4653,12 +4384,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/@smithy/config-resolver/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@smithy/core": {
       "version": "2.3.2",
@@ -4679,12 +4404,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/core/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@smithy/credential-provider-imds": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
@@ -4701,12 +4420,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/credential-provider-imds/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@smithy/eventstream-codec": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.1.2.tgz",
@@ -4718,12 +4431,6 @@
         "@smithy/util-hex-encoding": "^3.0.0",
         "tslib": "^2.6.2"
       }
-    },
-    "node_modules/@smithy/eventstream-codec/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@smithy/eventstream-serde-browser": {
       "version": "3.0.5",
@@ -4739,12 +4446,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/eventstream-serde-browser/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.3.tgz",
@@ -4757,12 +4458,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/@smithy/eventstream-serde-config-resolver/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@smithy/eventstream-serde-node": {
       "version": "3.0.4",
@@ -4778,12 +4473,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/eventstream-serde-node/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@smithy/eventstream-serde-universal": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.4.tgz",
@@ -4798,12 +4487,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/eventstream-serde-universal/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@smithy/fetch-http-handler": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
@@ -4817,12 +4500,6 @@
         "tslib": "^2.6.2"
       }
     },
-    "node_modules/@smithy/fetch-http-handler/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@smithy/hash-blob-browser": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-3.1.2.tgz",
@@ -4834,12 +4511,6 @@
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       }
-    },
-    "node_modules/@smithy/hash-blob-browser/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@smithy/hash-node": {
       "version": "3.0.3",
@@ -4856,12 +4527,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/hash-node/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@smithy/hash-stream-node": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-3.1.2.tgz",
@@ -4876,12 +4541,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/hash-stream-node/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@smithy/invalid-dependency": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
@@ -4891,12 +4550,6 @@
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       }
-    },
-    "node_modules/@smithy/invalid-dependency/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@smithy/is-array-buffer": {
       "version": "3.0.0",
@@ -4910,12 +4563,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/is-array-buffer/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@smithy/md5-js": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-3.0.3.tgz",
@@ -4926,12 +4573,6 @@
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       }
-    },
-    "node_modules/@smithy/md5-js/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@smithy/middleware-content-length": {
       "version": "3.0.5",
@@ -4946,12 +4587,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/@smithy/middleware-content-length/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@smithy/middleware-endpoint": {
       "version": "3.1.0",
@@ -4970,12 +4605,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/@smithy/middleware-endpoint/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@smithy/middleware-retry": {
       "version": "3.0.14",
@@ -4996,12 +4625,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/@smithy/middleware-retry/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@smithy/middleware-retry/node_modules/uuid": {
       "version": "9.0.1",
@@ -5029,12 +4652,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/middleware-serde/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@smithy/middleware-stack": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
@@ -5047,12 +4664,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/@smithy/middleware-stack/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@smithy/node-config-provider": {
       "version": "3.1.4",
@@ -5068,12 +4679,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/@smithy/node-config-provider/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@smithy/node-http-handler": {
       "version": "3.1.4",
@@ -5091,12 +4696,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/node-http-handler/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@smithy/property-provider": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
@@ -5110,12 +4709,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/property-provider/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@smithy/protocol-http": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
@@ -5128,12 +4721,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/@smithy/protocol-http/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@smithy/querystring-builder": {
       "version": "3.0.3",
@@ -5149,12 +4736,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/querystring-builder/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@smithy/querystring-parser": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
@@ -5167,12 +4748,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/@smithy/querystring-parser/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@smithy/service-error-classification": {
       "version": "3.0.3",
@@ -5199,12 +4774,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/shared-ini-file-loader/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@smithy/signature-v4": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
@@ -5224,12 +4793,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/signature-v4/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@smithy/smithy-client": {
       "version": "3.1.12",
       "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.12.tgz",
@@ -5247,12 +4810,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/smithy-client/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@smithy/types": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
@@ -5265,12 +4822,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/types/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@smithy/url-parser": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
@@ -5281,12 +4832,6 @@
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       }
-    },
-    "node_modules/@smithy/url-parser/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@smithy/util-base64": {
       "version": "3.0.0",
@@ -5302,12 +4847,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/util-base64/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@smithy/util-body-length-browser": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
@@ -5316,12 +4855,6 @@
       "dependencies": {
         "tslib": "^2.6.2"
       }
-    },
-    "node_modules/@smithy/util-body-length-browser/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@smithy/util-body-length-node": {
       "version": "3.0.0",
@@ -5334,12 +4867,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/@smithy/util-body-length-node/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
@@ -5354,12 +4881,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/util-buffer-from/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@smithy/util-config-provider": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
@@ -5371,12 +4892,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/@smithy/util-config-provider/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
       "version": "3.0.14",
@@ -5393,12 +4908,6 @@
       "engines": {
         "node": ">= 10.0.0"
       }
-    },
-    "node_modules/@smithy/util-defaults-mode-browser/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@smithy/util-defaults-mode-node": {
       "version": "3.0.14",
@@ -5418,12 +4927,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@smithy/util-defaults-mode-node/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@smithy/util-endpoints": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.5.tgz",
@@ -5438,12 +4941,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/util-endpoints/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@smithy/util-hex-encoding": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
@@ -5455,12 +4952,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/@smithy/util-hex-encoding/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@smithy/util-middleware": {
       "version": "3.0.3",
@@ -5475,12 +4966,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/util-middleware/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@smithy/util-retry": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
@@ -5494,12 +4979,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/@smithy/util-retry/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@smithy/util-stream": {
       "version": "3.1.3",
@@ -5520,12 +4999,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/util-stream/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@smithy/util-uri-escape": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
@@ -5537,12 +5010,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/@smithy/util-uri-escape/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@smithy/util-utf8": {
       "version": "3.0.0",
@@ -5557,12 +5024,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/util-utf8/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
     "node_modules/@smithy/util-waiter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.2.tgz",
@@ -5576,12 +5037,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/@smithy/util-waiter/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "5.0.1",
@@ -7244,12 +6699,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/async-mutex/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
     },
     "node_modules/async-retry": {
       "version": "1.3.3",
@@ -16213,6 +15662,13 @@
         }
       }
     },
+    "node_modules/priorityqueuejs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/priorityqueuejs/-/priorityqueuejs-2.0.0.tgz",
+      "integrity": "sha512-19BMarhgpq3x4ccvVi8k2QpJZcymo/iFUcrhPd4V96kYGovOdTsWwy7fxChYi4QY+m2EnGBWSX9Buakz+tWNQQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/proc-log": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-3.0.0.tgz",
@@ -17073,12 +16529,6 @@
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/rxjs/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
     "node_modules/safe-array-concat": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
@@ -17183,6 +16633,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/semaphore": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
+      "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/semver": {
@@ -18127,13 +17586,6 @@
         "url": "https://opencollective.com/unts"
       }
     },
-    "node_modules/synckit/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/table": {
       "version": "6.8.2",
       "resolved": "https://registry.npmjs.org/table/-/table-6.8.2.tgz",
@@ -18706,6 +18158,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/tuf-js": {
       "version": "1.1.7",
@@ -20541,8 +20000,7 @@
         "testcontainers": "^10.20.0"
       },
       "devDependencies": {
-        "@types/pg": "^8.11.6",
-        "pg": "^8.12.0"
+        "@azure/cosmos": "^4.2.0"
       }
     },
     "packages/modules/qdrant": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19720,7 +19720,9 @@
       "dependencies": {
         "testcontainers": "^10.20.0"
       },
-      "devDependencies": {}
+      "devDependencies": {
+        "@azure/cosmos": "^4.2.0"
+      }
     },
     "packages/modules/azurite": {
       "name": "@testcontainers/azurite",
@@ -20000,7 +20002,8 @@
         "testcontainers": "^10.20.0"
       },
       "devDependencies": {
-        "@azure/cosmos": "^4.2.0"
+        "@types/pg": "^8.11.6",
+        "pg": "^8.12.0"
       }
     },
     "packages/modules/qdrant": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5605,6 +5605,10 @@
       "resolved": "packages/modules/arangodb",
       "link": true
     },
+    "node_modules/@testcontainers/azure-cosmosdb-emulator": {
+      "resolved": "packages/modules/azurecosmosdb",
+      "link": true
+    },
     "node_modules/@testcontainers/azurite": {
       "resolved": "packages/modules/azurite",
       "link": true
@@ -20249,6 +20253,15 @@
       "devDependencies": {
         "arangojs": "^8.8.1"
       }
+    },
+    "packages/modules/azurecosmosdb": {
+      "name": "@testcontainers/azure-cosmosdb-emulator",
+      "version": "10.20.0",
+      "license": "MIT",
+      "dependencies": {
+        "testcontainers": "^10.20.0"
+      },
+      "devDependencies": {}
     },
     "packages/modules/azurite": {
       "name": "@testcontainers/azurite",

--- a/packages/modules/azurecosmosdb/package.json
+++ b/packages/modules/azurecosmosdb/package.json
@@ -30,7 +30,9 @@
     "prepack": "shx cp ../../../README.md . && shx cp ../../../LICENSE .",
     "build": "tsc --project tsconfig.build.json"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "@azure/cosmos": "^4.2.0"
+  },
   "dependencies": {
     "testcontainers": "^10.20.0"
   }

--- a/packages/modules/azurecosmosdb/package.json
+++ b/packages/modules/azurecosmosdb/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@testcontainers/azure-cosmosdb-emulator",
+  "version": "10.20.0",
+  "license": "MIT",
+  "keywords": [
+    "azure-cosmosdb",
+    "cosmosdb",
+    "emulator",
+    "testing",
+    "docker",
+    "testcontainers"
+  ],
+  "description": "Azure Cosmos DB Emulator module for Testcontainers",
+  "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/testcontainers/testcontainers-node"
+  },
+  "bugs": {
+    "url": "https://github.com/testcontainers/testcontainers-node/issues"
+  },
+  "main": "build/index.js",
+  "files": [
+    "build"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "prepack": "shx cp ../../../README.md . && shx cp ../../../LICENSE .",
+    "build": "tsc --project tsconfig.build.json"
+  },
+  "devDependencies": {},
+  "dependencies": {
+    "testcontainers": "^10.20.0"
+  }
+}

--- a/packages/modules/azurecosmosdb/src/azure-cosmosdb-emulator-container.test.ts
+++ b/packages/modules/azurecosmosdb/src/azure-cosmosdb-emulator-container.test.ts
@@ -1,0 +1,59 @@
+import { CosmosClient } from "@azure/cosmos";
+import * as https from "node:https";
+import { expect } from "vitest";
+import { AzureCosmosDbEmulatorContainer } from "./azure-cosmosdb-emulator-container";
+
+describe("AzureCosmosDbEmulatorContainer", { timeout: 180_000 }, async () => {
+  it("should set https protocol", async () => {
+    const container = await new AzureCosmosDbEmulatorContainer().withProtocol("https").start();
+    const connectionUri = container.getConnectionUri();
+    expect(connectionUri).toContain("AccountEndpoint=https://");
+    await container.stop();
+  });
+  it("should set http protocol if no protocol is specified", async () => {
+    const container = await new AzureCosmosDbEmulatorContainer().start();
+    const connectionUri = container.getConnectionUri();
+    expect(connectionUri).toContain("AccountEndpoint=http://");
+    await container.stop();
+  });
+
+  it("should be able to create a database using http", async () => {
+    const container = await new AzureCosmosDbEmulatorContainer().withProtocol("http").start();
+    const cosmosClient = new CosmosClient({
+      endpoint: container.getEndpoint(),
+      key: container.getKey(),
+    });
+
+    const dbName = "testdb";
+    const createResponse = await cosmosClient.databases.createIfNotExists({
+      id: dbName,
+    });
+    expect(createResponse.statusCode).toBe(201);
+
+    const db = await cosmosClient.database(dbName).read();
+    expect(db.database.id).toBe(dbName);
+
+    await container.stop();
+  });
+  it("should be able to create a database using https", async () => {
+    const container = await new AzureCosmosDbEmulatorContainer().withProtocol("https").start();
+    const cosmosClient = new CosmosClient({
+      endpoint: container.getEndpoint(),
+      key: container.getKey(),
+      agent: new https.Agent({
+        rejectUnauthorized: false,
+      }),
+    });
+
+    const dbName = "testdb";
+    const createResponse = await cosmosClient.databases.createIfNotExists({
+      id: dbName,
+    });
+    expect(createResponse.statusCode).toBe(201);
+
+    const db = await cosmosClient.database(dbName).read();
+    expect(db.database.id).toBe(dbName);
+
+    await container.stop();
+  });
+});

--- a/packages/modules/azurecosmosdb/src/azure-cosmosdb-emulator-container.test.ts
+++ b/packages/modules/azurecosmosdb/src/azure-cosmosdb-emulator-container.test.ts
@@ -1,4 +1,4 @@
-import { CosmosClient } from "@azure/cosmos";
+import { CosmosClient, PartitionKeyKind } from "@azure/cosmos";
 import * as https from "node:https";
 import { expect } from "vitest";
 import { AzureCosmosDbEmulatorContainer } from "./azure-cosmosdb-emulator-container";
@@ -17,6 +17,7 @@ describe("AzureCosmosDbEmulatorContainer", { timeout: 180_000 }, async () => {
     await container.stop();
   });
 
+  // httpCreateDB {
   it("should be able to create a database using http", async () => {
     const container = await new AzureCosmosDbEmulatorContainer().withProtocol("http").start();
     const cosmosClient = new CosmosClient({
@@ -35,13 +36,16 @@ describe("AzureCosmosDbEmulatorContainer", { timeout: 180_000 }, async () => {
 
     await container.stop();
   });
+  // }
+
+  // httpsCreateDB {
   it("should be able to create a database using https", async () => {
     const container = await new AzureCosmosDbEmulatorContainer().withProtocol("https").start();
     const cosmosClient = new CosmosClient({
       endpoint: container.getEndpoint(),
       key: container.getKey(),
       agent: new https.Agent({
-        rejectUnauthorized: false,
+        rejectUnauthorized: false, //allows insecure TLS; import * as https from "node:https";
       }),
     });
 
@@ -56,4 +60,40 @@ describe("AzureCosmosDbEmulatorContainer", { timeout: 180_000 }, async () => {
 
     await container.stop();
   });
+  // }
+
+  // createAndRead {
+  it("should be able to create a container and store and retrieve items", async () => {
+    const container = await new AzureCosmosDbEmulatorContainer().withProtocol("http").start();
+    const cosmosClient = new CosmosClient({
+      endpoint: container.getEndpoint(),
+      key: container.getKey(),
+    });
+
+    const dbName = "testdb";
+    await cosmosClient.databases.createIfNotExists({
+      id: dbName,
+    });
+    const dbClient = cosmosClient.database(dbName);
+
+    const containerName = "testcontainer";
+    await dbClient.containers.createIfNotExists({
+      id: containerName,
+      partitionKey: {
+        kind: PartitionKeyKind.Hash,
+        paths: ["/foo"],
+      },
+    });
+
+    const containerClient = dbClient.container(containerName);
+    const createResponse = await containerClient.items.create({
+      foo: "bar",
+    });
+
+    const readItem = await containerClient.item(createResponse.item.id, "bar").read();
+    expect(readItem.resource.foo).toEqual("bar");
+
+    await container.stop();
+  });
+  // }
 });

--- a/packages/modules/azurecosmosdb/src/azure-cosmosdb-emulator-container.ts
+++ b/packages/modules/azurecosmosdb/src/azure-cosmosdb-emulator-container.ts
@@ -1,0 +1,101 @@
+import * as net from "node:net";
+import { AbstractStartedContainer, GenericContainer, StartedTestContainer, Wait } from "testcontainers";
+
+type Protocol = "http" | "https";
+const DEFAULT_KEY = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="; // default key for Cosmos DB Emulator
+const DEFAULT_PROTOCOL = "http";
+const DEFAULT_TELEMETRY_ENABLED = false;
+const DEFAULT_EXPLORER_ENABLED = false;
+
+const COSMOS_READY_LOG_MESSAGE = "Now listening on: ";
+
+export class AzureCosmosDbEmulatorContainer extends GenericContainer {
+  private key = DEFAULT_KEY;
+  private protocol: Protocol = DEFAULT_PROTOCOL;
+  private telemetryEnabled = DEFAULT_TELEMETRY_ENABLED;
+  private explorerEnabled = DEFAULT_EXPLORER_ENABLED;
+
+  constructor(image = "mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview") {
+    super(image);
+    this.withWaitStrategy(Wait.forLogMessage(COSMOS_READY_LOG_MESSAGE));
+  }
+
+  public withProtocol(protocol: Protocol): this {
+    this.protocol = protocol;
+    return this;
+  }
+
+  public withTelemetryEnabled(telemetryEnabled: boolean): this {
+    this.telemetryEnabled = telemetryEnabled;
+    return this;
+  }
+
+  public override async start(): Promise<StartedAzureCosmosDbEmulatorContainer> {
+    const port = await this.getFreePort();
+    this.withExposedPorts({
+      host: port,
+      container: port,
+    });
+    this.withEnvironment({
+      PROTOCOL: this.protocol,
+      PORT: port.toString(),
+      ENABLE_TELEMETRY: this.telemetryEnabled.toString(),
+      ENABLE_EXPLORER: this.explorerEnabled.toString(),
+    });
+
+    return new StartedAzureCosmosDbEmulatorContainer(await super.start(), this.key, port, this.protocol);
+  }
+
+  /**
+   * The mapped port has to be passed to CosmosDB as an environment variable for HTTPS to work.
+   * Since the mapped port would only be known after container creation, we need to find an available port ourselves
+   * before starting the container.
+   * @private
+   */
+  private async getFreePort(): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const server = net.createServer();
+      server.listen(0, () => {
+        const address = server.address();
+        if (typeof address !== "string" && address?.port) {
+          server.close(() => resolve(address.port));
+        } else {
+          server.close(() => reject(new Error("Failed to get available port from host")));
+        }
+      });
+      server.on("error", reject);
+    });
+  }
+}
+
+export class StartedAzureCosmosDbEmulatorContainer extends AbstractStartedContainer {
+  constructor(
+    startedContainer: StartedTestContainer,
+    private readonly key: string,
+    private readonly port: number,
+    private readonly protocol: Protocol
+  ) {
+    super(startedContainer);
+  }
+
+  public getPort(): number {
+    return this.port;
+  }
+
+  public getKey(): string {
+    return this.key;
+  }
+
+  public getEndpoint(): string {
+    const proto = this.protocol === "http" ? "http" : "https";
+    return `${proto}://${this.getHost()}:${this.getPort()}`;
+  }
+
+  /**
+   * Returns a connection URI in the format:
+   * AccountEndpoint=[protocol]://[host]:[port];AccountKey=[key];
+   */
+  public getConnectionUri(): string {
+    return `AccountEndpoint=${this.getEndpoint()};AccountKey=${this.getKey()};`;
+  }
+}

--- a/packages/modules/azurecosmosdb/src/azure-cosmosdb-emulator-container.ts
+++ b/packages/modules/azurecosmosdb/src/azure-cosmosdb-emulator-container.ts
@@ -1,5 +1,12 @@
 import * as net from "node:net";
-import { AbstractStartedContainer, GenericContainer, StartedTestContainer, Wait } from "testcontainers";
+import {
+  AbstractStartedContainer,
+  GenericContainer,
+  PortGenerator,
+  RandomUniquePortGenerator,
+  StartedTestContainer,
+  Wait,
+} from "testcontainers";
 
 type Protocol = "http" | "https";
 const DEFAULT_KEY = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="; // default key for Cosmos DB Emulator
@@ -14,9 +21,11 @@ export class AzureCosmosDbEmulatorContainer extends GenericContainer {
   private protocol: Protocol = DEFAULT_PROTOCOL;
   private telemetryEnabled = DEFAULT_TELEMETRY_ENABLED;
   private explorerEnabled = DEFAULT_EXPLORER_ENABLED;
+  private portGenerator: PortGenerator;
 
   constructor(image = "mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview") {
     super(image);
+    this.portGenerator = new RandomUniquePortGenerator();
     this.withWaitStrategy(Wait.forLogMessage(COSMOS_READY_LOG_MESSAGE));
   }
 
@@ -31,7 +40,7 @@ export class AzureCosmosDbEmulatorContainer extends GenericContainer {
   }
 
   public override async start(): Promise<StartedAzureCosmosDbEmulatorContainer> {
-    const port = await this.getFreePort();
+    const port = await this.portGenerator.generatePort();
     this.withExposedPorts({
       host: port,
       container: port,

--- a/packages/modules/azurecosmosdb/src/azure-cosmosdb-emulator-container.ts
+++ b/packages/modules/azurecosmosdb/src/azure-cosmosdb-emulator-container.ts
@@ -47,7 +47,7 @@ export class AzureCosmosDbEmulatorContainer extends GenericContainer {
   }
 
   /**
-   * The mapped port has to be passed to CosmosDB as an environment variable for HTTPS to work.
+   * The mapped port has to be passed to CosmosDB as an environment variable.
    * Since the mapped port would only be known after container creation, we need to find an available port ourselves
    * before starting the container.
    * @private

--- a/packages/modules/azurecosmosdb/src/azure-cosmosdb-emulator-container.ts
+++ b/packages/modules/azurecosmosdb/src/azure-cosmosdb-emulator-container.ts
@@ -1,4 +1,3 @@
-import * as net from "node:net";
 import {
   AbstractStartedContainer,
   GenericContainer,
@@ -23,7 +22,7 @@ export class AzureCosmosDbEmulatorContainer extends GenericContainer {
   private explorerEnabled = DEFAULT_EXPLORER_ENABLED;
   private portGenerator: PortGenerator;
 
-  constructor(image = "mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview") {
+  constructor(image = "mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-EN20250228") {
     super(image);
     this.portGenerator = new RandomUniquePortGenerator();
     this.withWaitStrategy(Wait.forLogMessage(COSMOS_READY_LOG_MESSAGE));
@@ -53,27 +52,6 @@ export class AzureCosmosDbEmulatorContainer extends GenericContainer {
     });
 
     return new StartedAzureCosmosDbEmulatorContainer(await super.start(), this.key, port, this.protocol);
-  }
-
-  /**
-   * The mapped port has to be passed to CosmosDB as an environment variable.
-   * Since the mapped port would only be known after container creation, we need to find an available port ourselves
-   * before starting the container.
-   * @private
-   */
-  private async getFreePort(): Promise<number> {
-    return new Promise((resolve, reject) => {
-      const server = net.createServer();
-      server.listen(0, () => {
-        const address = server.address();
-        if (typeof address !== "string" && address?.port) {
-          server.close(() => resolve(address.port));
-        } else {
-          server.close(() => reject(new Error("Failed to get available port from host")));
-        }
-      });
-      server.on("error", reject);
-    });
   }
 }
 

--- a/packages/modules/azurecosmosdb/src/index.ts
+++ b/packages/modules/azurecosmosdb/src/index.ts
@@ -1,0 +1,4 @@
+export {
+  AzureCosmosDbEmulatorContainer,
+  StartedAzureCosmosDbEmulatorContainer,
+} from "./azure-cosmosdb-emulator-container";

--- a/packages/modules/azurecosmosdb/tsconfig.build.json
+++ b/packages/modules/azurecosmosdb/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "build",
+    "jest.config.ts",
+    "src/**/*.test.ts"
+  ],
+  "references": [
+    {
+      "path": "../../testcontainers"
+    }
+  ]
+}

--- a/packages/modules/azurecosmosdb/tsconfig.json
+++ b/packages/modules/azurecosmosdb/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build",
+    "paths": {
+      "testcontainers": [
+        "../../testcontainers/src"
+      ]
+    }
+  },
+  "exclude": [
+    "build",
+    "jest.config.ts"
+  ],
+  "references": [
+    {
+      "path": "../../testcontainers"
+    }
+  ]
+}

--- a/packages/modules/postgresql/package.json
+++ b/packages/modules/postgresql/package.json
@@ -30,7 +30,8 @@
     "build": "tsc --project tsconfig.build.json"
   },
   "devDependencies": {
-    "@azure/cosmos": "^4.2.0"
+    "@types/pg": "^8.11.6",
+    "pg": "^8.12.0"
   },
   "dependencies": {
     "testcontainers": "^10.20.0"

--- a/packages/modules/postgresql/package.json
+++ b/packages/modules/postgresql/package.json
@@ -30,8 +30,7 @@
     "build": "tsc --project tsconfig.build.json"
   },
   "devDependencies": {
-    "@types/pg": "^8.11.6",
-    "pg": "^8.12.0"
+    "@azure/cosmos": "^4.2.0"
   },
   "dependencies": {
     "testcontainers": "^10.20.0"

--- a/packages/testcontainers/src/index.ts
+++ b/packages/testcontainers/src/index.ts
@@ -22,6 +22,7 @@ export { CommitOptions, Content, ExecOptions, ExecResult, InspectResult } from "
 export { BoundPorts } from "./utils/bound-ports";
 export { LABEL_TESTCONTAINERS_SESSION_ID } from "./utils/labels";
 export { getContainerPort, hasHostBinding, PortWithBinding, PortWithOptionalBinding } from "./utils/port";
+export { PortGenerator, RandomUniquePortGenerator } from "./utils/port-generator";
 export { ImagePullPolicy, PullPolicy } from "./utils/pull-policy";
 export { HttpWaitStrategyOptions } from "./wait-strategies/http-wait-strategy";
 export { StartupCheckStrategy, StartupStatus } from "./wait-strategies/startup-check-strategy";


### PR DESCRIPTION
This adds support for the Azure Cosmos DB emulator. Unlike the existing module for Java, .NET, and Python, this implementation uses the new Linux emulator. The old emulator is very slow and cumbersome to work with, and using the new linux-based one seems like a decent tradeoff to make.

The container requires the mapped port to be passed as an env var. I have found a solution to achieve this, but it seems quite hacky to me. I'm very open to other ideas to solve this problem.

The port has to be passed, because CosmosDB provides redirects to the individual write/read endpoints. Those redirects then target the port passed in the env var, defaulting to 8081. The Azure Cosmos SDK client follows these redirects by default, leading to an ECONREFUSED if the port in the env is different than the mapped port.

This could be avoided by disabling endpoint discovery in the client like this:
```typescript
const cosmosClient = new CosmosClient({
      endpoint: container.getEndpoint(),
      key: container.getKey(),
      connectionPolicy: {
        enableEndpointDiscovery: false,
      },
    });
```

However, this would force users of this testcontainer to specify different configurations depending on whether their client is running in prod or dev/test.