### PR TITLE
Allow overriding default compose wait strategy

### DIFF
--- a/packages/testcontainers/src/docker-compose-environment/docker-compose-environment.test.ts
+++ b/packages/testcontainers/src/docker-compose-environment/docker-compose-environment.test.ts
@@ -98,6 +98,16 @@ describe("DockerComposeEnvironment", { timeout: 180_000 }, () => {
     await startedEnvironment.down();
   });
 
+  it("should support default wait strategy", async () => {
+    const startedEnvironment = await new DockerComposeEnvironment(fixtures, "docker-compose-with-healthcheck.yml")
+      .withDefaultWaitStrategy(Wait.forHealthCheck())
+      .up();
+      
+    await checkEnvironmentContainerIsHealthy(startedEnvironment, await composeContainerName("container"));
+
+    await startedEnvironment.down();
+  });
+
   it("should support log message wait strategy", async () => {
     const startedEnvironment = await new DockerComposeEnvironment(fixtures, "docker-compose.yml")
       .withWaitStrategy(await composeContainerName("container"), Wait.forLogMessage("Listening on port 8080"))

--- a/packages/testcontainers/src/docker-compose-environment/docker-compose-environment.ts
+++ b/packages/testcontainers/src/docker-compose-environment/docker-compose-environment.ts
@@ -23,6 +23,7 @@ export class DockerComposeEnvironment {
   private profiles: string[] = [];
   private environment: Environment = {};
   private pullPolicy: ImagePullPolicy = PullPolicy.defaultPolicy();
+  private defaultWaitStrategy: WaitStrategy = Wait.forListeningPorts();
   private waitStrategy: { [containerName: string]: WaitStrategy } = {};
   private startupTimeout?: number;
 
@@ -60,6 +61,11 @@ export class DockerComposeEnvironment {
 
   public withPullPolicy(pullPolicy: ImagePullPolicy): this {
     this.pullPolicy = pullPolicy;
+    return this;
+  }
+
+  public withDefaultWaitStrategy(waitStrategy: WaitStrategy): this {
+    this.defaultWaitStrategy = waitStrategy;
     return this;
   }
 
@@ -140,7 +146,7 @@ export class DockerComposeEnvironment {
           const boundPorts = BoundPorts.fromInspectResult(client.info.containerRuntime.hostIps, mappedInspectResult);
           const waitStrategy = this.waitStrategy[containerName]
             ? this.waitStrategy[containerName]
-            : Wait.forListeningPorts();
+            : this.defaultWaitStrategy;
           if (this.startupTimeout !== undefined) {
             waitStrategy.withStartupTimeout(this.startupTimeout);
           }


### PR DESCRIPTION
Allow the default wait strategy to be overriden for docker compose environments. The default "listening ports" strategy doesn't work for distroless images and in complex setups, having to explicitly override the wait strategy for each service is error-prone.