### PR TITLE
Don't log compose version

### DIFF
--- a/packages/testcontainers/src/container-runtime/clients/client.ts
+++ b/packages/testcontainers/src/container-runtime/clients/client.ts
@@ -17,7 +17,7 @@ import { DockerImageClient } from "./image/docker-image-client";
 import { ImageClient } from "./image/image-client";
 import { DockerNetworkClient } from "./network/docker-network-client";
 import { NetworkClient } from "./network/network-client";
-import { ComposeInfo, ContainerRuntimeInfo, Info, NodeInfo } from "./types";
+import { ContainerRuntimeInfo, Info, NodeInfo } from "./types";
 
 export class ContainerRuntimeClient {
   constructor(
@@ -123,9 +123,7 @@ async function initStrategy(strategy: ContainerRuntimeClientStrategy): Promise<C
     labels: dockerodeInfo.Labels ? dockerodeInfo.Labels : [],
   };
 
-  const composeInfo: ComposeInfo = composeClient.version;
-
-  const info: Info = { node: nodeInfo, containerRuntime: containerRuntimeInfo, compose: composeInfo };
+  const info: Info = { node: nodeInfo, containerRuntime: containerRuntimeInfo };
 
   log.trace(`Container runtime info:\n${JSON.stringify(info, null, 2)}`);
   return new ContainerRuntimeClient(info, composeClient, containerClient, imageClient, networkClient);

--- a/packages/testcontainers/src/container-runtime/clients/compose/compose-client.ts
+++ b/packages/testcontainers/src/container-runtime/clients/compose/compose-client.ts
@@ -4,7 +4,6 @@ import { defaultComposeOptions } from "./default-compose-options";
 import { ComposeDownOptions, ComposeOptions } from "./types";
 
 export interface ComposeClient {
-  version: string;
   up(options: ComposeOptions, services?: Array<string>): Promise<void>;
   pull(options: ComposeOptions, services?: Array<string>): Promise<void>;
   stop(options: ComposeOptions): Promise<void>;
@@ -13,18 +12,14 @@ export interface ComposeClient {
 
 export async function getComposeClient(environment: NodeJS.ProcessEnv): Promise<ComposeClient> {
   try {
-    const version = (await compose.version()).data.version;
-    return new DockerComposeClient(version, environment);
+    return new DockerComposeClient(environment);
   } catch (err) {
-    return new MissingComposeClient("N/A");
+    return new MissingComposeClient();
   }
 }
 
 class DockerComposeClient implements ComposeClient {
-  constructor(
-    public readonly version: string,
-    private readonly environment: NodeJS.ProcessEnv
-  ) {}
+  constructor(private readonly environment: NodeJS.ProcessEnv) {}
 
   async up(options: ComposeOptions, services: Array<string> | undefined): Promise<void> {
     try {
@@ -94,7 +89,7 @@ class DockerComposeClient implements ComposeClient {
 }
 
 class MissingComposeClient implements ComposeClient {
-  constructor(public readonly version: string) {}
+  constructor() {}
 
   up(): Promise<void> {
     throw new Error("Compose is not installed");

--- a/packages/testcontainers/src/container-runtime/clients/types.ts
+++ b/packages/testcontainers/src/container-runtime/clients/types.ts
@@ -1,7 +1,6 @@
 export type Info = {
   node: NodeInfo;
   containerRuntime: ContainerRuntimeInfo;
-  compose: ComposeInfo;
 };
 
 export type NodeInfo = {
@@ -24,7 +23,5 @@ export type ContainerRuntimeInfo = {
   runtimes: string[];
   labels: string[];
 };
-
-export type ComposeInfo = string;
 
 export type HostIp = { address: string; family: number };


### PR DESCRIPTION
Now that we have dropped support for compose v1 this isn't necessary
