### PR TITLE
Add support for redis-stack containers

### DIFF
--- a/docs/modules/redis.md
+++ b/docs/modules/redis.md
@@ -11,21 +11,37 @@ npm install @testcontainers/redis --save-dev
 ## Examples
 
 <!--codeinclude-->
+
 [Start container:](../../packages/modules/redis/src/redis-container.test.ts) inside_block:startContainer
+
 <!--/codeinclude-->
 
 <!--codeinclude-->
+
 [Connect redis client to container:](../../packages/modules/redis/src/redis-container.test.ts) inside_block:simpleConnect
+
 <!--/codeinclude-->
 
 <!--codeinclude-->
+
 [Start container with password authentication:](../../packages/modules/redis/src/redis-container.test.ts) inside_block:startWithCredentials
+
 <!--/codeinclude-->
 
 <!--codeinclude-->
+
 [Define volume for persistent/predefined data:](../../packages/modules/redis/src/redis-container.test.ts) inside_block:persistentData
+
 <!--/codeinclude-->
 
 <!--codeinclude-->
+
+[Define volume for persistent/predefined data:](../../packages/modules/redis/src/redis-container.test.ts) inside_block:startWithRedisStack
+
+<!--/codeinclude-->
+
+<!--codeinclude-->
+
 [Execute a command inside the container:](../../packages/modules/redis/src/redis-container.test.ts) inside_block:executeCommand
+
 <!--/codeinclude-->

--- a/docs/modules/redis.md
+++ b/docs/modules/redis.md
@@ -36,7 +36,7 @@ npm install @testcontainers/redis --save-dev
 
 <!--codeinclude-->
 
-[Define volume for persistent/predefined data:](../../packages/modules/redis/src/redis-container.test.ts) inside_block:startWithRedisStack
+[Start container with redis/redis-stack-server image:](../../packages/modules/redis/src/redis-container.test.ts) inside_block:startWithRedisStack
 
 <!--/codeinclude-->
 

--- a/packages/modules/redis/src/redis-container.test.ts
+++ b/packages/modules/redis/src/redis-container.test.ts
@@ -102,6 +102,7 @@ describe("RedisContainer", { timeout: 240_000 }, () => {
   });
   // }
 
