### PR TITLE
add withRemove() and tests

### DIFF
--- a/packages/testcontainers/src/docker-compose-environment/docker-compose-environment.ts
+++ b/packages/testcontainers/src/docker-compose-environment/docker-compose-environment.ts
@@ -169,6 +169,7 @@ export class DockerComposeEnvironment {
             boundPorts,
             containerName,
             waitStrategy
+            // not sure how to control 'remove' option for the whole compose stack, will use default value here (true)
           );
         })
       )

--- a/packages/testcontainers/src/generic-container/generic-container-reuse.test.ts
+++ b/packages/testcontainers/src/generic-container/generic-container-reuse.test.ts
@@ -153,6 +153,27 @@ describe("GenericContainer reuse", { timeout: 180_000 }, () => {
     await container2.stop();
   });
 
+  it("should reuse container when an existing reusable container created using withRemove(false) has stopped", async () => {
+    const name = `there_can_only_be_one_${randomUuid()}`;
+    const container1 = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+      .withName(name)
+      .withExposedPorts(8080)
+      .withReuse()
+      .withRemove(false)
+      .start();
+    await container1.stop({ timeout: 10000 });
+
+    const container2 = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+      .withName(name)
+      .withExposedPorts(8080)
+      .withReuse()
+      .start();
+    await checkContainerIsHealthy(container2);
+
+    expect(container1.getId()).toBe(container2.getId());
+    await container2.stop();
+  });
+
   it("should keep the labels passed in when a new reusable container is created", async () => {
     const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
       .withName(`there_can_only_be_one_${randomUuid()}`)

--- a/packages/testcontainers/src/generic-container/generic-container.ts
+++ b/packages/testcontainers/src/generic-container/generic-container.ts
@@ -50,6 +50,7 @@ export class GenericContainer implements TestContainer {
   protected environment: Record<string, string> = {};
   protected exposedPorts: PortWithOptionalBinding[] = [];
   protected reuse = false;
+  protected remove = true;
   protected networkMode?: string;
   protected networkAliases: string[] = [];
   protected pullPolicy: ImagePullPolicy = PullPolicy.defaultPolicy();
@@ -158,7 +159,8 @@ export class GenericContainer implements TestContainer {
       inspectResult,
       boundPorts,
       inspectResult.Name,
-      this.waitStrategy
+      this.waitStrategy,
+      this.remove
     );
   }
 
@@ -222,7 +224,8 @@ export class GenericContainer implements TestContainer {
       inspectResult,
       boundPorts,
       inspectResult.Name,
-      this.waitStrategy
+      this.waitStrategy,
+      this.remove
     );
 
     if (this.containerStarted) {
@@ -430,6 +433,11 @@ export class GenericContainer implements TestContainer {
 
   public withReuse(): this {
     this.reuse = true;
+    return this;
+  }
+
+  public withRemove(remove: boolean): this {
+    this.remove = remove;
     return this;
   }
 

--- a/packages/testcontainers/src/utils/test-helper.ts
+++ b/packages/testcontainers/src/utils/test-helper.ts
@@ -36,8 +36,16 @@ export const getDockerEventStream = async (opts: GetEventsOptions = {}): Promise
 };
 
 export const getRunningContainerNames = async (): Promise<string[]> => {
+  return getContainerNames(false);
+};
+
+export const getStoppedContainerNames = async (): Promise<string[]> => {
+  return getContainerNames(true, { status: ["paused", "exited"] });
+};
+
+const getContainerNames = async (all: boolean, filters?: string | { [key: string]: string[] }): Promise<string[]> => {
   const dockerode = (await getContainerRuntimeClient()).container.dockerode;
-  const containers = await dockerode.listContainers();
+  const containers = await dockerode.listContainers({ all, filters });
   return containers
     .map((container) => container.Names)
     .reduce((result, containerNames) => [...result, ...containerNames], [])


### PR DESCRIPTION
Related issue https://github.com/testcontainers/testcontainers-node/issues/850

Add withRemove() method to GenericContainer and tests. This allows to control autoremoval behaviour of a container.

Containers are removed by default if `remove` option is not set when container is being stopped.
```
await container.stop(); // will remove stopped container.
```

`withRemove(true)` produces the same effect as explicitly setting remove flag when stopping container.
```
container.withRemove(true).start();
...
await container.stop();

// is equivalent of doing:

await container.stop({ remove: true });

// is equivalent of doing:

await container.stop();
```

`withRemove(false)` disables removing container by default.
```
container.withRemove(false).start();
...
await container.stop(); // will NOT remove stopped container.
```

`container.stop()` options have higher priority than `withRemove()`
```
container.withRemove(false).start();
...
await container.stop({ remove: true }); // will override withRemove(false) and remove stopped container.
```

Keep in mind that Ryuk will remove stopped container after tests finished regardless of value passed in `withRemove` method, unless Ryuk is disabled. Setting `withRemove(false)` and disabling Ryuk is not recommeded.

