### PR TITLE
CI: Add Node.js 24 to version matrix

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
 
       - name: Configure Git

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
         uses: ./.github/actions/npm-setup
         with:
           runner: ubuntu-22.04
-          node-version: 22.x
+          node-version: 24.x
           workspace: "${{ matrix.module }}"
       - name: Code linting
         env:
@@ -83,7 +83,7 @@ jobs:
       fail-fast: true
       matrix:
         runner: [ubuntu-22.04]
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Code checkout
@@ -116,7 +116,7 @@ jobs:
       fail-fast: false
       matrix:
         module: ${{ fromJSON(needs.detect-modules.outputs.modules) }}
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
     uses: ./.github/workflows/test-template.yml
     with:
       runner: ubuntu-22.04
@@ -136,7 +136,7 @@ jobs:
       fail-fast: false
       matrix:
         module: ${{ fromJSON(needs.detect-modules.outputs.modules) }}
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
     uses: ./.github/workflows/test-template.yml
     with:
       runner: ubuntu-22.04


### PR DESCRIPTION
Node.js 24 is the "current" and next LTS version. Add it to CI version matrix.

Had to wait until 24.0.1 is out in `versions-node`. 24.0.0 contained accidental deprecation which failed MSSQL and GCloud containers.

For successful CI run, see[ PR in this fork](https://github.com/stscoundrel/testcontainers-node/pull/12)