### PR TITLE
Minor fixes

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -34,6 +34,8 @@ jobs:
       - name: Podman setup
         if: ${{ inputs.container-runtime == 'podman' }}
         run: |
+          curl -fsSL "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_$(lsb_release -rs)/Release.key" | gpg --dearmor | sudo tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg > /dev/null
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg] https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_$(lsb_release -rs)/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null
           sudo apt-get update
           sudo apt-get -y install podman
           systemctl enable --now --user podman podman.socket

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -34,8 +34,6 @@ jobs:
       - name: Podman setup
         if: ${{ inputs.container-runtime == 'podman' }}
         run: |
-          curl -fsSL "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_$(lsb_release -rs)/Release.key" | gpg --dearmor | sudo tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg > /dev/null
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg] https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_$(lsb_release -rs)/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null
           sudo apt-get update
           sudo apt-get -y install podman
           systemctl enable --now --user podman podman.socket

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       "devDependencies": {
         "@eslint/js": "^9.22.0",
         "@eslint/json": "^0.11.0",
-        "@vitest/coverage-v8": "^3.0.8",
+        "@vitest/coverage-v8": "v3.1.0-beta.1",
         "cross-env": "^7.0.3",
         "eslint": "^9.22.0",
         "eslint-config-prettier": "^10.1.1",
@@ -28,7 +28,7 @@
         "ts-node": "^10.9.2",
         "typescript": "^4.9.5",
         "typescript-eslint": "^8.26.1",
-        "vitest": "^3.0.8"
+        "vitest": "v3.1.0-beta.1"
       },
       "engines": {
         "node": ">= 10.16"
@@ -3936,9 +3936,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.35.0.tgz",
-      "integrity": "sha512-uYQ2WfPaqz5QtVgMxfN6NpLD+no0MYHDBywl7itPYd3K5TjjSghNKmX8ic9S8NU8w81NVhJv/XojcHptRly7qQ==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.36.0.tgz",
+      "integrity": "sha512-jgrXjjcEwN6XpZXL0HUeOVGfjXhPyxAbbhD0BlXUB+abTOpbPiN5Wb3kOT7yb+uEtATNYF5x5gIfwutmuBA26w==",
       "cpu": [
         "arm"
       ],
@@ -3950,9 +3950,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.35.0.tgz",
-      "integrity": "sha512-FtKddj9XZudurLhdJnBl9fl6BwCJ3ky8riCXjEw3/UIbjmIY58ppWwPEvU3fNu+W7FUsAsB1CdH+7EQE6CXAPA==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.36.0.tgz",
+      "integrity": "sha512-NyfuLvdPdNUfUNeYKUwPwKsE5SXa2J6bCt2LdB/N+AxShnkpiczi3tcLJrm5mA+eqpy0HmaIY9F6XCa32N5yzg==",
       "cpu": [
         "arm64"
       ],
@@ -3964,9 +3964,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.35.0.tgz",
-      "integrity": "sha512-Uk+GjOJR6CY844/q6r5DR/6lkPFOw0hjfOIzVx22THJXMxktXG6CbejseJFznU8vHcEBLpiXKY3/6xc+cBm65Q==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.36.0.tgz",
+      "integrity": "sha512-JQ1Jk5G4bGrD4pWJQzWsD8I1n1mgPXq33+/vP4sk8j/z/C2siRuxZtaUA7yMTf71TCZTZl/4e1bfzwUmFb3+rw==",
       "cpu": [
         "arm64"
       ],
@@ -3978,9 +3978,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.35.0.tgz",
-      "integrity": "sha512-3IrHjfAS6Vkp+5bISNQnPogRAW5GAV1n+bNCrDwXmfMHbPl5EhTmWtfmwlJxFRUCBZ+tZ/OxDyU08aF6NI/N5Q==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.36.0.tgz",
+      "integrity": "sha512-6c6wMZa1lrtiRsbDziCmjE53YbTkxMYhhnWnSW8R/yqsM7a6mSJ3uAVT0t8Y/DGt7gxUWYuFM4bwWk9XCJrFKA==",
       "cpu": [
         "x64"
       ],
@@ -3992,9 +3992,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.35.0.tgz",
-      "integrity": "sha512-sxjoD/6F9cDLSELuLNnY0fOrM9WA0KrM0vWm57XhrIMf5FGiN8D0l7fn+bpUeBSU7dCgPV2oX4zHAsAXyHFGcQ==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.36.0.tgz",
+      "integrity": "sha512-KXVsijKeJXOl8QzXTsA+sHVDsFOmMCdBRgFmBb+mfEb/7geR7+C8ypAml4fquUt14ZyVXaw2o1FWhqAfOvA4sg==",
       "cpu": [
         "arm64"
       ],
@@ -4006,9 +4006,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.35.0.tgz",
-      "integrity": "sha512-2mpHCeRuD1u/2kruUiHSsnjWtHjqVbzhBkNVQ1aVD63CcexKVcQGwJ2g5VphOd84GvxfSvnnlEyBtQCE5hxVVw==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.36.0.tgz",
+      "integrity": "sha512-dVeWq1ebbvByI+ndz4IJcD4a09RJgRYmLccwlQ8bPd4olz3Y213uf1iwvc7ZaxNn2ab7bjc08PrtBgMu6nb4pQ==",
       "cpu": [
         "x64"
       ],
@@ -4020,9 +4020,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.35.0.tgz",
-      "integrity": "sha512-mrA0v3QMy6ZSvEuLs0dMxcO2LnaCONs1Z73GUDBHWbY8tFFocM6yl7YyMu7rz4zS81NDSqhrUuolyZXGi8TEqg==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.36.0.tgz",
+      "integrity": "sha512-bvXVU42mOVcF4le6XSjscdXjqx8okv4n5vmwgzcmtvFdifQ5U4dXFYaCB87namDRKlUL9ybVtLQ9ztnawaSzvg==",
       "cpu": [
         "arm"
       ],
@@ -4034,9 +4034,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.35.0.tgz",
-      "integrity": "sha512-DnYhhzcvTAKNexIql8pFajr0PiDGrIsBYPRvCKlA5ixSS3uwo/CWNZxB09jhIapEIg945KOzcYEAGGSmTSpk7A==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.36.0.tgz",
+      "integrity": "sha512-JFIQrDJYrxOnyDQGYkqnNBtjDwTgbasdbUiQvcU8JmGDfValfH1lNpng+4FWlhaVIR4KPkeddYjsVVbmJYvDcg==",
       "cpu": [
         "arm"
       ],
@@ -4048,9 +4048,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.35.0.tgz",
-      "integrity": "sha512-uagpnH2M2g2b5iLsCTZ35CL1FgyuzzJQ8L9VtlJ+FckBXroTwNOaD0z0/UF+k5K3aNQjbm8LIVpxykUOQt1m/A==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.36.0.tgz",
+      "integrity": "sha512-KqjYVh3oM1bj//5X7k79PSCZ6CvaVzb7Qs7VMWS+SlWB5M8p3FqufLP9VNp4CazJ0CsPDLwVD9r3vX7Ci4J56A==",
       "cpu": [
         "arm64"
       ],
@@ -4062,9 +4062,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.35.0.tgz",
-      "integrity": "sha512-XQxVOCd6VJeHQA/7YcqyV0/88N6ysSVzRjJ9I9UA/xXpEsjvAgDTgH3wQYz5bmr7SPtVK2TsP2fQ2N9L4ukoUg==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.36.0.tgz",
+      "integrity": "sha512-QiGnhScND+mAAtfHqeT+cB1S9yFnNQ/EwCg5yE3MzoaZZnIV0RV9O5alJAoJKX/sBONVKeZdMfO8QSaWEygMhw==",
       "cpu": [
         "arm64"
       ],
@@ -4076,9 +4076,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.35.0.tgz",
-      "integrity": "sha512-5pMT5PzfgwcXEwOaSrqVsz/LvjDZt+vQ8RT/70yhPU06PTuq8WaHhfT1LW+cdD7mW6i/J5/XIkX/1tCAkh1W6g==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.36.0.tgz",
+      "integrity": "sha512-1ZPyEDWF8phd4FQtTzMh8FQwqzvIjLsl6/84gzUxnMNFBtExBtpL51H67mV9xipuxl1AEAerRBgBwFNpkw8+Lg==",
       "cpu": [
         "loong64"
       ],
@@ -4090,9 +4090,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.35.0.tgz",
-      "integrity": "sha512-c+zkcvbhbXF98f4CtEIP1EBA/lCic5xB0lToneZYvMeKu5Kamq3O8gqrxiYYLzlZH6E3Aq+TSW86E4ay8iD8EA==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.36.0.tgz",
+      "integrity": "sha512-VMPMEIUpPFKpPI9GZMhJrtu8rxnp6mJR3ZzQPykq4xc2GmdHj3Q4cA+7avMyegXy4n1v+Qynr9fR88BmyO74tg==",
       "cpu": [
         "ppc64"
       ],
@@ -4104,9 +4104,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.35.0.tgz",
-      "integrity": "sha512-s91fuAHdOwH/Tad2tzTtPX7UZyytHIRR6V4+2IGlV0Cej5rkG0R61SX4l4y9sh0JBibMiploZx3oHKPnQBKe4g==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.36.0.tgz",
+      "integrity": "sha512-ttE6ayb/kHwNRJGYLpuAvB7SMtOeQnVXEIpMtAvx3kepFQeowVED0n1K9nAdraHUPJ5hydEMxBpIR7o4nrm8uA==",
       "cpu": [
         "riscv64"
       ],
@@ -4118,9 +4118,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.35.0.tgz",
-      "integrity": "sha512-hQRkPQPLYJZYGP+Hj4fR9dDBMIM7zrzJDWFEMPdTnTy95Ljnv0/4w/ixFw3pTBMEuuEuoqtBINYND4M7ujcuQw==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.36.0.tgz",
+      "integrity": "sha512-4a5gf2jpS0AIe7uBjxDeUMNcFmaRTbNv7NxI5xOCs4lhzsVyGR/0qBXduPnoWf6dGC365saTiwag8hP1imTgag==",
       "cpu": [
         "s390x"
       ],
@@ -4132,9 +4132,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.35.0.tgz",
-      "integrity": "sha512-Pim1T8rXOri+0HmV4CdKSGrqcBWX0d1HoPnQ0uw0bdp1aP5SdQVNBy8LjYncvnLgu3fnnCt17xjWGd4cqh8/hA==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.36.0.tgz",
+      "integrity": "sha512-5KtoW8UWmwFKQ96aQL3LlRXX16IMwyzMq/jSSVIIyAANiE1doaQsx/KRyhAvpHlPjPiSU/AYX/8m+lQ9VToxFQ==",
       "cpu": [
         "x64"
       ],
@@ -4146,9 +4146,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.35.0.tgz",
-      "integrity": "sha512-QysqXzYiDvQWfUiTm8XmJNO2zm9yC9P/2Gkrwg2dH9cxotQzunBHYr6jk4SujCTqnfGxduOmQcI7c2ryuW8XVg==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.36.0.tgz",
+      "integrity": "sha512-sycrYZPrv2ag4OCvaN5js+f01eoZ2U+RmT5as8vhxiFz+kxwlHrsxOwKPSA8WyS+Wc6Epid9QeI/IkQ9NkgYyQ==",
       "cpu": [
         "x64"
       ],
@@ -4160,9 +4160,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.35.0.tgz",
-      "integrity": "sha512-OUOlGqPkVJCdJETKOCEf1mw848ZyJ5w50/rZ/3IBQVdLfR5jk/6Sr5m3iO2tdPgwo0x7VcncYuOvMhBWZq8ayg==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.36.0.tgz",
+      "integrity": "sha512-qbqt4N7tokFwwSVlWDsjfoHgviS3n/vZ8LK0h1uLG9TYIRuUTJC88E1xb3LM2iqZ/WTqNQjYrtmtGmrmmawB6A==",
       "cpu": [
         "arm64"
       ],
@@ -4174,9 +4174,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.35.0.tgz",
-      "integrity": "sha512-2/lsgejMrtwQe44glq7AFFHLfJBPafpsTa6JvP2NGef/ifOa4KBoglVf7AKN7EV9o32evBPRqfg96fEHzWo5kw==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.36.0.tgz",
+      "integrity": "sha512-t+RY0JuRamIocMuQcfwYSOkmdX9dtkr1PbhKW42AMvaDQa+jOdpUYysroTF/nuPpAaQMWp7ye+ndlmmthieJrQ==",
       "cpu": [
         "ia32"
       ],
@@ -4188,9 +4188,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.35.0.tgz",
-      "integrity": "sha512-PIQeY5XDkrOysbQblSW7v3l1MDZzkTEzAfTPkj5VAu3FW8fS4ynyLg2sINp0fp3SjZ8xkRYpLqoKcYqAkhU1dw==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.36.0.tgz",
+      "integrity": "sha512-aRXd7tRZkWLqGbChgcMMDEHjOKudo1kChb1Jt1IfR8cY/KIpgNviLeJy5FUb9IpSuQj8dU2fAYNMPW/hLKOSTw==",
       "cpu": [
         "x64"
       ],
@@ -5918,9 +5918,9 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.0.8.tgz",
-      "integrity": "sha512-y7SAKsQirsEJ2F8bulBck4DoluhI2EEgTimHd6EEUgJBGKy9tC25cpywh1MH4FvDGoG2Unt7+asVd1kj4qOSAw==",
+      "version": "3.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.1.0-beta.1.tgz",
+      "integrity": "sha512-l0LB1v72TuD72HxOHihsHt9Wzgia8OH/AdDVpPc7Kdb4I4GFC0L6MxXqwDwgnZPaDd6bbRXVwjb6j6iS0R9Gog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5941,8 +5941,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "3.0.8",
-        "vitest": "3.0.8"
+        "@vitest/browser": "3.1.0-beta.1",
+        "vitest": "3.1.0-beta.1"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -5976,14 +5976,14 @@
       "license": "MIT"
     },
     "node_modules/@vitest/expect": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.8.tgz",
