### PR TITLE
Add `Wait.forListeningPorts` to Cassandra/Cockroach/Postgres modules

### DIFF
--- a/packages/modules/cassandra/src/cassandra-container.ts
+++ b/packages/modules/cassandra/src/cassandra-container.ts
@@ -10,7 +10,9 @@ export class CassandraContainer extends GenericContainer {
 
   constructor(image = "cassandra:5.0.2") {
     super(image);
-    this.withExposedPorts(CASSANDRA_PORT).withWaitStrategy(Wait.forHealthCheck()).withStartupTimeout(120_000);
+    this.withExposedPorts(CASSANDRA_PORT)
+      .withWaitStrategy(Wait.forAll([Wait.forHealthCheck(), Wait.forListeningPorts()]))
+      .withStartupTimeout(120_000);
   }
 
   public withDatacenter(dc: string): this {

--- a/packages/modules/cockroachdb/src/cockroachdb-container.ts
+++ b/packages/modules/cockroachdb/src/cockroachdb-container.ts
@@ -11,7 +11,7 @@ export class CockroachDbContainer extends GenericContainer {
     super(image);
     this.withExposedPorts(COCKROACH_PORT, COCKROACH_HTTP_PORT)
       .withCommand(["start-single-node", "--insecure", `--http-addr=0.0.0.0:${COCKROACH_HTTP_PORT}`])
-      .withWaitStrategy(Wait.forHealthCheck());
+      .withWaitStrategy(Wait.forAll([Wait.forHealthCheck(), Wait.forListeningPorts()]));
   }
 
   public withDatabase(database: string): this {

--- a/packages/modules/postgresql/src/postgresql-container.ts
+++ b/packages/modules/postgresql/src/postgresql-container.ts
@@ -10,7 +10,7 @@ export class PostgreSqlContainer extends GenericContainer {
   constructor(image = "postgres:13.3-alpine") {
     super(image);
     this.withExposedPorts(POSTGRES_PORT);
-    this.withWaitStrategy(Wait.forHealthCheck());
+    this.withWaitStrategy(Wait.forAll([Wait.forHealthCheck(), Wait.forListeningPorts()]));
     this.withStartupTimeout(120_000);
   }
 


### PR DESCRIPTION
fix #997

Does not implement the `Wait.forListeningPorts()` but fixes the problem I tried to fix with it.