### PR TITLE
Wait for ZK to be listening when using provided ZK

### DIFF
--- a/packages/modules/kafka/src/kafka-container.ts
+++ b/packages/modules/kafka/src/kafka-container.ts
@@ -64,7 +64,6 @@ export class KafkaContainer extends GenericContainer {
 
   constructor(image: string) {
     super(image);
-    // this.withWaitStrategy(Wait.forLogMessage(/Kafka startTimeMs/));
     this.withExposedPorts(KAFKA_PORT).withStartupTimeout(180_000).withEnvironment({
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "BROKER:PLAINTEXT,PLAINTEXT:PLAINTEXT",
       KAFKA_INTER_BROKER_LISTENER_NAME: "BROKER",

--- a/packages/testcontainers/src/generic-container/inspect-container-util-ports-exposed.ts
+++ b/packages/testcontainers/src/generic-container/inspect-container-util-ports-exposed.ts
@@ -13,9 +13,9 @@ export async function inspectContainerUntilPortsExposed(
   inspectFn: () => Promise<ContainerInspectInfo>,
   ports: PortWithOptionalBinding[],
   containerId: string,
-  timeout = 5000
+  timeout = 10_000
 ): Promise<Result> {
-  const result = await new IntervalRetry<Result, Error>(100).retryUntil(
+  const result = await new IntervalRetry<Result, Error>(250).retryUntil(
     async () => {
       const inspectResult = await inspectFn();
       const mappedInspectResult = mapInspectResult(inspectResult);


### PR DESCRIPTION
This fixes a flaky test, where the Kafka client complains that the RF is zero, because there are no brokers yet listening.