-      "integrity": "sha512-Xu6TTIavTvSSS6LZaA3EebWFr6tsoXPetOWNMOlc7LO88QVVBwq2oQWBoDiLCN6YTvNYsGSjqOO8CAdjom5DCQ==",
+      "version": "3.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.0-beta.1.tgz",
+      "integrity": "sha512-LI6R0bD4RgI3vSKnAAmLGgfVaH5SkO82JDdYFhsI1lu9ACToV7L4aAVIy9sHVqU5a3ZrFPOQi2wA6J0shOoJ/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.0.8",
-        "@vitest/utils": "3.0.8",
+        "@vitest/spy": "3.1.0-beta.1",
+        "@vitest/utils": "3.1.0-beta.1",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -5991,10 +5991,37 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vitest/mocker": {
+      "version": "3.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.0-beta.1.tgz",
+      "integrity": "sha512-187IruDxlxp+PCHa9SOwQV8rNADJuSZs/F+gF/obn3QvBINsn8ILa1n2S92YFjZjXUtRlfFzfvtqzCezUcYOxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.1.0-beta.1",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.8.tgz",
-      "integrity": "sha512-BNqwbEyitFhzYMYHUVbIvepOyeQOSFA/NeJMIP9enMntkkxLgOcgABH6fjyXG85ipTgvero6noreavGIqfJcIg==",
+      "version": "3.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.0-beta.1.tgz",
+      "integrity": "sha512-ElN4L6VwcR1fPY2n4gH4kLNaawEIITJMzvHCWdN4oC90/xiFpX3p0WIhuHO0XrIwDHsUrC8kBw5pNoPz/axz2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6005,13 +6032,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.0.8.tgz",
-      "integrity": "sha512-c7UUw6gEcOzI8fih+uaAXS5DwjlBaCJUo7KJ4VvJcjL95+DSR1kova2hFuRt3w41KZEFcOEiq098KkyrjXeM5w==",
+      "version": "3.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.0-beta.1.tgz",
+      "integrity": "sha512-y5tfw0N5JEiuLcZandKG4eWKZFuK84t27aGUM26b+4SsBrE9grcnje+ZD9VpNTiRS0DKhpH2179CSqzjdY2VVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.0.8",
+        "@vitest/utils": "3.1.0-beta.1",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -6019,13 +6046,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.8.tgz",
-      "integrity": "sha512-x8IlMGSEMugakInj44nUrLSILh/zy1f2/BgH0UeHpNyOocG18M9CWVIFBaXPt8TrqVZWmcPjwfG/ht5tnpba8A==",
+      "version": "3.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.0-beta.1.tgz",
+      "integrity": "sha512-9sGHyh+G4kNd5FAyLYKh/klIfq4huIwDDFUvYJty4scS60sAz2vBTUmlfQlSQQq1HyiktW1OPCO973fMOaKlqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.0.8",
+        "@vitest/pretty-format": "3.1.0-beta.1",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -6034,9 +6061,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.8.tgz",
-      "integrity": "sha512-MR+PzJa+22vFKYb934CejhR4BeRpMSoxkvNoDit68GQxRLSf11aT6CTj3XaqUU9rxgWJFnqicN/wxw6yBRkI1Q==",
+      "version": "3.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.0-beta.1.tgz",
+      "integrity": "sha512-zWo4KSAffWs5u2LAghiiKObEQktAag82S2mulyKL9DyuFz6mSXeo/NgnWv5lDJYvJ9AnaxxciWYgHaUFIlPbFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6047,13 +6074,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.8.tgz",
-      "integrity": "sha512-nkBC3aEhfX2PdtQI/QwAWp8qZWwzASsU4Npbcd5RdMPBSSLCpkZp52P3xku3s3uA0HIEhGvEcF8rNkBsz9dQ4Q==",
+      "version": "3.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.0-beta.1.tgz",
+      "integrity": "sha512-n1Fgig8q94IE9UFlPKevfLS4jCJLbzEzNUv0W/BiYY5fmrjodBQ5iZHgzSx05xr2UgJvaICUzYzcve11cbbbaQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.0.8",
+        "@vitest/pretty-format": "3.1.0-beta.1",
         "loupe": "^3.1.3",
         "tinyrainbow": "^2.0.0"
       },
