### PR TITLE
Docs: clarified timeout unit in different places

### DIFF
--- a/docs/features/compose.md
+++ b/docs/features/compose.md
@@ -140,11 +140,11 @@ const environment = await new DockerComposeEnvironment(composeFilePath, composeF
 await environment.down();
 ```
 
-If you need to wait for the environment to be downed, you can provide a timeout:
+If you need to wait for the environment to be downed, you can provide a timeout. The unit of timeout here is **second**:
 
 ```javascript
 const environment = await new DockerComposeEnvironment(composeFilePath, composeFile).up();
-await environment.down({ timeout: 10000 }); // ms
+await environment.down({ timeout: 10 }); // timeout after 10 seconds
 ```
 
 Volumes created by the environment are removed when stopped. This is configurable:

--- a/docs/features/containers.md
+++ b/docs/features/containers.md
@@ -334,11 +334,11 @@ const container = await new GenericContainer("alpine").start();
 await container.stop();
 ```
 
-If you need to wait for the container to be stopped, you can provide a timeout:
+If you need to wait for the container to be stopped, you can provide a timeout. The unit of timeout option here is **second**:
 
 ```javascript
 const container = await new GenericContainer("alpine").start();
-await container.stop({ timeout: 10000 }); // ms
+await container.stop({ timeout: 10 }); // 10 seconds
 ```
 
 You can disable automatic removal of the container, which is useful for debugging, or if for example you want to copy content from the container once it has stopped:

--- a/docs/features/wait-strategies.md
+++ b/docs/features/wait-strategies.md
@@ -1,12 +1,12 @@
 # Wait Strategies
 
-Note that the startup timeout of all wait strategies is configurable:
+Note that the startup timeout of all wait strategies is configurable. The unit of timeout of wait strategies is **millisecond**:
 
 ```javascript
 const { GenericContainer } = require("testcontainers");
 
 const container = await new GenericContainer("alpine")
-  .withStartupTimeout(120000) // wait 120s
+  .withStartupTimeout(120000) // wait 120 seconds
   .start();
 ```
 
@@ -73,7 +73,7 @@ const { GenericContainer, Wait } = require("testcontainers");
 const container = await new GenericContainer("alpine").withWaitStrategy(Wait.forHealthCheck()).start();
 ```
 
-Define your own health check:
+Define your own health check. The unit of timeouts and intervals here is **millisecond**:
 
 ```javascript
 const { GenericContainer, Wait } = require("testcontainers");
@@ -148,7 +148,7 @@ const container = await new GenericContainer("redis")
   .withMethod("POST")
   .withHeaders({ X_CUSTOM_VALUE: "custom" })
   .withBasicCredentials("username", "password")
-  .withReadTimeout(10000))
+  .withReadTimeout(10000)) // timeout after 10 seconds
 ```
 
 ### Use TLS
@@ -202,11 +202,11 @@ const container = await new GenericContainer("alpine")
   .start();
 ```
 
-The composite wait strategy by default will respect each individual wait strategy's startup timeout. For example:
+The composite wait strategy by default will respect each individual wait strategy's startup timeout. The unit of timeouts here is **millisecond**. For example:
 
 ```javascript
-const w1 = Wait.forListeningPorts().withStartupTimeout(1000);
-const w2 = Wait.forLogMessage("READY").withStartupTimeout(2000);
+const w1 = Wait.forListeningPorts().withStartupTimeout(1000); // wait 1 second
+const w2 = Wait.forLogMessage("READY").withStartupTimeout(2000); // wait 2 seconds
 
 const composite = Wait.forAll([w1, w2]);
 
@@ -217,21 +217,21 @@ expect(w2.getStartupTimeout()).toBe(2000);
 The startup timeout of inner wait strategies that have not defined their own startup timeout can be set by setting the startup timeout on the composite:
 
 ```javascript
-const w1 = Wait.forListeningPorts().withStartupTimeout(1000);
+const w1 = Wait.forListeningPorts().withStartupTimeout(1000); // wait 1 second
 const w2 = Wait.forLogMessage("READY");
 
-const composite = Wait.forAll([w1, w2]).withStartupTimeout(2000);
+const composite = Wait.forAll([w1, w2]).withStartupTimeout(2000); // wait 2 seconds
 
 expect(w1.getStartupTimeout()).toBe(1000);
 expect(w2.getStartupTimeout()).toBe(2000);
 ```
 
-The startup timeout of all wait strategies can be controlled by setting a deadline on the composite. In this case, the composite will throw unless all inner wait strategies have resolved before the deadline.
+The startup timeout of all wait strategies can be controlled by setting a deadline on the composite. In this case, the composite will throw unless all inner wait strategies have resolved before the deadline. The unit of deadline timeout is **millisecond**.
 
 ```javascript
 const w1 = Wait.forListeningPorts();
 const w2 = Wait.forLogMessage("READY");
-const composite = Wait.forAll([w1, w2]).withDeadline(2000);
+const composite = Wait.forAll([w1, w2]).withDeadline(2000); // wait 2 seconds
 ```
 
 ## Other startup strategies
@@ -248,7 +248,7 @@ const {
 
 class ReadyAfterDelayWaitStrategy extends StartupCheckStrategy {
   public checkStartupState(dockerClient: Dockerode, containerId: string): Promise<StartupStatus> {
-    return new Promise((resolve) => setTimeout(() => resolve("SUCCESS"), 3000));
+    return new Promise((resolve) => setTimeout(() => resolve("SUCCESS"), 3000)); // after 3 seconds
   }
 }
 


### PR DESCRIPTION
#817

Docker API itself is a little inconsistent, it uses **seconds** here in `stop` https://docs.docker.com/reference/api/engine/version/v1.48/#tag/Container/operation/ContainerStop
and also **seconds** here in compose up/down https://docs.docker.com/reference/cli/docker/compose/down/

Docker is using **nanoseconds** in HEALTHCHECK (which testcontainers convert from **milliseconds** and pass down) here https://docs.docker.com/reference/api/engine/version/v1.48/#tag/Container/operation/ContainerCreate

Testcontainers APIs use **millisecond** consistently. I have documented timeout values to say which units they are expecting (seconds or millis, etc).