### PR TITLE
Retry inspecting container until exposed ports are mapped

### DIFF
--- a/packages/testcontainers/src/generic-container/inspect-container-util-ports-exposed.test.ts
+++ b/packages/testcontainers/src/generic-container/inspect-container-util-ports-exposed.test.ts
@@ -1,0 +1,91 @@
+import { ContainerInspectInfo } from "dockerode";
+import { InspectResult } from "../types";
+import { mapInspectResult } from "../utils/map-inspect-result";
+import { inspectContainerUntilPortsExposed } from "./inspect-container-util-ports-exposed";
+
+function mockExposed(): { inspectResult: ContainerInspectInfo; mappedInspectResult: InspectResult } {
+  const date = new Date();
+
+  const inspectResult: ContainerInspectInfo = {
+    Name: "container-id",
+    Config: {
+      Hostname: "hostname",
+      Labels: {},
+    },
+    State: {
+      Health: {
+        Status: "healthy",
+      },
+      Status: "running",
+      Running: true,
+      StartedAt: date.toISOString(),
+      FinishedAt: date.toISOString(),
+    },
+    NetworkSettings: {
+      Ports: { "8080/tcp": [{ HostIp: "0.0.0.0", HostPort: "45000" }] },
+      Networks: {},
+    },
+  } as unknown as ContainerInspectInfo;
+
+  return { inspectResult, mappedInspectResult: mapInspectResult(inspectResult) };
+}
+
+function mockNotExposed(): { inspectResult: ContainerInspectInfo; mappedInspectResult: InspectResult } {
+  const date = new Date();
+
+  const inspectResult: ContainerInspectInfo = {
+    Name: "container-id",
+    Config: {
+      Hostname: "hostname",
+      Labels: {},
+    },
+    State: {
+      Health: {
+        Status: "healthy",
+      },
+      Status: "running",
+      Running: true,
+      StartedAt: date.toISOString(),
+      FinishedAt: date.toISOString(),
+    },
+    NetworkSettings: {
+      Ports: { "8080/tcp": [] },
+      Networks: {},
+    },
+  } as unknown as ContainerInspectInfo;
+
+  return { inspectResult, mappedInspectResult: mapInspectResult(inspectResult) };
+}
+
+test("returns the inspect results when all ports are exposed", async () => {
+  const data = mockExposed();
+  const inspectFn = vi.fn().mockResolvedValueOnce(data.inspectResult);
+
+  const result = await inspectContainerUntilPortsExposed(inspectFn, [8080], "container-id");
+
+  expect(result).toEqual(data);
+});
+
+test("retries the inspect if ports are not yet exposed", async () => {
+  const data1 = mockNotExposed();
+  const data2 = mockExposed();
+  const inspectFn = vi
+    .fn()
+    .mockResolvedValueOnce(data1.inspectResult)
+    .mockResolvedValueOnce(data1.inspectResult)
+    .mockResolvedValueOnce(data2.inspectResult);
+
+  const result = await inspectContainerUntilPortsExposed(inspectFn, [8080], "container-id");
+
+  expect(result).toEqual(data2);
+  expect(inspectFn).toHaveBeenCalledTimes(3);
+});
+
+test("throws an error ", async () => {
+  const data = mockNotExposed();
+  const inspectFn = vi.fn().mockResolvedValue(data.inspectResult);
+
+  await expect(inspectContainerUntilPortsExposed(inspectFn, [8080], "container-id", 0)).rejects.toThrow(
+    "Container did not expose all ports after starting"
+  );
+});

--- a/packages/testcontainers/src/generic-container/inspect-container-util-ports-exposed.test.ts
+++ b/packages/testcontainers/src/generic-container/inspect-container-util-ports-exposed.test.ts
@@ -81,7 +81,7 @@ test("retries the inspect if ports are not yet exposed", async () => {
   expect(inspectFn).toHaveBeenCalledTimes(3);
 });
 
-test("throws an error ", async () => {
+test("throws an error when ports are not exposed within timeout", async () => {
   const data = mockNotExposed();
   const inspectFn = vi.fn().mockResolvedValue(data.inspectResult);
 

--- a/packages/testcontainers/src/generic-container/inspect-container-util-ports-exposed.ts
+++ b/packages/testcontainers/src/generic-container/inspect-container-util-ports-exposed.ts
@@ -1,0 +1,45 @@
+import { ContainerInspectInfo } from "dockerode";
+import { IntervalRetry, log } from "../common";
+import { InspectResult } from "../types";
+import { mapInspectResult } from "../utils/map-inspect-result";
+import { getContainerPort, PortWithOptionalBinding } from "../utils/port";
+
+type Result = {
+  inspectResult: ContainerInspectInfo;
+  mappedInspectResult: InspectResult;
+};
+
+export async function inspectContainerUntilPortsExposed(
+  inspectFn: () => Promise<ContainerInspectInfo>,
+  ports: PortWithOptionalBinding[],
+  containerId: string,
+  timeout = 5000
+): Promise<Result> {
+  const result = await new IntervalRetry<Result, Error>(100).retryUntil(
+    async () => {
+      const inspectResult = await inspectFn();
+      const mappedInspectResult = mapInspectResult(inspectResult);
+      return { inspectResult, mappedInspectResult };
+    },
+    ({ mappedInspectResult }) =>
+      ports
+        .map((exposedPort) => getContainerPort(exposedPort))
+        .every(
+          (exposedPort) =>
+            mappedInspectResult.ports[exposedPort].length > 0 &&
+            mappedInspectResult.ports[exposedPort].every(({ hostPort }) => hostPort !== undefined)
+        ),
+    () => {
+      const message = `Container did not expose all ports after starting`;
+      log.error(message, { containerId });
+      return new Error(message);
+    },
+    timeout
+  );
+
+  if (result instanceof Error) {
+    throw result;
+  }
+
+  return result;
+}

--- a/packages/testcontainers/src/generic-container/inspect-container-util-ports-exposed.ts
+++ b/packages/testcontainers/src/generic-container/inspect-container-util-ports-exposed.ts
@@ -24,11 +24,7 @@ export async function inspectContainerUntilPortsExposed(
     ({ mappedInspectResult }) =>
       ports
         .map((exposedPort) => getContainerPort(exposedPort))
-        .every(
-          (exposedPort) =>
-            mappedInspectResult.ports[exposedPort].length > 0 &&
-            mappedInspectResult.ports[exposedPort].every(({ hostPort }) => hostPort !== undefined)
-        ),
+        .every((exposedPort) => mappedInspectResult.ports[exposedPort].length > 0),
     () => {
       const message = `Container did not expose all ports after starting`;
       log.error(message, { containerId });


### PR DESCRIPTION
Relates to #818 

Also adds "/tcp" suffix to port bindings, which are apparently now needed.