@@ -10563,11 +10590,12 @@
       }
     },
     "node_modules/get-port": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
-      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
+      "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -13977,9 +14005,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.9.tgz",
-      "integrity": "sha512-SppoicMGpZvbF1l3z4x7No3OlIjP7QJvC9XR7AhZr1kL133KHnKPztkKDc+Ir4aJ/1VhTySrtKhrsycmrMQfvg==",
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.10.tgz",
+      "integrity": "sha512-vSJJTG+t/dIKAUhUDw/dLdZ9s//5OxcHqLaDWWrW4Cdq7o6tdLIczUkMXt2MBNmk6sJRZBZRXVixs7URY1CmIg==",
       "dev": true,
       "funding": [
         {
@@ -16459,9 +16487,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.35.0.tgz",
-      "integrity": "sha512-kg6oI4g+vc41vePJyO6dHt/yl0Rz3Thv0kJeVQ3D1kS3E5XSuKbPc29G4IpT/Kv1KQwgHVcN+HtyS+HYLNSvQg==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.36.0.tgz",
+      "integrity": "sha512-zwATAXNQxUcd40zgtQG0ZafcRK4g004WtEl7kbuhTWPvf07PsfohXl39jVUvPF7jvNAIkKPQ2XrsDlWuxBd++Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16475,25 +16503,25 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.35.0",
-        "@rollup/rollup-android-arm64": "4.35.0",
-        "@rollup/rollup-darwin-arm64": "4.35.0",
-        "@rollup/rollup-darwin-x64": "4.35.0",
-        "@rollup/rollup-freebsd-arm64": "4.35.0",
-        "@rollup/rollup-freebsd-x64": "4.35.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.35.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.35.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.35.0",
-        "@rollup/rollup-linux-arm64-musl": "4.35.0",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.35.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.35.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.35.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.35.0",
-        "@rollup/rollup-linux-x64-gnu": "4.35.0",
-        "@rollup/rollup-linux-x64-musl": "4.35.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.35.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.35.0",
-        "@rollup/rollup-win32-x64-msvc": "4.35.0",
+        "@rollup/rollup-android-arm-eabi": "4.36.0",
+        "@rollup/rollup-android-arm64": "4.36.0",
+        "@rollup/rollup-darwin-arm64": "4.36.0",
+        "@rollup/rollup-darwin-x64": "4.36.0",
+        "@rollup/rollup-freebsd-arm64": "4.36.0",
+        "@rollup/rollup-freebsd-x64": "4.36.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.36.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.36.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.36.0",
+        "@rollup/rollup-linux-arm64-musl": "4.36.0",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.36.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.36.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.36.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.36.0",
+        "@rollup/rollup-linux-x64-gnu": "4.36.0",
+        "@rollup/rollup-linux-x64-musl": "4.36.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.36.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.36.0",
+        "@rollup/rollup-win32-x64-msvc": "4.36.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -18830,9 +18858,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.1.tgz",
-      "integrity": "sha512-n2GnqDb6XPhlt9B8olZPrgMD/es/Nd1RdChF6CBD/fHW6pUyUTt2sQW2fPRX5GiD9XEa6+8A6A4f2vT6pSsE7Q==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.2.tgz",
+      "integrity": "sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18902,9 +18930,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.8.tgz",
-      "integrity": "sha512-6PhR4H9VGlcwXZ+KWCdMqbtG649xCPZqfI9j2PsK1FcXgEzro5bGHcVKFCTqPLaNKZES8Evqv4LwvZARsq5qlg==",
+      "version": "3.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.0-beta.1.tgz",
+      "integrity": "sha512-xG//Z8ygQaYT5b4l1bdEVBy9UdpL4p0vXXsctys+oDAcnNM1i1gxXSuezq/+Qd5kCc9q3oqJ+GrFB52294R+3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18950,19 +18978,19 @@
       "license": "MIT"
     },
     "node_modules/vitest": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.8.tgz",
-      "integrity": "sha512-dfqAsNqRGUc8hB9OVR2P0w8PZPEckti2+5rdZip0WIz9WW0MnImJ8XiR61QhqLa92EQzKP2uPkzenKOAHyEIbA==",
+      "version": "3.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.0-beta.1.tgz",
+      "integrity": "sha512-JXtpU0x8RNDb25zH1URHZx+8sv5K0BsVZYwyxNtfa1vFcey9NRK1ZQKLC8uK6qQ+pemWLJyhHGJOfV2mtl6e0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "3.0.8",
-        "@vitest/mocker": "3.0.8",
-        "@vitest/pretty-format": "^3.0.8",
-        "@vitest/runner": "3.0.8",
-        "@vitest/snapshot": "3.0.8",
-        "@vitest/spy": "3.0.8",
-        "@vitest/utils": "3.0.8",
+        "@vitest/expect": "3.1.0-beta.1",
+        "@vitest/mocker": "3.1.0-beta.1",
+        "@vitest/pretty-format": "^3.1.0-beta.1",
+        "@vitest/runner": "3.1.0-beta.1",
+        "@vitest/snapshot": "3.1.0-beta.1",
+        "@vitest/spy": "3.1.0-beta.1",
+        "@vitest/utils": "3.1.0-beta.1",
         "chai": "^5.2.0",
         "debug": "^4.4.0",
         "expect-type": "^1.1.0",
@@ -18974,7 +19002,7 @@
         "tinypool": "^1.0.2",
         "tinyrainbow": "^2.0.0",
         "vite": "^5.0.0 || ^6.0.0",
-        "vite-node": "3.0.8",
+        "vite-node": "3.1.0-beta.1",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -18990,8 +19018,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.0.8",
-        "@vitest/ui": "3.0.8",
+        "@vitest/browser": "3.1.0-beta.1",
+        "@vitest/ui": "3.1.0-beta.1",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -19015,33 +19043,6 @@
           "optional": true
         },
         "jsdom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.0.8.tgz",
