### PR TITLE
Support Neo4j plugins other than Apoc

### DIFF
--- a/docs/modules/neo4j.md
+++ b/docs/modules/neo4j.md
@@ -21,3 +21,7 @@ npm install @testcontainers/neo4j --save-dev
 <!--codeinclude-->
 [Configure APOC:](../../packages/modules/neo4j/src/neo4j-container.test.ts) inside_block:apoc
 <!--/codeinclude-->
+
+<!--codeinclude-->
+[Configure other supported plugins:](../../packages/modules/neo4j/src/neo4j-container.test.ts) inside_block:pluginsList
+<!--/codeinclude-->

--- a/packages/modules/neo4j/src/index.ts
+++ b/packages/modules/neo4j/src/index.ts
@@ -1,1 +1,1 @@
-export { Neo4jContainer, StartedNeo4jContainer } from "./neo4j-container";
+export { Neo4jContainer, Neo4jPlugin, StartedNeo4jContainer } from "./neo4j-container";

--- a/packages/modules/neo4j/src/neo4j-container.test.ts
+++ b/packages/modules/neo4j/src/neo4j-container.test.ts
@@ -1,5 +1,5 @@
 import neo4j from "neo4j-driver";
-import { Neo4jContainer } from "./neo4j-container";
+import { Neo4jContainer, Neo4jPlugin } from "./neo4j-container";
 
 describe("Neo4jContainer", { timeout: 180_000 }, () => {
   // createNode {
@@ -77,6 +77,36 @@ describe("Neo4jContainer", { timeout: 180_000 }, () => {
     const result = await session.run("CALL apoc.help('text')");
     const singleRecord = result.records[0];
     expect(singleRecord.length).toBeGreaterThan(0);
+
+    await session.close();
+    await driver.close();
+    await container.stop();
+  });
+  // }
+
+  // pluginsList {
+  it("should work with plugin list", async () => {
+    const container = await new Neo4jContainer("neo4j:5.26.5")
+      .withPlugins([Neo4jPlugin.APOC_EXTENDED, Neo4jPlugin.GRAPH_DATA_SCIENCE])
+      .withStartupTimeout(120_000)
+      .start();
+    const driver = neo4j.driver(
+      container.getBoltUri(),
+      neo4j.auth.basic(container.getUsername(), container.getPassword())
+    );
+
+    const session = driver.session();
+
+    // Monitor methods are only available in extended Apoc.
+    const result = await session.run("CALL apoc.monitor.ids()");
+    expect(result.records[0].get("nodeIds")).toEqual({ high: 0, low: 0 });
+
+    // Insert one node.
+    await session.run("CREATE (a:Person {name: $name}) RETURN a", { name: "Some dude" });
+
+    // Monitor result should reflect increase in data.
+    const result2 = await session.run("CALL apoc.monitor.ids()");
+    expect(result2.records[0].get("nodeIds")).toEqual({ high: 0, low: 1 });
 
     await session.close();
     await driver.close();


### PR DESCRIPTION
Add withPlugins method to Neo4jContainer for setting up plugins included in the docker image. Previously only withApoc was provided for setting up Apoc-plugin. Now withApoc uses the same plugin list under-the-hood.

Availability of specific plugins may depend on what version of Neo4j image is used.

Closes #993 