### PR TITLE
Upgrade NATS library used for tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3238,6 +3238,60 @@
         "node": ">=18"
       }
     },
+    "node_modules/@nats-io/jetstream": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@nats-io/jetstream/-/jetstream-3.0.2.tgz",
+      "integrity": "sha512-dR789x1xhMyEukXILPWDo6ODW53nHpBD9LnsnnywA+pTkwYFydEkYdyhv9HzFc6s6Nfrb2TpibrT4znijlg2dg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nats-io/nats-core": "3.0.2"
+      }
+    },
+    "node_modules/@nats-io/nats-core": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@nats-io/nats-core/-/nats-core-3.0.2.tgz",
+      "integrity": "sha512-gACbRIhY3yQTO+5C4E1LY/qO2e5EhGUBeDsnPDT8Hd3qY9mfhNtluY6R7d7WX7/JMGsXRPbYdSLSADr/ECSy3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nats-io/nkeys": "2.0.3",
+        "@nats-io/nuid": "2.0.3"
+      }
+    },
+    "node_modules/@nats-io/nkeys": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nats-io/nkeys/-/nkeys-2.0.3.tgz",
+      "integrity": "sha512-JVt56GuE6Z89KUkI4TXUbSI9fmIfAmk6PMPknijmuL72GcD+UgIomTcRWiNvvJKxA01sBbmIPStqJs5cMRBC3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tweetnacl": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@nats-io/nuid": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nats-io/nuid/-/nuid-2.0.3.tgz",
+      "integrity": "sha512-TpA3HEBna/qMVudy+3HZr5M3mo/L1JPofpVT4t0HkFGkz2Cn9wrlrQC8tvR8Md5Oa9//GtGG26eN0qEWF5Vqew==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 18.x"
+      }
+    },
+    "node_modules/@nats-io/transport-node": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@nats-io/transport-node/-/transport-node-3.0.2.tgz",
+      "integrity": "sha512-hPuep/ObVepjAM1dFy+XhqMlIzga3bQpbgQiOWM5AxwNZ9CF7GHAtfaxG7WY6+t057tBW8axC0nBL71Q8chQBQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nats-io/nats-core": "3.0.2",
+        "@nats-io/nkeys": "2.0.3",
+        "@nats-io/nuid": "2.0.3"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -14108,18 +14162,6 @@
       "integrity": "sha512-E7QQoM+3jvNtlmyfqRZ0/U75VFgCls+fSkbml2MpgWkWyz3ox8Y58gNhfuziuQYGNNQAbFZJQck55LHCnCK6CA==",
       "dev": true
     },
