### PR TITLE
Simplify log-wait-strategy

### DIFF
--- a/packages/testcontainers/src/wait-strategies/log-wait-strategy.test.ts
+++ b/packages/testcontainers/src/wait-strategies/log-wait-strategy.test.ts
@@ -55,7 +55,6 @@ describe("LogWaitStrategy", { timeout: 180_000 }, () => {
     expect(await getRunningContainerNames()).not.toContain(containerName);
   });
 
-
   it("should throw an error if the message is never received", async () => {
     const containerName = `container-${new RandomUuid().nextUuid()}`;
 
@@ -72,7 +71,11 @@ describe("LogWaitStrategy", { timeout: 180_000 }, () => {
 
   it("does not matter if container does not send all content in a single line", async () => {
     const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-      .withCommand(["node", "-e", "process.stdout.write('Hello '); setTimeout(() => process.stdout.write('World\\n'), 2000)"])
+      .withCommand([
+        "node",
+        "-e",
+        "process.stdout.write('Hello '); setTimeout(() => process.stdout.write('World\\n'), 2000)",
+      ])
       .withWaitStrategy(Wait.forLogMessage("Hello World"))
       .start();
 

--- a/packages/testcontainers/src/wait-strategies/log-wait-strategy.test.ts
+++ b/packages/testcontainers/src/wait-strategies/log-wait-strategy.test.ts
@@ -3,7 +3,7 @@ import { GenericContainer } from "../generic-container/generic-container";
 import { checkContainerIsHealthy, getRunningContainerNames } from "../utils/test-helper";
 import { Wait } from "./wait";
 
-describe("LogWaitStrategy", { timeout: 5_000 }, () => {
+describe("LogWaitStrategy", { timeout: 180_000 }, () => {
   it("should wait for log", async () => {
     const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
       .withExposedPorts(8080)

--- a/packages/testcontainers/src/wait-strategies/log-wait-strategy.test.ts
+++ b/packages/testcontainers/src/wait-strategies/log-wait-strategy.test.ts
@@ -56,6 +56,20 @@ describe("LogWaitStrategy", { timeout: 180_000 }, () => {
   });
 
 
+  it("should throw an error if the message is never received", async () => {
+    const containerName = `container-${new RandomUuid().nextUuid()}`;
+
+    await expect(
+      new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+        .withName(containerName)
+        .withCommand("/bin/sh", "-c", 'echo "Ready"')
+        .withWaitStrategy(Wait.forLogMessage("unexpected"))
+        .start()
+    ).rejects.toThrowError(`Log stream ended and message "unexpected" was not received`);
+
+    expect(await getRunningContainerNames()).not.toContain(containerName);
+  });
+
   it("does not matter if container does not send all content in a single line", async () => {
     const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
       .withCommand(["node", "-e", "process.stdout.write('Hello '); setTimeout(() => process.stdout.write('World\\n'), 2000)"])

--- a/packages/testcontainers/src/wait-strategies/log-wait-strategy.test.ts
+++ b/packages/testcontainers/src/wait-strategies/log-wait-strategy.test.ts
@@ -56,17 +56,12 @@ describe("LogWaitStrategy", { timeout: 180_000 }, () => {
   });
 
 
-  it("should throw an error if the message is never received", async () => {
-    const containerName = `container-${new RandomUuid().nextUuid()}`;
+  it("does not matter if container does not send all content in a single line", async () => {
+    const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+      .withCommand(["node", "-e", "process.stdout.write('Hello '); setTimeout(() => process.stdout.write('World\\n'), 2000)"])
+      .withWaitStrategy(Wait.forLogMessage("Hello World"))
+      .start();
 
-    await expect(
-      new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-        .withName(containerName)
-        .withCommand("/bin/sh", "-c", 'echo "Ready"')
-        .withWaitStrategy(Wait.forLogMessage("unexpected"))
-        .start()
-    ).rejects.toThrowError(`Log stream ended and message "unexpected" was not received`);
-
-    expect(await getRunningContainerNames()).not.toContain(containerName);
+    await container.stop();
   });
 });

--- a/packages/testcontainers/src/wait-strategies/log-wait-strategy.test.ts
+++ b/packages/testcontainers/src/wait-strategies/log-wait-strategy.test.ts
@@ -3,7 +3,7 @@ import { GenericContainer } from "../generic-container/generic-container";
 import { checkContainerIsHealthy, getRunningContainerNames } from "../utils/test-helper";
 import { Wait } from "./wait";
 
-describe("LogWaitStrategy", { timeout: 180_000 }, () => {
+describe("LogWaitStrategy", { timeout: 5_000 }, () => {
   it("should wait for log", async () => {
     const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
       .withExposedPorts(8080)
@@ -51,6 +51,21 @@ describe("LogWaitStrategy", { timeout: 180_000 }, () => {
         .withStartupTimeout(0)
         .start()
     ).rejects.toThrowError(`Log message "unexpected" not received after 0ms`);
+
+    expect(await getRunningContainerNames()).not.toContain(containerName);
+  });
+
+
+  it("should throw an error if the message is never received", async () => {
+    const containerName = `container-${new RandomUuid().nextUuid()}`;
+
+    await expect(
+      new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+        .withName(containerName)
+        .withCommand("/bin/sh", "-c", 'echo "Ready"')
+        .withWaitStrategy(Wait.forLogMessage("unexpected"))
+        .start()
+    ).rejects.toThrowError(`Log stream ended and message "unexpected" was not received`);
 
     expect(await getRunningContainerNames()).not.toContain(containerName);
   });

--- a/packages/testcontainers/src/wait-strategies/log-wait-strategy.ts
+++ b/packages/testcontainers/src/wait-strategies/log-wait-strategy.ts
@@ -31,6 +31,7 @@ export class LogWaitStrategy extends AbstractWaitStrategy {
 
     let matches = 0;
     for await (const chunk of stream) {
+      console.log(chunk)
       if (this.matches(chunk)) {
         if (++matches === this.times) {
           return log.debug(`Log wait strategy complete`, { containerId: container.id });

--- a/packages/testcontainers/src/wait-strategies/log-wait-strategy.ts
+++ b/packages/testcontainers/src/wait-strategies/log-wait-strategy.ts
@@ -31,7 +31,6 @@ export class LogWaitStrategy extends AbstractWaitStrategy {
 
     let matches = 0;
     for await (const chunk of stream) {
-      console.log(chunk)
       if (this.matches(chunk)) {
         if (++matches === this.times) {
           return log.debug(`Log wait strategy complete`, { containerId: container.id });

--- a/packages/testcontainers/src/wait-strategies/log-wait-strategy.ts
+++ b/packages/testcontainers/src/wait-strategies/log-wait-strategy.ts
@@ -1,10 +1,10 @@
+import byline from "byline";
 import Dockerode from "dockerode";
 import { setTimeout } from "timers/promises";
 import { log } from "../common";
 import { getContainerRuntimeClient } from "../container-runtime";
 import { BoundPorts } from "../utils/bound-ports";
 import { AbstractWaitStrategy } from "./wait-strategy";
-import byline from "byline";
 
 export type Log = string;
 

--- a/packages/testcontainers/src/wait-strategies/log-wait-strategy.ts
+++ b/packages/testcontainers/src/wait-strategies/log-wait-strategy.ts
@@ -10,7 +10,7 @@ export type Log = string;
 export class LogWaitStrategy extends AbstractWaitStrategy {
   constructor(
     private readonly message: Log | RegExp,
-    private readonly times: number,
+    private readonly times: number
   ) {
     super();
   }

--- a/packages/testcontainers/src/wait-strategies/log-wait-strategy.ts
+++ b/packages/testcontainers/src/wait-strategies/log-wait-strategy.ts
@@ -1,5 +1,5 @@
-import byline from "byline";
 import Dockerode from "dockerode";
+import { setTimeout } from "timers/promises";
 import { log } from "../common";
 import { getContainerRuntimeClient } from "../container-runtime";
 import { BoundPorts } from "../utils/bound-ports";
@@ -16,46 +16,34 @@ export class LogWaitStrategy extends AbstractWaitStrategy {
   }
 
   public async waitUntilReady(container: Dockerode.Container, boundPorts: BoundPorts, startTime?: Date): Promise<void> {
+    await Promise.race([this.handleTimeout(container.id), this.handleLogs(container, startTime)]);
+  }
+
+  async handleTimeout(containerId: string): Promise<void> {
+    await setTimeout(this.startupTimeout);
+    const message = `Log message "${this.message}" not received after ${this.startupTimeout}ms`;
+    log.error(message, { containerId });
+    throw new Error(message);
+  }
+
+  async handleLogs(container: Dockerode.Container, startTime?: Date): Promise<void> {
     log.debug(`Waiting for log message "${this.message}"...`, { containerId: container.id });
     const client = await getContainerRuntimeClient();
     const stream = await client.container.logs(container, { since: startTime ? startTime.getTime() / 1000 : 0 });
-    return new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        const message = `Log message "${this.message}" not received after ${this.startupTimeout}ms`;
-        log.error(message, { containerId: container.id });
-        reject(new Error(message));
-      }, this.startupTimeout);
 
-      const comparisonFn: (line: string) => boolean = (line: string) => {
-        if (this.message instanceof RegExp) {
-          return this.message.test(line);
-        } else {
-          return line.includes(this.message);
+    let matches = 0;
+    for await (const chunk of stream) {
+      if (this.matches(chunk)) {
+        if (++matches === this.times) {
+          return log.debug(`Log wait strategy complete`, { containerId: container.id });
         }
-      };
+      }
+    }
 
-      let count = 0;
-      const lineProcessor = (line: string) => {
-        if (comparisonFn(line)) {
-          if (++count === this.times) {
-            stream.destroy();
-            clearTimeout(timeout);
-            log.debug(`Log wait strategy complete`, { containerId: container.id });
-            resolve();
-          }
-        }
-      };
+    throw new Error("Log message not found");
+  }
 
-      byline(stream)
-        .on("data", lineProcessor)
-        .on("err", lineProcessor)
-        .on("end", () => {
-          stream.destroy();
-          clearTimeout(timeout);
-          const message = `Log stream ended and message "${this.message}" was not received`;
-          log.error(message, { containerId: container.id });
-          reject(new Error(message));
-        });
-    });
+  matches(chunk: string): boolean {
+    return this.message instanceof RegExp ? this.message.test(chunk) : chunk.includes(this.message);
   }
 }

--- a/packages/testcontainers/src/wait-strategies/log-wait-strategy.ts
+++ b/packages/testcontainers/src/wait-strategies/log-wait-strategy.ts
@@ -4,6 +4,7 @@ import { log } from "../common";
 import { getContainerRuntimeClient } from "../container-runtime";
 import { BoundPorts } from "../utils/bound-ports";
 import { AbstractWaitStrategy } from "./wait-strategy";
+import byline from "byline";
 
 export type Log = string;
 
@@ -30,8 +31,8 @@ export class LogWaitStrategy extends AbstractWaitStrategy {
     const stream = await client.container.logs(container, { since: startTime ? startTime.getTime() / 1000 : 0 });
 
     let matches = 0;
-    for await (const chunk of stream) {
-      if (this.matches(chunk)) {
+    for await (const line of byline(stream)) {
+      if (this.matches(line)) {
         if (++matches === this.times) {
           return log.debug(`Log wait strategy complete`, { containerId: container.id });
         }

--- a/packages/testcontainers/src/wait-strategies/log-wait-strategy.ts
+++ b/packages/testcontainers/src/wait-strategies/log-wait-strategy.ts
@@ -42,8 +42,8 @@ export class LogWaitStrategy extends AbstractWaitStrategy {
     this.throwError(container.id, `Log stream ended and message "${this.message}" was not received`);
   }
 
-  matches(chunk: string): boolean {
-    return this.message instanceof RegExp ? this.message.test(chunk) : chunk.includes(this.message);
+  matches(line: string): boolean {
+    return this.message instanceof RegExp ? this.message.test(line) : line.includes(this.message);
   }
 
   throwError(containerId: string, message: string): void {


### PR DESCRIPTION
This pull request simplifies the log-wait-strategy in a number of ways:

- Replaces all callbacks with async code
- Separates concerns of timeout and log processing
- Starts timeout immediately so that if Docker/dockerode is slow it will still timeout in the correct amount of time
- Removes bylines dependency
 - 95% of all consoles will buffer by line anyway
 - More flexible as it could allow a regex across multiple lines when need
 - Minor performance improvement 
- Bonus 20% less code

I'd also argue that it is a lot easier to read!