### PR TITLE
NATS: Add codec, scratch compatibility

### DIFF
--- a/packages/modules/nats/src/nats-container.ts
+++ b/packages/modules/nats/src/nats-container.ts
@@ -81,7 +81,7 @@ export class NatsContainer extends GenericContainer {
   }
 
   private getNormalizedCommand(): string[] {
-    const result: string[] = ["nats-server"];
+    const result: string[] = [];
     for (const arg of this.args) {
       result.push(arg);
       if (this.values.has(arg)) {


### PR DESCRIPTION
Changes:
* Restores codec to the pubsub sample code, using the global TextEncoder/TextDecoder
* Adds compatibility with the "nats" scratch image used by the other NATS Testcontainers

The "nats" compatibility change is explained in https://github.com/testcontainers/testcontainers-node/pull/1009#discussion_r2103089677