-    "node_modules/nats": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/nats/-/nats-2.28.0.tgz",
-      "integrity": "sha512-zXWOTOZEizUQy8UO2lMYFAee0htGrZLmJ2sddfmsDI00nc+dsK5+gS7p7bt26O1omfdCLVU5xymlnAjaqYnOmw==",
-      "dev": true,
-      "dependencies": {
-        "nkeys.js": "1.1.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -14198,18 +14240,6 @@
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/nkeys.js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/nkeys.js/-/nkeys.js-1.1.0.tgz",
-      "integrity": "sha512-tB/a0shZL5UZWSwsoeyqfTszONTt4k2YS0tuQioMOD180+MbombYVgzDUYHlx+gejYK6rgf08n/2Df99WY0Sxg==",
-      "dev": true,
-      "dependencies": {
-        "tweetnacl": "1.0.3"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
@@ -18417,7 +18447,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "dev": true
+      "license": "Unlicense"
     },
     "node_modules/type": {
       "version": "2.7.3",
@@ -20162,10 +20192,9 @@
       "version": "10.27.0",
       "license": "MIT",
       "dependencies": {
+        "@nats-io/jetstream": "^3.0.2",
+        "@nats-io/transport-node": "^3.0.2",
         "testcontainers": "^10.27.0"
-      },
-      "devDependencies": {
-        "nats": "^2.28.0"
       }
     },
     "packages/modules/neo4j": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3242,6 +3242,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@nats-io/jetstream/-/jetstream-3.0.2.tgz",
       "integrity": "sha512-dR789x1xhMyEukXILPWDo6ODW53nHpBD9LnsnnywA+pTkwYFydEkYdyhv9HzFc6s6Nfrb2TpibrT4znijlg2dg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@nats-io/nats-core": "3.0.2"
@@ -3251,6 +3252,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@nats-io/nats-core/-/nats-core-3.0.2.tgz",
       "integrity": "sha512-gACbRIhY3yQTO+5C4E1LY/qO2e5EhGUBeDsnPDT8Hd3qY9mfhNtluY6R7d7WX7/JMGsXRPbYdSLSADr/ECSy3w==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@nats-io/nkeys": "2.0.3",
@@ -3261,6 +3263,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@nats-io/nkeys/-/nkeys-2.0.3.tgz",
       "integrity": "sha512-JVt56GuE6Z89KUkI4TXUbSI9fmIfAmk6PMPknijmuL72GcD+UgIomTcRWiNvvJKxA01sBbmIPStqJs5cMRBC3A==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tweetnacl": "^1.0.3"
@@ -3273,6 +3276,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@nats-io/nuid/-/nuid-2.0.3.tgz",
       "integrity": "sha512-TpA3HEBna/qMVudy+3HZr5M3mo/L1JPofpVT4t0HkFGkz2Cn9wrlrQC8tvR8Md5Oa9//GtGG26eN0qEWF5Vqew==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 18.x"
@@ -3282,6 +3286,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@nats-io/transport-node/-/transport-node-3.0.2.tgz",
       "integrity": "sha512-hPuep/ObVepjAM1dFy+XhqMlIzga3bQpbgQiOWM5AxwNZ9CF7GHAtfaxG7WY6+t057tBW8axC0nBL71Q8chQBQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@nats-io/nats-core": "3.0.2",
@@ -18447,6 +18452,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "dev": true,
       "license": "Unlicense"
     },
     "node_modules/type": {
@@ -20192,9 +20198,11 @@
       "version": "10.27.0",
       "license": "MIT",
       "dependencies": {
-        "@nats-io/jetstream": "^3.0.2",
-        "@nats-io/transport-node": "^3.0.2",
         "testcontainers": "^10.27.0"
+      },
+      "devDependencies": {
+        "@nats-io/jetstream": "^3.0.2",
+        "@nats-io/transport-node": "^3.0.2"
       }
     },
     "packages/modules/neo4j": {

--- a/packages/modules/nats/package.json
+++ b/packages/modules/nats/package.json
@@ -29,8 +29,10 @@
     "build": "tsc --project tsconfig.build.json"
   },
   "dependencies": {
-    "@nats-io/jetstream": "^3.0.2",
-    "@nats-io/transport-node": "^3.0.2",
     "testcontainers": "^10.27.0"
+  },
+  "devDependencies": {
+    "@nats-io/jetstream": "^3.0.2",
+    "@nats-io/transport-node": "^3.0.2"
   }
 }

--- a/packages/modules/nats/package.json
+++ b/packages/modules/nats/package.json
@@ -28,10 +28,9 @@
     "prepack": "shx cp ../../../README.md . && shx cp ../../../LICENSE .",
     "build": "tsc --project tsconfig.build.json"
   },
-  "devDependencies": {
-    "nats": "^2.28.0"
-  },
   "dependencies": {
+    "@nats-io/jetstream": "^3.0.2",
+    "@nats-io/transport-node": "^3.0.2",
     "testcontainers": "^10.27.0"
   }
 }

--- a/packages/modules/nats/src/nats-container.ts
+++ b/packages/modules/nats/src/nats-container.ts
@@ -11,7 +11,7 @@ export class NatsContainer extends GenericContainer {
   private args = new Set<string>();
   private values = new Map<string, string | undefined>();
 
-  constructor(image = "nats:2.11.3-alpine") {
+  constructor(image = "nats:2.8.4-alpine") {
     super(image);
 
     this.withUsername("test");

--- a/packages/modules/nats/src/nats-container.ts
+++ b/packages/modules/nats/src/nats-container.ts
@@ -11,7 +11,7 @@ export class NatsContainer extends GenericContainer {
   private args = new Set<string>();
   private values = new Map<string, string | undefined>();
 
-  constructor(image = "nats:2.8.4-alpine") {
+  constructor(image = "nats:2.11.3-alpine") {
     super(image);
 
     this.withUsername("test");


### PR DESCRIPTION
# Story

NATS support was broken with a newer version of NATS. An issue was opened describing the situation https://github.com/testcontainers/testcontainers-node/issues/1008

This pull request upgrades the NATS components and uses their migration guide to modify the code to support it.