### PR TITLE
Add snapshot support to postgres module

### DIFF
--- a/docs/modules/postgresql.md
+++ b/docs/modules/postgresql.md
@@ -25,3 +25,18 @@ npm install @testcontainers/postgresql --save-dev
 <!--codeinclude-->
 [Set username:](../../packages/modules/postgresql/src/postgresql-container.test.ts) inside_block:setUsername
 <!--/codeinclude-->
+
+### Using Snapshots
+
+This example shows the usage of the postgres module's Snapshot feature to give each test a clean database without having
+to recreate the database container on every test or run heavy scripts to clean your database. This makes the individual
+tests very modular, since they always run on a brand-new database.
+
+!!!tip
+    You should never pass the `"postgres"` system database as the container database name if you want to use snapshots. 
+    The Snapshot logic requires dropping the connected database and using the system database to run commands, which will
+    not work if the database for the container is set to `"postgres"`.
+
+<!--codeinclude-->
+[Test with a reusable Postgres container](../../packages/modules/postgresql/src/postgresql-container.test.ts) inside_block:createAndRestoreFromSnapshot
+<!--/codeinclude-->

--- a/packages/modules/postgresql/src/postgresql-container.test.ts
+++ b/packages/modules/postgresql/src/postgresql-container.test.ts
@@ -154,7 +154,7 @@ describe("PostgreSqlContainer snapshot and restore", { timeout: 180_000 }, () =>
     await client.end();
 
     // Restore to the snapshot
-    await container.restore();
+    await container.restoreSnapshot();
 
     // Reconnect to database
     client = new Client({
@@ -205,7 +205,7 @@ describe("PostgreSqlContainer snapshot and restore", { timeout: 180_000 }, () =>
     await client.end();
 
     // Restore using the custom snapshot name
-    await container.restore(customSnapshotName);
+    await container.restoreSnapshot(customSnapshotName);
 
     // Reconnect to database
     client = new Client({
@@ -272,7 +272,7 @@ describe("PostgreSqlContainer snapshot and restore", { timeout: 180_000 }, () =>
     await client.end();
 
     // Restore to first snapshot (empty table)
-    await container.restore("snapshot1");
+    await container.restoreSnapshot("snapshot1");
 
     // Reconnect to database
     client = new Client({
@@ -288,7 +288,7 @@ describe("PostgreSqlContainer snapshot and restore", { timeout: 180_000 }, () =>
     await client.end();
 
     // Restore to second snapshot (one record)
-    await container.restore("snapshot2");
+    await container.restoreSnapshot("snapshot2");
 
     // Reconnect to database
     client = new Client({
@@ -309,11 +309,11 @@ describe("PostgreSqlContainer snapshot and restore", { timeout: 180_000 }, () =>
     const container = await new PostgreSqlContainer().withDatabase("postgres").start();
 
     await expect(container.snapshot()).rejects.toThrow(
-      "Cannot restore the postgres system database as it cannot be dropped to be restored"
+      "Snapshot feature is not supported when using the postgres system database"
     );
 
-    await expect(container.restore()).rejects.toThrow(
-      "Cannot restore the postgres system database as it cannot be dropped to be restored"
+    await expect(container.restoreSnapshot()).rejects.toThrow(
+      "Snapshot feature is not supported when using the postgres system database"
     );
 
     await container.stop();

--- a/packages/modules/postgresql/src/postgresql-container.test.ts
+++ b/packages/modules/postgresql/src/postgresql-container.test.ts
@@ -309,11 +309,11 @@ describe("PostgreSqlContainer snapshot and restore", { timeout: 180_000 }, () =>
     const container = await new PostgreSqlContainer().withDatabase("postgres").start();
 
     await expect(container.snapshot()).rejects.toThrow(
-      "cannot restore the postgres system database as it cannot be dropped to be restored"
+      "Cannot restore the postgres system database as it cannot be dropped to be restored"
     );
 
     await expect(container.restore()).rejects.toThrow(
-      "cannot restore the postgres system database as it cannot be dropped to be restored"
+      "Cannot restore the postgres system database as it cannot be dropped to be restored"
     );
 
     await container.stop();

--- a/packages/modules/postgresql/src/postgresql-container.test.ts
+++ b/packages/modules/postgresql/src/postgresql-container.test.ts
@@ -2,323 +2,320 @@ import { Client } from "pg";
 import { PostgreSqlContainer } from "./postgresql-container";
 
 describe("PostgreSqlContainer", { timeout: 180_000 }, () => {
-	// connect {
-	it("should connect and return a query result", async () => {
-		const container = await new PostgreSqlContainer().start();
+  // connect {
+  it("should connect and return a query result", async () => {
+    const container = await new PostgreSqlContainer().start();
 
-		const client = new Client({
-			host: container.getHost(),
-			port: container.getPort(),
-			database: container.getDatabase(),
-			user: container.getUsername(),
-			password: container.getPassword(),
-		});
-		await client.connect();
+    const client = new Client({
+      host: container.getHost(),
+      port: container.getPort(),
+      database: container.getDatabase(),
+      user: container.getUsername(),
+      password: container.getPassword(),
+    });
+    await client.connect();
 
-		const result = await client.query("SELECT 1");
-		expect(result.rows[0]).toEqual({ "?column?": 1 });
+    const result = await client.query("SELECT 1");
+    expect(result.rows[0]).toEqual({ "?column?": 1 });
 
-		await client.end();
-		await container.stop();
-	});
-	// }
+    await client.end();
+    await container.stop();
+  });
+  // }
 
-	// uriConnect {
-	it("should work with database URI", async () => {
-		const container = await new PostgreSqlContainer().start();
+  // uriConnect {
+  it("should work with database URI", async () => {
+    const container = await new PostgreSqlContainer().start();
 
-		const client = new Client({
-			connectionString: container.getConnectionUri(),
-		});
-		await client.connect();
+    const client = new Client({
+      connectionString: container.getConnectionUri(),
+    });
+    await client.connect();
 
-		const result = await client.query("SELECT 1");
-		expect(result.rows[0]).toEqual({ "?column?": 1 });
+    const result = await client.query("SELECT 1");
+    expect(result.rows[0]).toEqual({ "?column?": 1 });
 
-		await client.end();
-		await container.stop();
-	});
-	// }
+    await client.end();
+    await container.stop();
+  });
+  // }
 
-	// setDatabase {
-	it("should set database", async () => {
-		const container = await new PostgreSqlContainer().withDatabase("customDatabase").start();
+  // setDatabase {
+  it("should set database", async () => {
+    const container = await new PostgreSqlContainer().withDatabase("customDatabase").start();
 
-		const client = new Client({
-			host: container.getHost(),
-			port: container.getPort(),
-			database: container.getDatabase(),
-			user: container.getUsername(),
-			password: container.getPassword(),
-		});
-		await client.connect();
+    const client = new Client({
+      host: container.getHost(),
+      port: container.getPort(),
+      database: container.getDatabase(),
+      user: container.getUsername(),
+      password: container.getPassword(),
+    });
+    await client.connect();
 
-		const result = await client.query("SELECT current_database()");
-		expect(result.rows[0]).toEqual({ current_database: "customDatabase" });
+    const result = await client.query("SELECT current_database()");
+    expect(result.rows[0]).toEqual({ current_database: "customDatabase" });
 
-		await client.end();
-		await container.stop();
-	});
-	// }
+    await client.end();
+    await container.stop();
+  });
+  // }
 
-	// setUsername {
-	it("should set username", async () => {
-		const container = await new PostgreSqlContainer().withUsername("customUsername").start();
+  // setUsername {
+  it("should set username", async () => {
+    const container = await new PostgreSqlContainer().withUsername("customUsername").start();
 
-		const client = new Client({
-			host: container.getHost(),
-			port: container.getPort(),
-			database: container.getDatabase(),
-			user: container.getUsername(),
-			password: container.getPassword(),
-		});
-		await client.connect();
+    const client = new Client({
+      host: container.getHost(),
+      port: container.getPort(),
+      database: container.getDatabase(),
+      user: container.getUsername(),
+      password: container.getPassword(),
+    });
+    await client.connect();
 
-		const result = await client.query("SELECT current_user");
-		expect(result.rows[0]).toEqual({ current_user: "customUsername" });
+    const result = await client.query("SELECT current_user");
+    expect(result.rows[0]).toEqual({ current_user: "customUsername" });
 
-		await client.end();
-		await container.stop();
-	});
-	// }
+    await client.end();
+    await container.stop();
+  });
+  // }
 
-	it("should work with restarted container", async () => {
-		const container = await new PostgreSqlContainer().start();
-		await container.restart();
+  it("should work with restarted container", async () => {
+    const container = await new PostgreSqlContainer().start();
+    await container.restart();
 
-		const client = new Client({
-			host: container.getHost(),
-			port: container.getPort(),
-			database: container.getDatabase(),
-			user: container.getUsername(),
-			password: container.getPassword(),
-		});
-		await client.connect();
+    const client = new Client({
+      host: container.getHost(),
+      port: container.getPort(),
+      database: container.getDatabase(),
+      user: container.getUsername(),
+      password: container.getPassword(),
+    });
+    await client.connect();
 
-		const result = await client.query("SELECT 1");
-		expect(result.rows[0]).toEqual({ "?column?": 1 });
+    const result = await client.query("SELECT 1");
+    expect(result.rows[0]).toEqual({ "?column?": 1 });
 
-		await client.end();
-		await container.stop();
-	});
+    await client.end();
+    await container.stop();
+  });
 
-	it("should allow custom healthcheck", async () => {
-		const container = new PostgreSqlContainer().withHealthCheck({
-			test: ["CMD-SHELL", "exit 1"],
-			interval: 100,
-			retries: 0,
-			timeout: 0,
-		});
+  it("should allow custom healthcheck", async () => {
+    const container = new PostgreSqlContainer().withHealthCheck({
+      test: ["CMD-SHELL", "exit 1"],
+      interval: 100,
+      retries: 0,
+      timeout: 0,
+    });
 
-		await expect(() => container.start()).rejects.toThrow();
-	});
+    await expect(() => container.start()).rejects.toThrow();
+  });
 });
 
 describe("PostgreSqlContainer snapshot and restore", { timeout: 180_000 }, () => {
-	// createAndRestoreFromSnapshot {
-	it("should create and restore from snapshot", async () => {
-		const container = await new PostgreSqlContainer().start();
+  // createAndRestoreFromSnapshot {
+  it("should create and restore from snapshot", async () => {
+    const container = await new PostgreSqlContainer().start();
 
-		// Connect to the database
-		let client = new Client({
-			connectionString: container.getConnectionUri(),
-		});
-		await client.connect();
+    // Connect to the database
+    let client = new Client({
+      connectionString: container.getConnectionUri(),
+    });
+    await client.connect();
 
-		// Create some test data
-		await client.query("CREATE TABLE test_table (id SERIAL PRIMARY KEY, name TEXT)");
-		await client.query("INSERT INTO test_table (name) VALUES ('initial data')");
+    // Create some test data
+    await client.query("CREATE TABLE test_table (id SERIAL PRIMARY KEY, name TEXT)");
+    await client.query("INSERT INTO test_table (name) VALUES ('initial data')");
 
-		// Close connection before snapshot (otherwise we'll get an error because user is already connected)
-		await client.end();
+    // Close connection before snapshot (otherwise we'll get an error because user is already connected)
+    await client.end();
 
-		// Take a snapshot
-		await container.snapshot();
+    // Take a snapshot
+    await container.snapshot();
 
-		// Reconnect to database
-		client = new Client({
-			connectionString: container.getConnectionUri(),
-		});
-		await client.connect();
+    // Reconnect to database
+    client = new Client({
+      connectionString: container.getConnectionUri(),
+    });
+    await client.connect();
 
-		// Modify the database
-		await client.query("INSERT INTO test_table (name) VALUES ('data after snapshot')");
+    // Modify the database
+    await client.query("INSERT INTO test_table (name) VALUES ('data after snapshot')");
 
-		// Verify both records exist
-		let result = await client.query("SELECT * FROM test_table ORDER BY id");
-		expect(result.rows).toHaveLength(2);
-		expect(result.rows[0].name).toEqual("initial data");
-		expect(result.rows[1].name).toEqual("data after snapshot");
+    // Verify both records exist
+    let result = await client.query("SELECT * FROM test_table ORDER BY id");
+    expect(result.rows).toHaveLength(2);
+    expect(result.rows[0].name).toEqual("initial data");
+    expect(result.rows[1].name).toEqual("data after snapshot");
 
-		// Close connection before restore (same reason as above)
-		await client.end();
+    // Close connection before restore (same reason as above)
+    await client.end();
 
-		// Restore to the snapshot
-		await container.restore();
+    // Restore to the snapshot
+    await container.restore();
 
-		// Reconnect to database
-		client = new Client({
-			connectionString: container.getConnectionUri(),
-		});
-		await client.connect();
+    // Reconnect to database
+    client = new Client({
+      connectionString: container.getConnectionUri(),
+    });
+    await client.connect();
 
-		// Verify only the initial data exists after restore
-		result = await client.query("SELECT * FROM test_table ORDER BY id");
-		expect(result.rows).toHaveLength(1);
-		expect(result.rows[0].name).toEqual("initial data");
+    // Verify only the initial data exists after restore
+    result = await client.query("SELECT * FROM test_table ORDER BY id");
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].name).toEqual("initial data");
 
-		await client.end();
-		await container.stop();
-	});
-	// }
+    await client.end();
+    await container.stop();
+  });
+  // }
 
-	it("should use custom snapshot name", async () => {
-		const container = await new PostgreSqlContainer().start();
-		const customSnapshotName = "my_custom_snapshot";
+  it("should use custom snapshot name", async () => {
+    const container = await new PostgreSqlContainer().start();
+    const customSnapshotName = "my_custom_snapshot";
 
-		// Connect to the database
-		let client = new Client({
-			connectionString: container.getConnectionUri(),
-		});
-		await client.connect();
+    // Connect to the database
+    let client = new Client({
+      connectionString: container.getConnectionUri(),
+    });
+    await client.connect();
 
-		// Create a test table and insert data
-		await client.query("CREATE TABLE test_table (id SERIAL PRIMARY KEY, name TEXT)");
-		await client.query("INSERT INTO test_table (name) VALUES ('initial data')");
+    // Create a test table and insert data
+    await client.query("CREATE TABLE test_table (id SERIAL PRIMARY KEY, name TEXT)");
+    await client.query("INSERT INTO test_table (name) VALUES ('initial data')");
 
-		// Close connection before snapshot
-		await client.end();
+    // Close connection before snapshot
+    await client.end();
 
-		// Take a snapshot with custom name
-		await container.snapshot(customSnapshotName);
+    // Take a snapshot with custom name
+    await container.snapshot(customSnapshotName);
 
-		// Reconnect to database
-		client = new Client({
-			connectionString: container.getConnectionUri(),
-		});
-		await client.connect();
+    // Reconnect to database
+    client = new Client({
+      connectionString: container.getConnectionUri(),
+    });
+    await client.connect();
 
-		// Modify the database
-		await client.query("INSERT INTO test_table (name) VALUES ('data after snapshot')");
+    // Modify the database
+    await client.query("INSERT INTO test_table (name) VALUES ('data after snapshot')");
 
-		// Close connection before restore
-		await client.end();
+    // Close connection before restore
+    await client.end();
 
-		// Restore using the custom snapshot name
-		await container.restore(customSnapshotName);
+    // Restore using the custom snapshot name
+    await container.restore(customSnapshotName);
 
-		// Reconnect to database
-		client = new Client({
-			connectionString: container.getConnectionUri(),
-		});
-		await client.connect();
+    // Reconnect to database
+    client = new Client({
+      connectionString: container.getConnectionUri(),
+    });
+    await client.connect();
 
-		// Verify only the initial data exists after restore
-		const result = await client.query("SELECT * FROM test_table ORDER BY id");
-		expect(result.rows).toHaveLength(1);
-		expect(result.rows[0].name).toEqual("initial data");
+    // Verify only the initial data exists after restore
+    const result = await client.query("SELECT * FROM test_table ORDER BY id");
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].name).toEqual("initial data");
 
-		await client.end();
-		await container.stop();
-	});
+    await client.end();
+    await container.stop();
+  });
 
-	it("should handle multiple snapshots", async () => {
-		const container = await new PostgreSqlContainer().start();
+  it("should handle multiple snapshots", async () => {
+    const container = await new PostgreSqlContainer().start();
 
-		// Connect to the database
-		let client = new Client({
-			connectionString: container.getConnectionUri(),
-		});
-		await client.connect();
+    // Connect to the database
+    let client = new Client({
+      connectionString: container.getConnectionUri(),
+    });
+    await client.connect();
 
-		// Create a test table
-		await client.query("CREATE TABLE test_table (id SERIAL PRIMARY KEY, name TEXT)");
+    // Create a test table
+    await client.query("CREATE TABLE test_table (id SERIAL PRIMARY KEY, name TEXT)");
 
-		// Close connection before snapshot
-		await client.end();
+    // Close connection before snapshot
+    await client.end();
 
-		// Take first snapshot with empty table
-		await container.snapshot("snapshot1");
+    // Take first snapshot with empty table
+    await container.snapshot("snapshot1");
 
-		// Reconnect to database
-		client = new Client({
-			connectionString: container.getConnectionUri(),
-		});
-		await client.connect();
+    // Reconnect to database
+    client = new Client({
+      connectionString: container.getConnectionUri(),
+    });
+    await client.connect();
 
-		// Add first record
-		await client.query("INSERT INTO test_table (name) VALUES ('data for snapshot 2')");
+    // Add first record
+    await client.query("INSERT INTO test_table (name) VALUES ('data for snapshot 2')");
 
-		// Close connection before snapshot
-		await client.end();
+    // Close connection before snapshot
+    await client.end();
 
-		// Take second snapshot with one record
-		await container.snapshot("snapshot2");
+    // Take second snapshot with one record
+    await container.snapshot("snapshot2");
 
-		// Reconnect to database
-		client = new Client({
-			connectionString: container.getConnectionUri(),
-		});
-		await client.connect();
+    // Reconnect to database
+    client = new Client({
+      connectionString: container.getConnectionUri(),
+    });
+    await client.connect();
 
-		// Add second record
-		await client.query("INSERT INTO test_table (name) VALUES ('data after snapshots')");
+    // Add second record
+    await client.query("INSERT INTO test_table (name) VALUES ('data after snapshots')");
 
-		// Verify we have two records
-		let result = await client.query("SELECT COUNT(*) as count FROM test_table");
-		expect(result.rows[0].count).toEqual("2");
+    // Verify we have two records
+    let result = await client.query("SELECT COUNT(*) as count FROM test_table");
+    expect(result.rows[0].count).toEqual("2");
 
-		// Close connection before restore
-		await client.end();
+    // Close connection before restore
+    await client.end();
 
-		// Restore to first snapshot (empty table)
-		await container.restore("snapshot1");
+    // Restore to first snapshot (empty table)
+    await container.restore("snapshot1");
 
-		// Reconnect to database
-		client = new Client({
-			connectionString: container.getConnectionUri(),
-		});
-		await client.connect();
+    // Reconnect to database
+    client = new Client({
+      connectionString: container.getConnectionUri(),
+    });
+    await client.connect();
 
-		// Verify table is empty
-		result = await client.query("SELECT COUNT(*) as count FROM test_table");
-		expect(result.rows[0].count).toEqual("0");
+    // Verify table is empty
+    result = await client.query("SELECT COUNT(*) as count FROM test_table");
+    expect(result.rows[0].count).toEqual("0");
 
-		// Close connection before restore
-		await client.end();
+    // Close connection before restore
+    await client.end();
 
-		// Restore to second snapshot (one record)
-		await container.restore("snapshot2");
+    // Restore to second snapshot (one record)
+    await container.restore("snapshot2");
 
-		// Reconnect to database
-		client = new Client({
-			connectionString: container.getConnectionUri(),
-		});
-		await client.connect();
+    // Reconnect to database
+    client = new Client({
+      connectionString: container.getConnectionUri(),
+    });
+    await client.connect();
 
-		// Verify we have one record
-		result = await client.query("SELECT * FROM test_table");
-		expect(result.rows).toHaveLength(1);
-		expect(result.rows[0].name).toEqual("data for snapshot 2");
+    // Verify we have one record
+    result = await client.query("SELECT * FROM test_table");
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].name).toEqual("data for snapshot 2");
 
-		await client.end();
-		await container.stop();
-	});
+    await client.end();
+    await container.stop();
+  });
 
-	it("should throw an error when trying to snapshot postgres system database", async () => {
-		const container = await new PostgreSqlContainer()
-			.withDatabase("postgres")
-			.start();
+  it("should throw an error when trying to snapshot postgres system database", async () => {
+    const container = await new PostgreSqlContainer().withDatabase("postgres").start();
 
-		await expect(container.snapshot()).rejects.toThrow(
-			"cannot restore the postgres system database as it cannot be dropped to be restored"
-		);
+    await expect(container.snapshot()).rejects.toThrow(
+      "cannot restore the postgres system database as it cannot be dropped to be restored"
+    );
 
-		await expect(container.restore()).rejects.toThrow(
-			"cannot restore the postgres system database as it cannot be dropped to be restored"
-		);
+    await expect(container.restore()).rejects.toThrow(
+      "cannot restore the postgres system database as it cannot be dropped to be restored"
+    );
 
-		await container.stop();
-	});
-
+    await container.stop();
+  });
 });

--- a/packages/modules/postgresql/src/postgresql-container.test.ts
+++ b/packages/modules/postgresql/src/postgresql-container.test.ts
@@ -2,114 +2,323 @@ import { Client } from "pg";
 import { PostgreSqlContainer } from "./postgresql-container";
 
 describe("PostgreSqlContainer", { timeout: 180_000 }, () => {
-  // connect {
-  it("should connect and return a query result", async () => {
-    const container = await new PostgreSqlContainer().start();
+	// connect {
+	it("should connect and return a query result", async () => {
+		const container = await new PostgreSqlContainer().start();
 
-    const client = new Client({
-      host: container.getHost(),
-      port: container.getPort(),
-      database: container.getDatabase(),
-      user: container.getUsername(),
-      password: container.getPassword(),
-    });
-    await client.connect();
+		const client = new Client({
+			host: container.getHost(),
+			port: container.getPort(),
+			database: container.getDatabase(),
+			user: container.getUsername(),
+			password: container.getPassword(),
+		});
+		await client.connect();
 
-    const result = await client.query("SELECT 1");
-    expect(result.rows[0]).toEqual({ "?column?": 1 });
+		const result = await client.query("SELECT 1");
+		expect(result.rows[0]).toEqual({ "?column?": 1 });
 
-    await client.end();
-    await container.stop();
-  });
-  // }
+		await client.end();
+		await container.stop();
+	});
+	// }
 
-  // uriConnect {
-  it("should work with database URI", async () => {
-    const container = await new PostgreSqlContainer().start();
+	// uriConnect {
+	it("should work with database URI", async () => {
+		const container = await new PostgreSqlContainer().start();
 
-    const client = new Client({
-      connectionString: container.getConnectionUri(),
-    });
-    await client.connect();
+		const client = new Client({
+			connectionString: container.getConnectionUri(),
+		});
+		await client.connect();
 
-    const result = await client.query("SELECT 1");
-    expect(result.rows[0]).toEqual({ "?column?": 1 });
+		const result = await client.query("SELECT 1");
+		expect(result.rows[0]).toEqual({ "?column?": 1 });
 
-    await client.end();
-    await container.stop();
-  });
-  // }
+		await client.end();
+		await container.stop();
+	});
+	// }
 
-  // setDatabase {
-  it("should set database", async () => {
-    const container = await new PostgreSqlContainer().withDatabase("customDatabase").start();
+	// setDatabase {
+	it("should set database", async () => {
+		const container = await new PostgreSqlContainer().withDatabase("customDatabase").start();
 
-    const client = new Client({
-      host: container.getHost(),
-      port: container.getPort(),
-      database: container.getDatabase(),
-      user: container.getUsername(),
-      password: container.getPassword(),
-    });
-    await client.connect();
+		const client = new Client({
+			host: container.getHost(),
+			port: container.getPort(),
+			database: container.getDatabase(),
+			user: container.getUsername(),
+			password: container.getPassword(),
+		});
+		await client.connect();
 
-    const result = await client.query("SELECT current_database()");
-    expect(result.rows[0]).toEqual({ current_database: "customDatabase" });
+		const result = await client.query("SELECT current_database()");
+		expect(result.rows[0]).toEqual({ current_database: "customDatabase" });
 
-    await client.end();
-    await container.stop();
-  });
-  // }
+		await client.end();
+		await container.stop();
+	});
+	// }
 
-  // setUsername {
-  it("should set username", async () => {
-    const container = await new PostgreSqlContainer().withUsername("customUsername").start();
+	// setUsername {
+	it("should set username", async () => {
+		const container = await new PostgreSqlContainer().withUsername("customUsername").start();
 
-    const client = new Client({
-      host: container.getHost(),
-      port: container.getPort(),
-      database: container.getDatabase(),
-      user: container.getUsername(),
-      password: container.getPassword(),
-    });
-    await client.connect();
+		const client = new Client({
+			host: container.getHost(),
+			port: container.getPort(),
+			database: container.getDatabase(),
+			user: container.getUsername(),
+			password: container.getPassword(),
+		});
+		await client.connect();
 
-    const result = await client.query("SELECT current_user");
-    expect(result.rows[0]).toEqual({ current_user: "customUsername" });
+		const result = await client.query("SELECT current_user");
+		expect(result.rows[0]).toEqual({ current_user: "customUsername" });
 
-    await client.end();
-    await container.stop();
-  });
-  // }
+		await client.end();
+		await container.stop();
+	});
+	// }
 
-  it("should work with restarted container", async () => {
-    const container = await new PostgreSqlContainer().start();
-    await container.restart();
+	it("should work with restarted container", async () => {
+		const container = await new PostgreSqlContainer().start();
+		await container.restart();
 
-    const client = new Client({
-      host: container.getHost(),
-      port: container.getPort(),
-      database: container.getDatabase(),
-      user: container.getUsername(),
-      password: container.getPassword(),
-    });
-    await client.connect();
+		const client = new Client({
+			host: container.getHost(),
+			port: container.getPort(),
+			database: container.getDatabase(),
+			user: container.getUsername(),
+			password: container.getPassword(),
+		});
+		await client.connect();
 
-    const result = await client.query("SELECT 1");
-    expect(result.rows[0]).toEqual({ "?column?": 1 });
+		const result = await client.query("SELECT 1");
+		expect(result.rows[0]).toEqual({ "?column?": 1 });
 
-    await client.end();
-    await container.stop();
-  });
+		await client.end();
+		await container.stop();
+	});
 
-  it("should allow custom healthcheck", async () => {
-    const container = new PostgreSqlContainer().withHealthCheck({
-      test: ["CMD-SHELL", "exit 1"],
-      interval: 100,
-      retries: 0,
-      timeout: 0,
-    });
+	it("should allow custom healthcheck", async () => {
+		const container = new PostgreSqlContainer().withHealthCheck({
+			test: ["CMD-SHELL", "exit 1"],
+			interval: 100,
+			retries: 0,
+			timeout: 0,
+		});
 
-    await expect(() => container.start()).rejects.toThrow();
-  });
+		await expect(() => container.start()).rejects.toThrow();
+	});
+});
+
+describe("PostgreSqlContainer snapshot and restore", { timeout: 180_000 }, () => {
+	// createAndRestoreFromSnapshot {
+	it("should create and restore from snapshot", async () => {
+		const container = await new PostgreSqlContainer().start();
+
+		// Connect to the database
+		let client = new Client({
+			connectionString: container.getConnectionUri(),
+		});
+		await client.connect();
+
+		// Create some test data
+		await client.query("CREATE TABLE test_table (id SERIAL PRIMARY KEY, name TEXT)");
+		await client.query("INSERT INTO test_table (name) VALUES ('initial data')");
+
+		// Close connection before snapshot (otherwise we'll get an error because user is already connected)
+		await client.end();
+
+		// Take a snapshot
+		await container.snapshot();
+
+		// Reconnect to database
+		client = new Client({
+			connectionString: container.getConnectionUri(),
+		});
+		await client.connect();
+
+		// Modify the database
+		await client.query("INSERT INTO test_table (name) VALUES ('data after snapshot')");
+
+		// Verify both records exist
+		let result = await client.query("SELECT * FROM test_table ORDER BY id");
+		expect(result.rows).toHaveLength(2);
+		expect(result.rows[0].name).toEqual("initial data");
+		expect(result.rows[1].name).toEqual("data after snapshot");
+
+		// Close connection before restore (same reason as above)
+		await client.end();
+
+		// Restore to the snapshot
+		await container.restore();
+
+		// Reconnect to database
+		client = new Client({
+			connectionString: container.getConnectionUri(),
+		});
+		await client.connect();
+
+		// Verify only the initial data exists after restore
+		result = await client.query("SELECT * FROM test_table ORDER BY id");
+		expect(result.rows).toHaveLength(1);
+		expect(result.rows[0].name).toEqual("initial data");
+
+		await client.end();
+		await container.stop();
+	});
+	// }
+
+	it("should use custom snapshot name", async () => {
+		const container = await new PostgreSqlContainer().start();
+		const customSnapshotName = "my_custom_snapshot";
+
+		// Connect to the database
+		let client = new Client({
+			connectionString: container.getConnectionUri(),
+		});
+		await client.connect();
+
+		// Create a test table and insert data
+		await client.query("CREATE TABLE test_table (id SERIAL PRIMARY KEY, name TEXT)");
+		await client.query("INSERT INTO test_table (name) VALUES ('initial data')");
+
+		// Close connection before snapshot
+		await client.end();
+
+		// Take a snapshot with custom name
+		await container.snapshot(customSnapshotName);
+
+		// Reconnect to database
+		client = new Client({
+			connectionString: container.getConnectionUri(),
+		});
+		await client.connect();
+
+		// Modify the database
+		await client.query("INSERT INTO test_table (name) VALUES ('data after snapshot')");
+
+		// Close connection before restore
+		await client.end();
+
+		// Restore using the custom snapshot name
+		await container.restore(customSnapshotName);
+
+		// Reconnect to database
+		client = new Client({
+			connectionString: container.getConnectionUri(),
+		});
+		await client.connect();
+
+		// Verify only the initial data exists after restore
+		const result = await client.query("SELECT * FROM test_table ORDER BY id");
+		expect(result.rows).toHaveLength(1);
+		expect(result.rows[0].name).toEqual("initial data");
+
+		await client.end();
+		await container.stop();
+	});
+
+	it("should handle multiple snapshots", async () => {
+		const container = await new PostgreSqlContainer().start();
+
+		// Connect to the database
+		let client = new Client({
+			connectionString: container.getConnectionUri(),
+		});
+		await client.connect();
+
+		// Create a test table
+		await client.query("CREATE TABLE test_table (id SERIAL PRIMARY KEY, name TEXT)");
+
+		// Close connection before snapshot
+		await client.end();
+
+		// Take first snapshot with empty table
+		await container.snapshot("snapshot1");
+
+		// Reconnect to database
+		client = new Client({
+			connectionString: container.getConnectionUri(),
+		});
+		await client.connect();
+
+		// Add first record
+		await client.query("INSERT INTO test_table (name) VALUES ('data for snapshot 2')");
+
+		// Close connection before snapshot
+		await client.end();
+
+		// Take second snapshot with one record
+		await container.snapshot("snapshot2");
+
+		// Reconnect to database
+		client = new Client({
+			connectionString: container.getConnectionUri(),
+		});
+		await client.connect();
+
+		// Add second record
+		await client.query("INSERT INTO test_table (name) VALUES ('data after snapshots')");
+
+		// Verify we have two records
+		let result = await client.query("SELECT COUNT(*) as count FROM test_table");
+		expect(result.rows[0].count).toEqual("2");
+
+		// Close connection before restore
+		await client.end();
+
+		// Restore to first snapshot (empty table)
+		await container.restore("snapshot1");
+
+		// Reconnect to database
+		client = new Client({
+			connectionString: container.getConnectionUri(),
+		});
+		await client.connect();
+
+		// Verify table is empty
+		result = await client.query("SELECT COUNT(*) as count FROM test_table");
+		expect(result.rows[0].count).toEqual("0");
+
+		// Close connection before restore
+		await client.end();
+
+		// Restore to second snapshot (one record)
+		await container.restore("snapshot2");
+
+		// Reconnect to database
+		client = new Client({
+			connectionString: container.getConnectionUri(),
+		});
+		await client.connect();
+
+		// Verify we have one record
+		result = await client.query("SELECT * FROM test_table");
+		expect(result.rows).toHaveLength(1);
+		expect(result.rows[0].name).toEqual("data for snapshot 2");
+
+		await client.end();
+		await container.stop();
+	});
+
+	it("should throw an error when trying to snapshot postgres system database", async () => {
+		const container = await new PostgreSqlContainer()
+			.withDatabase("postgres")
+			.start();
+
+		await expect(container.snapshot()).rejects.toThrow(
+			"cannot restore the postgres system database as it cannot be dropped to be restored"
+		);
+
+		await expect(container.restore()).rejects.toThrow(
+			"cannot restore the postgres system database as it cannot be dropped to be restored"
+		);
+
+		await container.stop();
+	});
+
 });

--- a/packages/modules/postgresql/src/postgresql-container.ts
+++ b/packages/modules/postgresql/src/postgresql-container.ts
@@ -102,7 +102,7 @@ export class StartedPostgreSqlContainer extends AbstractStartedContainer {
    * @returns Promise resolving when snapshot is complete
    */
   public async snapshot(snapshotName?: string): Promise<void> {
-    const name = snapshotName || this.snapshotName;
+    const name = snapshotName ?? this.snapshotName;
 
     this.snapshotSanityCheck(name);
 
@@ -127,7 +127,7 @@ export class StartedPostgreSqlContainer extends AbstractStartedContainer {
    * @returns Promise resolving when restore is complete
    */
   public async restore(snapshotName?: string): Promise<void> {
-    const name = snapshotName || this.snapshotName;
+    const name = snapshotName ?? this.snapshotName;
 
     this.snapshotSanityCheck(name);
 
@@ -175,11 +175,11 @@ export class StartedPostgreSqlContainer extends AbstractStartedContainer {
    */
   private snapshotSanityCheck(snapshotName: string): void {
     if (this.getDatabase() === "postgres") {
-      throw new Error("cannot restore the postgres system database as it cannot be dropped to be restored");
+      throw new Error("Cannot restore the postgres system database as it cannot be dropped to be restored");
     }
 
     if (this.getDatabase() === snapshotName) {
-      throw new Error("cannot restore the database to itself");
+      throw new Error("Cannot restore the database to itself");
     }
   }
 }

--- a/packages/modules/postgresql/src/postgresql-container.ts
+++ b/packages/modules/postgresql/src/postgresql-container.ts
@@ -3,86 +3,185 @@ import { AbstractStartedContainer, GenericContainer, StartedTestContainer, Wait 
 const POSTGRES_PORT = 5432;
 
 export class PostgreSqlContainer extends GenericContainer {
-  private database = "test";
-  private username = "test";
-  private password = "test";
+	private database = "test";
+	private username = "test";
+	private password = "test";
 
-  constructor(image = "postgres:13.3-alpine") {
-    super(image);
-    this.withExposedPorts(POSTGRES_PORT);
-    this.withWaitStrategy(Wait.forHealthCheck());
-    this.withStartupTimeout(120_000);
-  }
+	constructor(image = "postgres:13.3-alpine") {
+		super(image);
+		this.withExposedPorts(POSTGRES_PORT);
+		this.withWaitStrategy(Wait.forHealthCheck());
+		this.withStartupTimeout(120_000);
+	}
 
-  public withDatabase(database: string): this {
-    this.database = database;
-    return this;
-  }
+	public withDatabase(database: string): this {
+		this.database = database;
+		return this;
+	}
 
-  public withUsername(username: string): this {
-    this.username = username;
-    return this;
-  }
+	public withUsername(username: string): this {
+		this.username = username;
+		return this;
+	}
 
-  public withPassword(password: string): this {
-    this.password = password;
-    return this;
-  }
+	public withPassword(password: string): this {
+		this.password = password;
+		return this;
+	}
 
-  public override async start(): Promise<StartedPostgreSqlContainer> {
-    this.withEnvironment({
-      POSTGRES_DB: this.database,
-      POSTGRES_USER: this.username,
-      POSTGRES_PASSWORD: this.password,
-    });
-    if (!this.healthCheck) {
-      this.withHealthCheck({
-        test: ["CMD-SHELL", `PGPASSWORD=${this.password} psql -U ${this.username} -d ${this.database} -c 'SELECT 1;'`],
-        interval: 250,
-        timeout: 1000,
-        retries: 1000,
-      });
-    }
-    return new StartedPostgreSqlContainer(await super.start(), this.database, this.username, this.password);
-  }
+	public override async start(): Promise<StartedPostgreSqlContainer> {
+		this.withEnvironment({
+			POSTGRES_DB: this.database,
+			POSTGRES_USER: this.username,
+			POSTGRES_PASSWORD: this.password,
+		});
+		if (!this.healthCheck) {
+			this.withHealthCheck({
+				test: ["CMD-SHELL", `PGPASSWORD=${this.password} psql -U ${this.username} -d ${this.database} -c 'SELECT 1;'`],
+				interval: 250,
+				timeout: 1000,
+				retries: 1000,
+			});
+		}
+		return new StartedPostgreSqlContainer(await super.start(), this.database, this.username, this.password);
+	}
 }
 
 export class StartedPostgreSqlContainer extends AbstractStartedContainer {
-  constructor(
-    startedTestContainer: StartedTestContainer,
-    private readonly database: string,
-    private readonly username: string,
-    private readonly password: string
-  ) {
-    super(startedTestContainer);
-  }
+	private snapshotName: string = "migrated_template";
+	constructor(
+		startedTestContainer: StartedTestContainer,
+		private readonly database: string,
+		private readonly username: string,
+		private readonly password: string,
+	) {
+		super(startedTestContainer);
+	}
 
-  public getPort(): number {
-    return super.getMappedPort(POSTGRES_PORT);
-  }
+	public getPort(): number {
+		return super.getMappedPort(POSTGRES_PORT);
+	}
 
-  public getDatabase(): string {
-    return this.database;
-  }
+	public getDatabase(): string {
+		return this.database;
+	}
 
-  public getUsername(): string {
-    return this.username;
-  }
+	public getUsername(): string {
+		return this.username;
+	}
 
-  public getPassword(): string {
-    return this.password;
-  }
+	public getPassword(): string {
+		return this.password;
+	}
 
-  /**
-   * @returns A connection URI in the form of `postgres[ql]://[username[:password]@][host[:port],]/database`
-   */
-  public getConnectionUri(): string {
-    const url = new URL("", "postgres://");
-    url.hostname = this.getHost();
-    url.port = this.getPort().toString();
-    url.pathname = this.getDatabase();
-    url.username = this.getUsername();
-    url.password = this.getPassword();
-    return url.toString();
-  }
+	/**
+	 * @returns A connection URI in the form of `postgres[ql]://[username[:password]@][host[:port],]/database`
+	 */
+	public getConnectionUri(): string {
+		const url = new URL("", "postgres://");
+		url.hostname = this.getHost();
+		url.port = this.getPort().toString();
+		url.pathname = this.getDatabase();
+		url.username = this.getUsername();
+		url.password = this.getPassword();
+		return url.toString();
+	}
+
+
+	public withSnapshotName(snapshotName: string): this {
+		this.snapshotName = snapshotName;
+		return this;
+	}
+
+
+	/**
+	 * Takes a snapshot of the current state of the database as a template, which can then be restored using
+	 * the restore method. By default, the snapshot will be created under a database called migrated_template.
+	 *
+	 * If a snapshot already exists under the given/default name, it will be overwritten with the new snapshot.
+	 *
+	 * @param opts Optional snapshot configuration options
+	 * @returns Promise resolving when snapshot is complete
+	 */
+	public async snapshot(snapshotName?: string): Promise<void> {
+		const name = snapshotName || this.snapshotName;
+
+		this.snapshotSanityCheck(name);
+
+		// Execute the commands to create the snapshot, in order
+		await this.execCommandsSQL([
+			// Update pg_database to remove the template flag, then drop the database if it exists.
+			// This is needed because dropping a template database will fail.
+			`UPDATE pg_database SET datistemplate = FALSE WHERE datname = '${name}'`,
+			`DROP DATABASE IF EXISTS "${name}"`,
+			// Create a copy of the database to another database to use as a template now that it was fully migrated
+			`CREATE DATABASE "${name}" WITH TEMPLATE "${this.getDatabase()}" OWNER "${this.getUsername()}"`,
+			// Snapshot the template database so we can restore it onto our original database going forward
+			`ALTER DATABASE "${name}" WITH is_template = TRUE`,
+		]);
+	}
+
+	/**
+	 * Restores the database to a specific snapshot. By default, it will restore the last snapshot taken on the
+	 * database by the snapshot method. If a snapshot name is provided, it will instead try to restore the snapshot by name.
+	 *
+	 * @param opts Optional snapshot configuration options
+	 * @returns Promise resolving when restore is complete
+	 */
+	public async restore(snapshotName?: string): Promise<void> {
+		const name = snapshotName || this.snapshotName;
+
+		this.snapshotSanityCheck(name);
+
+		// Execute the commands to restore the snapshot, in order
+		await this.execCommandsSQL([
+			// Drop the entire database by connecting to the postgres global database
+			`DROP DATABASE "${this.getDatabase()}" WITH (FORCE)`,
+			// Then restore the previous snapshot
+			`CREATE DATABASE "${this.getDatabase()}" WITH TEMPLATE "${name}" OWNER "${this.getUsername()}"`,
+		]);
+	}
+
+	/**
+	 * Executes a series of SQL commands against the Postgres database
+	 * @param commands SQL commands to execute
+	 */
+	private async execCommandsSQL(commands: string[]): Promise<void> {
+		for (const command of commands) {
+			try {
+				const result = await this.exec([
+					'psql',
+					'-v',
+					'ON_ERROR_STOP=1',
+					'-U',
+					this.getUsername(),
+					'-d',
+					'postgres',
+					'-c',
+					command,
+				]);
+
+				if (result.exitCode !== 0) {
+					throw new Error(`Command failed with exit code ${result.exitCode}: ${result.output}`);
+				}
+			} catch (error) {
+				console.error(`Failed to execute command: ${command}`, error);
+				throw error;
+			}
+		}
+	}
+
+	/**
+	 * Checks if the snapshot name is valid and if the database is not the postgres system database
+	 * @param snapshotName The name of the snapshot to check
+	 */
+	private snapshotSanityCheck(snapshotName: string): void {
+		if (this.getDatabase() === "postgres") {
+			throw new Error("cannot restore the postgres system database as it cannot be dropped to be restored");
+		}
+
+		if (this.getDatabase() === snapshotName) {
+			throw new Error("cannot restore the database to itself");
+		}
+	}
 }

--- a/packages/modules/postgresql/src/postgresql-container.ts
+++ b/packages/modules/postgresql/src/postgresql-container.ts
@@ -144,7 +144,7 @@ export class StartedPostgreSqlContainer extends AbstractStartedContainer {
 
   /**
    * Executes a series of SQL commands against the Postgres database
-   * 
+   *
    * @param commands Array of SQL commands to execute in sequence
    * @throws Error if any command fails to execute with details of the failure
    */

--- a/packages/modules/postgresql/src/postgresql-container.ts
+++ b/packages/modules/postgresql/src/postgresql-container.ts
@@ -3,185 +3,183 @@ import { AbstractStartedContainer, GenericContainer, StartedTestContainer, Wait 
 const POSTGRES_PORT = 5432;
 
 export class PostgreSqlContainer extends GenericContainer {
-	private database = "test";
-	private username = "test";
-	private password = "test";
+  private database = "test";
+  private username = "test";
+  private password = "test";
 
-	constructor(image = "postgres:13.3-alpine") {
-		super(image);
-		this.withExposedPorts(POSTGRES_PORT);
-		this.withWaitStrategy(Wait.forHealthCheck());
-		this.withStartupTimeout(120_000);
-	}
+  constructor(image = "postgres:13.3-alpine") {
+    super(image);
+    this.withExposedPorts(POSTGRES_PORT);
+    this.withWaitStrategy(Wait.forHealthCheck());
+    this.withStartupTimeout(120_000);
+  }
 
-	public withDatabase(database: string): this {
-		this.database = database;
-		return this;
-	}
+  public withDatabase(database: string): this {
+    this.database = database;
+    return this;
+  }
 
-	public withUsername(username: string): this {
-		this.username = username;
-		return this;
-	}
+  public withUsername(username: string): this {
+    this.username = username;
+    return this;
+  }
 
-	public withPassword(password: string): this {
-		this.password = password;
-		return this;
-	}
+  public withPassword(password: string): this {
+    this.password = password;
+    return this;
+  }
 
-	public override async start(): Promise<StartedPostgreSqlContainer> {
-		this.withEnvironment({
-			POSTGRES_DB: this.database,
-			POSTGRES_USER: this.username,
-			POSTGRES_PASSWORD: this.password,
-		});
-		if (!this.healthCheck) {
-			this.withHealthCheck({
-				test: ["CMD-SHELL", `PGPASSWORD=${this.password} psql -U ${this.username} -d ${this.database} -c 'SELECT 1;'`],
-				interval: 250,
-				timeout: 1000,
-				retries: 1000,
-			});
-		}
-		return new StartedPostgreSqlContainer(await super.start(), this.database, this.username, this.password);
-	}
+  public override async start(): Promise<StartedPostgreSqlContainer> {
+    this.withEnvironment({
+      POSTGRES_DB: this.database,
+      POSTGRES_USER: this.username,
+      POSTGRES_PASSWORD: this.password,
+    });
+    if (!this.healthCheck) {
+      this.withHealthCheck({
+        test: ["CMD-SHELL", `PGPASSWORD=${this.password} psql -U ${this.username} -d ${this.database} -c 'SELECT 1;'`],
+        interval: 250,
+        timeout: 1000,
+        retries: 1000,
+      });
+    }
+    return new StartedPostgreSqlContainer(await super.start(), this.database, this.username, this.password);
+  }
 }
 
 export class StartedPostgreSqlContainer extends AbstractStartedContainer {
-	private snapshotName: string = "migrated_template";
-	constructor(
-		startedTestContainer: StartedTestContainer,
-		private readonly database: string,
-		private readonly username: string,
-		private readonly password: string,
-	) {
-		super(startedTestContainer);
-	}
+  private snapshotName: string = "migrated_template";
+  constructor(
+    startedTestContainer: StartedTestContainer,
+    private readonly database: string,
+    private readonly username: string,
+    private readonly password: string
+  ) {
+    super(startedTestContainer);
+  }
 
-	public getPort(): number {
-		return super.getMappedPort(POSTGRES_PORT);
-	}
+  public getPort(): number {
+    return super.getMappedPort(POSTGRES_PORT);
+  }
 
-	public getDatabase(): string {
-		return this.database;
-	}
+  public getDatabase(): string {
+    return this.database;
+  }
 
-	public getUsername(): string {
-		return this.username;
-	}
+  public getUsername(): string {
+    return this.username;
+  }
 
-	public getPassword(): string {
-		return this.password;
-	}
+  public getPassword(): string {
+    return this.password;
+  }
 
-	/**
-	 * @returns A connection URI in the form of `postgres[ql]://[username[:password]@][host[:port],]/database`
-	 */
-	public getConnectionUri(): string {
-		const url = new URL("", "postgres://");
-		url.hostname = this.getHost();
-		url.port = this.getPort().toString();
-		url.pathname = this.getDatabase();
-		url.username = this.getUsername();
-		url.password = this.getPassword();
-		return url.toString();
-	}
+  /**
+   * @returns A connection URI in the form of `postgres[ql]://[username[:password]@][host[:port],]/database`
+   */
+  public getConnectionUri(): string {
+    const url = new URL("", "postgres://");
+    url.hostname = this.getHost();
+    url.port = this.getPort().toString();
+    url.pathname = this.getDatabase();
+    url.username = this.getUsername();
+    url.password = this.getPassword();
+    return url.toString();
+  }
 
+  public withSnapshotName(snapshotName: string): this {
+    this.snapshotName = snapshotName;
+    return this;
+  }
 
-	public withSnapshotName(snapshotName: string): this {
-		this.snapshotName = snapshotName;
-		return this;
-	}
+  /**
+   * Takes a snapshot of the current state of the database as a template, which can then be restored using
+   * the restore method. By default, the snapshot will be created under a database called migrated_template.
+   *
+   * If a snapshot already exists under the given/default name, it will be overwritten with the new snapshot.
+   *
+   * @param opts Optional snapshot configuration options
+   * @returns Promise resolving when snapshot is complete
+   */
+  public async snapshot(snapshotName?: string): Promise<void> {
+    const name = snapshotName || this.snapshotName;
 
+    this.snapshotSanityCheck(name);
 
-	/**
-	 * Takes a snapshot of the current state of the database as a template, which can then be restored using
-	 * the restore method. By default, the snapshot will be created under a database called migrated_template.
-	 *
-	 * If a snapshot already exists under the given/default name, it will be overwritten with the new snapshot.
-	 *
-	 * @param opts Optional snapshot configuration options
-	 * @returns Promise resolving when snapshot is complete
-	 */
-	public async snapshot(snapshotName?: string): Promise<void> {
-		const name = snapshotName || this.snapshotName;
+    // Execute the commands to create the snapshot, in order
+    await this.execCommandsSQL([
+      // Update pg_database to remove the template flag, then drop the database if it exists.
+      // This is needed because dropping a template database will fail.
+      `UPDATE pg_database SET datistemplate = FALSE WHERE datname = '${name}'`,
+      `DROP DATABASE IF EXISTS "${name}"`,
+      // Create a copy of the database to another database to use as a template now that it was fully migrated
+      `CREATE DATABASE "${name}" WITH TEMPLATE "${this.getDatabase()}" OWNER "${this.getUsername()}"`,
+      // Snapshot the template database so we can restore it onto our original database going forward
+      `ALTER DATABASE "${name}" WITH is_template = TRUE`,
+    ]);
+  }
 
-		this.snapshotSanityCheck(name);
+  /**
+   * Restores the database to a specific snapshot. By default, it will restore the last snapshot taken on the
+   * database by the snapshot method. If a snapshot name is provided, it will instead try to restore the snapshot by name.
+   *
+   * @param opts Optional snapshot configuration options
+   * @returns Promise resolving when restore is complete
+   */
+  public async restore(snapshotName?: string): Promise<void> {
+    const name = snapshotName || this.snapshotName;
 
-		// Execute the commands to create the snapshot, in order
-		await this.execCommandsSQL([
-			// Update pg_database to remove the template flag, then drop the database if it exists.
-			// This is needed because dropping a template database will fail.
-			`UPDATE pg_database SET datistemplate = FALSE WHERE datname = '${name}'`,
-			`DROP DATABASE IF EXISTS "${name}"`,
-			// Create a copy of the database to another database to use as a template now that it was fully migrated
-			`CREATE DATABASE "${name}" WITH TEMPLATE "${this.getDatabase()}" OWNER "${this.getUsername()}"`,
-			// Snapshot the template database so we can restore it onto our original database going forward
-			`ALTER DATABASE "${name}" WITH is_template = TRUE`,
-		]);
-	}
+    this.snapshotSanityCheck(name);
 
-	/**
-	 * Restores the database to a specific snapshot. By default, it will restore the last snapshot taken on the
-	 * database by the snapshot method. If a snapshot name is provided, it will instead try to restore the snapshot by name.
-	 *
-	 * @param opts Optional snapshot configuration options
-	 * @returns Promise resolving when restore is complete
-	 */
-	public async restore(snapshotName?: string): Promise<void> {
-		const name = snapshotName || this.snapshotName;
+    // Execute the commands to restore the snapshot, in order
+    await this.execCommandsSQL([
+      // Drop the entire database by connecting to the postgres global database
+      `DROP DATABASE "${this.getDatabase()}" WITH (FORCE)`,
+      // Then restore the previous snapshot
+      `CREATE DATABASE "${this.getDatabase()}" WITH TEMPLATE "${name}" OWNER "${this.getUsername()}"`,
+    ]);
+  }
 
-		this.snapshotSanityCheck(name);
+  /**
+   * Executes a series of SQL commands against the Postgres database
+   * @param commands SQL commands to execute
+   */
+  private async execCommandsSQL(commands: string[]): Promise<void> {
+    for (const command of commands) {
+      try {
+        const result = await this.exec([
+          "psql",
+          "-v",
+          "ON_ERROR_STOP=1",
+          "-U",
+          this.getUsername(),
+          "-d",
+          "postgres",
+          "-c",
+          command,
+        ]);
 
-		// Execute the commands to restore the snapshot, in order
-		await this.execCommandsSQL([
-			// Drop the entire database by connecting to the postgres global database
-			`DROP DATABASE "${this.getDatabase()}" WITH (FORCE)`,
-			// Then restore the previous snapshot
-			`CREATE DATABASE "${this.getDatabase()}" WITH TEMPLATE "${name}" OWNER "${this.getUsername()}"`,
-		]);
-	}
+        if (result.exitCode !== 0) {
+          throw new Error(`Command failed with exit code ${result.exitCode}: ${result.output}`);
+        }
+      } catch (error) {
+        console.error(`Failed to execute command: ${command}`, error);
+        throw error;
+      }
+    }
+  }
 
-	/**
-	 * Executes a series of SQL commands against the Postgres database
-	 * @param commands SQL commands to execute
-	 */
-	private async execCommandsSQL(commands: string[]): Promise<void> {
-		for (const command of commands) {
-			try {
-				const result = await this.exec([
-					'psql',
-					'-v',
-					'ON_ERROR_STOP=1',
-					'-U',
-					this.getUsername(),
-					'-d',
-					'postgres',
-					'-c',
-					command,
-				]);
+  /**
+   * Checks if the snapshot name is valid and if the database is not the postgres system database
+   * @param snapshotName The name of the snapshot to check
+   */
+  private snapshotSanityCheck(snapshotName: string): void {
+    if (this.getDatabase() === "postgres") {
+      throw new Error("cannot restore the postgres system database as it cannot be dropped to be restored");
+    }
 
-				if (result.exitCode !== 0) {
-					throw new Error(`Command failed with exit code ${result.exitCode}: ${result.output}`);
-				}
-			} catch (error) {
-				console.error(`Failed to execute command: ${command}`, error);
-				throw error;
-			}
-		}
-	}
-
-	/**
-	 * Checks if the snapshot name is valid and if the database is not the postgres system database
-	 * @param snapshotName The name of the snapshot to check
-	 */
-	private snapshotSanityCheck(snapshotName: string): void {
-		if (this.getDatabase() === "postgres") {
-			throw new Error("cannot restore the postgres system database as it cannot be dropped to be restored");
-		}
-
-		if (this.getDatabase() === snapshotName) {
-			throw new Error("cannot restore the database to itself");
-		}
-	}
+    if (this.getDatabase() === snapshotName) {
+      throw new Error("cannot restore the database to itself");
+    }
+  }
 }

--- a/packages/modules/postgresql/src/postgresql-container.ts
+++ b/packages/modules/postgresql/src/postgresql-container.ts
@@ -130,7 +130,7 @@ export class StartedPostgreSqlContainer extends AbstractStartedContainer {
    * @returns Promise resolving when restore is complete
    * @throws Error if attempting to restore the postgres system database or if using the same name as the database
    */
-  public async restore(snapshotName = this.snapshotName): Promise<void> {
+  public async restoreSnapshot(snapshotName = this.snapshotName): Promise<void> {
     this.snapshotSanityCheck(snapshotName);
 
     // Execute the commands to restore the snapshot, in order
@@ -179,11 +179,11 @@ export class StartedPostgreSqlContainer extends AbstractStartedContainer {
    */
   private snapshotSanityCheck(snapshotName: string): void {
     if (this.getDatabase() === "postgres") {
-      throw new Error("Cannot restore the postgres system database as it cannot be dropped to be restored");
+      throw new Error("Snapshot feature is not supported when using the postgres system database");
     }
 
     if (this.getDatabase() === snapshotName) {
-      throw new Error("Cannot restore the database to itself");
+      throw new Error("Snapshot name cannot be the same as the database name");
     }
   }
 }


### PR DESCRIPTION
Added snapshot and restore feature to Postgres module, very closely following the [Golang implementation](https://golang.testcontainers.org/modules/postgres/#using-snapshots) 

Closes https://github.com/testcontainers/testcontainers-node/issues/952

**Summary**:
- :heavy_check_mark:  Snapshot and restore functionality
- :heavy_check_mark:  Tests
- :heavy_check_mark: Docs updated and [previewed](https://github.com/testcontainers/testcontainers-node/blob/7f2aff2e61757253a1805ce679f63207432ea467/CONTRIBUTING.md#previewing-rendered-content) (copied over from golang)
- :heavy_check_mark:  Lint & format 
- :x: Haven't updated the package version

**What can be improved**:
I utilized comments very heavily, but it really helps with the glance value of the tests, you can very easily identify what is happening, but I can remove them if requested.

**Tests**:

```console
 ✓ src/postgresql-container.test.ts (10 tests) 27393ms
   ✓ PostgreSqlContainer > should connect and return a query result  2957ms
   ✓ PostgreSqlContainer > should work with database URI  2466ms
   ✓ PostgreSqlContainer > should set database  3059ms
   ✓ PostgreSqlContainer > should set username  2399ms
   ✓ PostgreSqlContainer > should work with restarted container  3013ms
   ✓ PostgreSqlContainer > should allow custom healthcheck  762ms
   ✓ PostgreSqlContainer snapshot and restore > should create and restore from snapshot  3334ms
   ✓ PostgreSqlContainer snapshot and restore > should use custom snapshot name  3314ms
   ✓ PostgreSqlContainer snapshot and restore > should handle multiple snapshots  4100ms
   ✓ PostgreSqlContainer snapshot and restore > should throw an error when trying to snapshot postgres system database  1987ms

 Test Files  1 passed (1)
      Tests  10 passed (10)
   Start at  07:26:23
   Duration  27.81s (transform 167ms, setup 0ms, collect 310ms, tests 27.39s, environment 0ms, prepare 31ms)

 PASS  Waiting for file changes...
       press h to show help, press q to quit
``` 

cc @cristianrgreco 