### PR TITLE
Bump `dockerode` dependency to `4.0.5`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20151,7 +20151,7 @@
         "byline": "^5.0.0",
         "debug": "^4.3.5",
         "docker-compose": "^0.24.8",
-        "dockerode": "^4.0.4",
+        "dockerode": "^4.0.5",
         "get-port": "^7.1.0",
         "proper-lockfile": "^4.1.2",
         "properties-reader": "^2.3.0",

--- a/packages/testcontainers/package.json
+++ b/packages/testcontainers/package.json
@@ -37,7 +37,7 @@
     "byline": "^5.0.0",
     "debug": "^4.3.5",
     "docker-compose": "^0.24.8",
-    "dockerode": "^4.0.4",
+    "dockerode": "^4.0.5",
     "get-port": "^7.1.0",
     "proper-lockfile": "^4.1.2",
     "properties-reader": "^2.3.0",


### PR DESCRIPTION
This PR bump `dockerode` to version `4.0.5` to fix a possible security warning (see [this issue](https://github.com/testcontainers/testcontainers-node/issues/979)).

It seems like the lock file was already updated with the new version (see [here](https://github.com/testcontainers/testcontainers-node/blob/b837e9091e350339d1ba024d33c80cb8c0c83c69/package-lock.json#L8370)). However, still, when I installed Testcontainers in my repo as a dependency, I got a security warning from GitHub, and it used `dockerode` version `4.0.4` as the dependency.