-      "integrity": "sha512-n3LjS7fcW1BCoF+zWZxG7/5XvuYH+lsFg+BDwwAz0arIwHQJFUEsKBQ0BLU49fCxuM/2HSeBPHQD8WjgrxMfow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "3.0.8",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
           "optional": true
         }
       }
@@ -20124,7 +20125,7 @@
         "debug": "^4.3.5",
         "docker-compose": "^0.24.8",
         "dockerode": "^3.3.5",
-        "get-port": "^5.1.1",
+        "get-port": "^7.1.0",
         "proper-lockfile": "^4.1.2",
         "properties-reader": "^2.3.0",
         "ssh-remote-port-forward": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@eslint/js": "^9.22.0",
     "@eslint/json": "^0.11.0",
-    "@vitest/coverage-v8": "^3.0.8",
+    "@vitest/coverage-v8": "v3.1.0-beta.1",
     "cross-env": "^7.0.3",
     "eslint": "^9.22.0",
     "eslint-config-prettier": "^10.1.1",
@@ -35,7 +35,7 @@
     "ts-node": "^10.9.2",
     "typescript": "^4.9.5",
     "typescript-eslint": "^8.26.1",
-    "vitest": "^3.0.8"
+    "vitest": "v3.1.0-beta.1"
   },
   "lint-staged": {
     "packages/**/*.ts": [

--- a/packages/modules/arangodb/package.json
+++ b/packages/modules/arangodb/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/azurecosmosdb/package.json
+++ b/packages/modules/azurecosmosdb/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/azurite/package.json
+++ b/packages/modules/azurite/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/cassandra/package.json
+++ b/packages/modules/cassandra/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/cassandra/src/cassandra-container.ts
+++ b/packages/modules/cassandra/src/cassandra-container.ts
@@ -1,4 +1,4 @@
-import { AbstractStartedContainer, GenericContainer, type StartedTestContainer } from "testcontainers";
+import { AbstractStartedContainer, GenericContainer, Wait, type StartedTestContainer } from "testcontainers";
 
 const CASSANDRA_PORT = 9042;
 
@@ -10,7 +10,7 @@ export class CassandraContainer extends GenericContainer {
 
   constructor(image = "cassandra:5.0.2") {
     super(image);
-    this.withExposedPorts(CASSANDRA_PORT).withStartupTimeout(120_000);
+    this.withExposedPorts(CASSANDRA_PORT).withWaitStrategy(Wait.forHealthCheck()).withStartupTimeout(120_000);
   }
 
   public withDatacenter(dc: string): this {
@@ -44,7 +44,20 @@ export class CassandraContainer extends GenericContainer {
       CASSANDRA_PASSWORD: this.password,
       CASSANDRA_SNITCH: "GossipingPropertyFileSnitch",
       CASSANDRA_ENDPOINT_SNITCH: "GossipingPropertyFileSnitch",
+      CASSANDRA_NUM_TOKENS: "1",
+      JVM_EXTRA_OPTS: "-Dcassandra.skip_wait_for_gossip_to_settle=0 -Dcassandra.initial_token=0",
     });
+    if (!this.healthCheck) {
+      this.withHealthCheck({
+        test: [
+          "CMD-SHELL",
+          `cqlsh -u ${this.username} -p ${this.password} -e "SELECT release_version FROM system.local;"`,
+        ],
+        interval: 250,
+        timeout: 1000,
+        retries: 1000,
+      });
+    }
     return new StartedCassandraContainer(await super.start(), this.dc, this.rack, this.username, this.password);
   }
 }

--- a/packages/modules/chromadb/package.json
+++ b/packages/modules/chromadb/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/cockroachdb/package.json
+++ b/packages/modules/cockroachdb/package.json
@@ -13,7 +13,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/couchbase/package.json
+++ b/packages/modules/couchbase/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/elasticsearch/package.json
+++ b/packages/modules/elasticsearch/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/eventstoredb/package.json
+++ b/packages/modules/eventstoredb/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/gcloud/package.json
+++ b/packages/modules/gcloud/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/hivemq/package.json
+++ b/packages/modules/hivemq/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/k3s/package.json
+++ b/packages/modules/k3s/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/kafka/package.json
+++ b/packages/modules/kafka/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/localstack/package.json
+++ b/packages/modules/localstack/package.json
@@ -13,7 +13,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/mariadb/package.json
+++ b/packages/modules/mariadb/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/minio/package.json
+++ b/packages/modules/minio/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/mongodb/package.json
+++ b/packages/modules/mongodb/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/mssqlserver/package.json
+++ b/packages/modules/mssqlserver/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/mysql/package.json
+++ b/packages/modules/mysql/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/nats/package.json
+++ b/packages/modules/nats/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/neo4j/package.json
+++ b/packages/modules/neo4j/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/ollama/package.json
+++ b/packages/modules/ollama/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/postgresql/package.json
+++ b/packages/modules/postgresql/package.json
@@ -13,7 +13,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/qdrant/package.json
+++ b/packages/modules/qdrant/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/qdrant/src/qdrant-container.test.ts
+++ b/packages/modules/qdrant/src/qdrant-container.test.ts
@@ -40,7 +40,7 @@ describe("QdrantContainer", { timeout: 100_000 }, () => {
       apiKey: "INVALID_KEY_" + crypto.randomUUID(),
     });
 
-    expect(client.getCollections()).rejects.toThrow("Unauthorized");
+    await expect(client.getCollections()).rejects.toThrow("Unauthorized");
 
     await container.stop();
   });
