### PR TITLE
Abort timers when log wait strategy completes

### DIFF
--- a/packages/testcontainers/src/wait-strategies/log-wait-strategy.test.ts
+++ b/packages/testcontainers/src/wait-strategies/log-wait-strategy.test.ts
@@ -69,9 +69,6 @@ describe("LogWaitStrategy", { timeout: 180_000 }, () => {
     expect(await getRunningContainerNames()).not.toContain(containerName);
   });
 
-  // TODO
-  it.skip("should throw an error if the log stream is open and the strategy times out", async () => {});
-
   it("does not matter if container does not send all content in a single line", async () => {
     const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
       .withCommand([

--- a/packages/testcontainers/src/wait-strategies/log-wait-strategy.test.ts
+++ b/packages/testcontainers/src/wait-strategies/log-wait-strategy.test.ts
@@ -55,19 +55,22 @@ describe("LogWaitStrategy", { timeout: 180_000 }, () => {
     expect(await getRunningContainerNames()).not.toContain(containerName);
   });
 
-  it("should throw an error if the message is never received", async () => {
+  it("should throw an error if the log stream ends and the message is not received", async () => {
     const containerName = `container-${new RandomUuid().nextUuid()}`;
 
     await expect(
       new GenericContainer("cristianrgreco/testcontainer:1.1.14")
         .withName(containerName)
-        .withCommand("/bin/sh", "-c", 'echo "Ready"')
+        .withCommand(["/bin/sh", "-c", 'echo "Ready"'])
         .withWaitStrategy(Wait.forLogMessage("unexpected"))
         .start()
     ).rejects.toThrowError(`Log stream ended and message "unexpected" was not received`);
 
     expect(await getRunningContainerNames()).not.toContain(containerName);
   });
+
+  // TODO
+  it.skip("should throw an error if the log stream is open and the strategy times out", async () => {});
 
   it("does not matter if container does not send all content in a single line", async () => {
     const container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")


### PR DESCRIPTION
Fixes #982

To reproduce this we need to run the reaper container which invokes `Wait.forLogMessage()`. This MUST be done in vitest's `globalSetup`. Unlike `setupFiles` or in an individual test, vitest will wait for all processes to complete before shutting down.

The issue is introduced here: https://github.com/testcontainers/testcontainers-node/pull/977/files#diff-586d44bcd7d69ec116da37a953ccb21b6d22a17c3977e1b98eb487870b899007R20

The `setTimeout` runs in the background even after the reaper container has started, preventing the process from exiting. This PR incorporates abort signals between the `setTimeout` and the resolution of the log message, to ensure that when one succeeds, the other is aborted.

Struggling to add a test for this.

---

Tempted to simply revert the commit instead of try to fix forward, in case more issues are introduced: https://github.com/testcontainers/testcontainers-node/pull/984