+  // startWithRedisStack {
   it("should start with redis-stack-server and json module", async () => {
     const container = await new RedisContainer("redis/redis-stack-server:latest").withPassword("testPassword").start();
     const client = await connectTo(container);
@@ -113,6 +114,7 @@ describe("RedisContainer", { timeout: 240_000 }, () => {
     await client.disconnect();
     await container.stop();
   });
+  // }
 
   // simpleConnect {
   async function connectTo(container: StartedRedisContainer) {

--- a/packages/modules/redis/src/redis-container.test.ts
+++ b/packages/modules/redis/src/redis-container.test.ts
@@ -104,7 +104,9 @@ describe("RedisContainer", { timeout: 240_000 }, () => {
 
   // startWithRedisStack {
   it("should start with redis-stack-server and json module", async () => {
-    const container = await new RedisContainer("redis/redis-stack-server:latest").withPassword("testPassword").start();
+    const container = await new RedisContainer("redis/redis-stack-server:7.4.0-v4")
+      .withPassword("testPassword")
+      .start();
     const client = await connectTo(container);
 
     await client.json.set("key", "$", { name: "test" });

--- a/packages/modules/redis/src/redis-container.test.ts
+++ b/packages/modules/redis/src/redis-container.test.ts
@@ -107,9 +107,9 @@ describe("RedisContainer", { timeout: 240_000 }, () => {
     const container = await new RedisContainer("redis/redis-stack-server:latest").withPassword("testPassword").start();
     const client = await connectTo(container);
 
-    await client.json.set("key", "$", JSON.stringify({ name: "test" }));
+    await client.json.set("key", "$", { name: "test" });
     const result = await client.json.get("key");
-    expect(result).toEqual(JSON.stringify({ name: "test" }));
+    expect(result).toEqual({ name: "test" });
 
     await client.disconnect();
     await container.stop();

--- a/packages/modules/redis/src/redis-container.test.ts
+++ b/packages/modules/redis/src/redis-container.test.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { createClient, RedisClientOptions } from "redis";
+import { createClient } from "redis";
 import { RedisContainer, StartedRedisContainer } from "./redis-container";
 
 describe("RedisContainer", { timeout: 240_000 }, () => {
@@ -103,11 +103,8 @@ describe("RedisContainer", { timeout: 240_000 }, () => {
   // }
 
   it("should start with redis-stack-server and json module", async () => {
-    const password = "testPassword";
-    const container = await new RedisContainer("redis/redis-stack-server:latest").withPassword(password).start();
-    const client = await connectTo(container, {
-      password,
-    });
+    const container = await new RedisContainer("redis/redis-stack-server:latest").withPassword("testPassword").start();
+    const client = await connectTo(container);
 
     await client.json.set("key", "$", JSON.stringify({ name: "test" }));
     const result = await client.json.get("key");
@@ -118,10 +115,9 @@ describe("RedisContainer", { timeout: 240_000 }, () => {
   });
 
   // simpleConnect {
-  async function connectTo(container: StartedRedisContainer, options?: Partial<RedisClientOptions>) {
+  async function connectTo(container: StartedRedisContainer) {
     const client = createClient({
       url: container.getConnectionUrl(),
-      ...options,
     });
     await client.connect();
     expect(client.isOpen).toBeTruthy();

--- a/packages/modules/redis/src/redis-container.ts
+++ b/packages/modules/redis/src/redis-container.ts
@@ -38,11 +38,10 @@ export class RedisContainer extends GenericContainer {
     }
   }
 
-  public override async start(options?: string[]): Promise<StartedRedisContainer> {
+  public override async start(): Promise<StartedRedisContainer> {
     const redisArgs = [
       ...(this.password ? [`--requirepass ${this.password}`] : []),
       ...(this.persistenceVolume ? ["--save 1 1 ", "--appendonly yes"] : []),
-      ...(options ?? []),
     ];
     if (this.imageName.image.includes("redis-stack")) {
       this.withEnvironment({

--- a/packages/modules/redis/src/redis-container.ts
+++ b/packages/modules/redis/src/redis-container.ts
@@ -38,12 +38,19 @@ export class RedisContainer extends GenericContainer {
     }
   }
 
-  public override async start(): Promise<StartedRedisContainer> {
-    this.withCommand([
-      "redis-server",
-      ...(this.password ? [`--requirepass "${this.password}"`] : []),
+  public override async start(options?: string[]): Promise<StartedRedisContainer> {
+    const redisArgs = [
+      ...(this.password ? [`--requirepass ${this.password}`] : []),
       ...(this.persistenceVolume ? ["--save 1 1 ", "--appendonly yes"] : []),
-    ]);
+      ...(options ?? []),
+    ];
+    if (this.imageName.image.includes("redis-stack")) {
+      this.withEnvironment({
+        REDIS_ARGS: redisArgs.join(" "),
+      }).withEntrypoint(["/entrypoint.sh"]);
+    } else {
+      this.withCommand(["redis-server", ...redisArgs]);
+    }
     if (this.persistenceVolume) {
       this.withBindMounts([{ mode: "rw", source: this.persistenceVolume, target: "/data" }]);
     }


### PR DESCRIPTION
Using the current version of `RedisContainer` with `redis/redis-stack-server` or `redis/redis-stack` images, the container lacks Redis modules because `start` method overrides the entrypoint script of redis-stack.

This problem has been described in this thread https://github.com/testcontainers/testcontainers-node/issues/827#issuecomment-2894254729

This PR:
- Uses default redis-stack entrypoint script on start
- Adds a test for redis-stack with JSON module
- Updates the documentation to show the test as an example