@@ -69,7 +69,7 @@ describe("QdrantContainer", { timeout: 100_000 }, () => {
       apiKey: "INVALID_KEY_" + crypto.randomUUID(),
     });
 
-    expect(client.getCollections()).rejects.toThrow("Unauthorized");
+    await expect(client.getCollections()).rejects.toThrow("Unauthorized");
 
     await container.stop();
   });

--- a/packages/modules/rabbitmq/package.json
+++ b/packages/modules/rabbitmq/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/rabbitmq/src/rabbitmq-container.test.ts
+++ b/packages/modules/rabbitmq/src/rabbitmq-container.test.ts
@@ -61,6 +61,6 @@ describe("RabbitMQContainer", { timeout: 240_000 }, () => {
     await connection.close();
 
     await rabbitMQContainer.stop();
-  }, 10_000);
+  }, 20_000);
   // }
 });

--- a/packages/modules/redis/package.json
+++ b/packages/modules/redis/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/redpanda/package.json
+++ b/packages/modules/redpanda/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/scylladb/package.json
+++ b/packages/modules/scylladb/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/selenium/package.json
+++ b/packages/modules/selenium/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/toxiproxy/package.json
+++ b/packages/modules/toxiproxy/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/valkey/package.json
+++ b/packages/modules/valkey/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/modules/weaviate/package.json
+++ b/packages/modules/weaviate/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/testcontainers/package.json
+++ b/packages/testcontainers/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/testcontainers/testcontainers-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testcontainers/testcontainers-node"
+    "url": "git+https://github.com/testcontainers/testcontainers-node.git"
   },
   "bugs": {
     "url": "https://github.com/testcontainers/testcontainers-node/issues"

--- a/packages/testcontainers/package.json
+++ b/packages/testcontainers/package.json
@@ -38,7 +38,7 @@
     "debug": "^4.3.5",
     "docker-compose": "^0.24.8",
     "dockerode": "^3.3.5",
-    "get-port": "^5.1.1",
+    "get-port": "^7.1.0",
     "proper-lockfile": "^4.1.2",
     "properties-reader": "^2.3.0",
     "ssh-remote-port-forward": "^1.0.4",

--- a/packages/testcontainers/src/utils/port-generator.ts
+++ b/packages/testcontainers/src/utils/port-generator.ts
@@ -1,4 +1,4 @@
-import getRandomPort from "get-port";
+import getPort, { portNumbers } from "get-port";
 
 export interface PortGenerator {
   generatePort(): Promise<number>;
@@ -6,11 +6,7 @@ export interface PortGenerator {
 
 class RandomPortGenerator {
   public generatePort(): Promise<number> {
-    return getRandomPort({ port: this.randomBetweenInclusive(10000, 65535) });
-  }
-
-  private randomBetweenInclusive(min: number, max: number) {
-    return Math.floor(Math.random() * (max - min + 1) + min);
+    return getPort({ port: portNumbers(10000, 65535) });
   }
 }
 

--- a/packages/testcontainers/src/utils/port-generator.ts
+++ b/packages/testcontainers/src/utils/port-generator.ts
@@ -1,11 +1,10 @@
-import getPort, { portNumbers } from "get-port";
-
 export interface PortGenerator {
   generatePort(): Promise<number>;
 }
 
 class RandomPortGenerator {
-  public generatePort(): Promise<number> {
+  public async generatePort(): Promise<number> {
+    const { default: getPort, portNumbers } = await import("get-port");
     return getPort({ port: portNumbers(10000, 65535) });
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    silent: "passed-only",
     mockReset: true,
     restoreMocks: true,
     alias: {


### PR DESCRIPTION
- Update `get-port` library to get access to helper method
- Fix `package.json` repository URLs with `npm pkg fix`
- Update vitest and use `silent: passed-only` to only show output from failing tests
- Fix some tests where expects were not being awaited
- Fix some test timeouts that were too short
- Cassandra container startup time improvements