### PR TITLE
Do not replace user-provided Localstack `LAMBDA_DOCKER_FLAGS`

### DIFF
--- a/packages/modules/localstack/src/localstack-container.test.ts
+++ b/packages/modules/localstack/src/localstack-container.test.ts
@@ -114,7 +114,7 @@ describe("LocalStackContainer", { timeout: 180_000 }, () => {
   it("should concatenate sessionId label to LAMBDA_DOCKER_FLAGS", async () => {
     const container = await new LocalstackContainer()
       .withEnvironment({
-        LAMBDA_DOCKER_FLAGS: `-l mylabel=myvalue -l ${LABEL_TESTCONTAINERS_SESSION_ID}=sessionId`,
+        LAMBDA_DOCKER_FLAGS: `-l mylabel=myvalue`,
       })
       .start();
     const sessionId = container.getLabels()[LABEL_TESTCONTAINERS_SESSION_ID];

--- a/packages/modules/localstack/src/localstack-container.test.ts
+++ b/packages/modules/localstack/src/localstack-container.test.ts
@@ -110,4 +110,19 @@ describe("LocalStackContainer", { timeout: 180_000 }, () => {
     expect(exitCode).toBe(0);
     expect(output).toContain(`${LABEL_TESTCONTAINERS_SESSION_ID}=${sessionId}`);
   });
+
+  it("should concatenate sessionId label to LAMBDA_DOCKER_FLAGS", async () => {
+    const container = await new LocalstackContainer()
+      .withEnvironment({
+        LAMBDA_DOCKER_FLAGS: `-l mylabel=myvalue -l ${LABEL_TESTCONTAINERS_SESSION_ID}=sessionId`,
+      })
+      .start();
+    const sessionId = container.getLabels()[LABEL_TESTCONTAINERS_SESSION_ID];
+
+    const { output, exitCode } = await container.exec(["printenv", "LAMBDA_DOCKER_FLAGS"]);
+
+    expect(exitCode).toBe(0);
+    expect(output).toContain(`${LABEL_TESTCONTAINERS_SESSION_ID}=${sessionId}`);
+    expect(output).toContain(`mylabel=myvalue`);
+  });
 });

--- a/packages/modules/localstack/src/localstack-container.ts
+++ b/packages/modules/localstack/src/localstack-container.ts
@@ -42,7 +42,15 @@ export class LocalstackContainer extends GenericContainer {
   private async flagLambdaSessionId(): Promise<void> {
     const client = await getContainerRuntimeClient();
     const reaper = await getReaper(client);
-    this.withEnvironment({ LAMBDA_DOCKER_FLAGS: `-l ${LABEL_TESTCONTAINERS_SESSION_ID}=${reaper.sessionId}` });
+
+    const lambdaDockerFlags = [
+      this.environment["LAMBDA_DOCKER_FLAGS"],
+      `-l ${LABEL_TESTCONTAINERS_SESSION_ID}=${reaper.sessionId}`,
+    ]
+      .filter((flag) => flag !== undefined)
+      .join(" ");
+
+    this.withEnvironment({ LAMBDA_DOCKER_FLAGS: lambdaDockerFlags });
   }
 
   protected override async beforeContainerCreated(): Promise<void> {

--- a/packages/modules/localstack/src/localstack-container.ts
+++ b/packages/modules/localstack/src/localstack-container.ts
@@ -43,14 +43,9 @@ export class LocalstackContainer extends GenericContainer {
     const client = await getContainerRuntimeClient();
     const reaper = await getReaper(client);
 
-    const lambdaDockerFlags = [
-      this.environment["LAMBDA_DOCKER_FLAGS"],
-      `-l ${LABEL_TESTCONTAINERS_SESSION_ID}=${reaper.sessionId}`,
-    ]
-      .filter((flag) => flag !== undefined)
-      .join(" ");
-
-    this.withEnvironment({ LAMBDA_DOCKER_FLAGS: lambdaDockerFlags });
+    this.withEnvironment({
+      LAMBDA_DOCKER_FLAGS: `${this.environment["LAMBDA_DOCKER_FLAGS"] ?? ""} -l ${LABEL_TESTCONTAINERS_SESSION_ID}=${reaper.sessionId}`,
+    });
   }
 
   protected override async beforeContainerCreated(): Promise<void> {


### PR DESCRIPTION
Improvement: 
Following [this fix](https://github.com/testcontainers/testcontainers-node/pull/922), prevent sessionId stored in Localstack `LAMBDA_DOCKER_FLAGS` from being overwritten when other flags are defined. 