### PR TITLE
Implement support for specifying the protocol when exposing ports

### DIFF
--- a/docs/features/containers.md
+++ b/docs/features/containers.md
@@ -572,6 +572,29 @@ const container = await new GenericContainer("alpine")
 const httpPort = container.getFirstMappedPort();
 ```
 
+Specify a protocol for the exposed port:
+
+```javascript
+const container = await new GenericContainer("alpine")
+  .withExposedPorts({
+    container: 80,
+    protocol: "udp"
+  })
+  .start();
+const httpPort = container.getMappedPort(80, "udp");
+```
+
+Alternatively, specify the protocol using a string with the format `port/protocol`:
+
+```javascript
+const container = await new GenericContainer("alpine")
+  .withExposedPorts("80/udp")
+  .start();
+const httpPort = container.getMappedPort("80/udp");
+```
+
+If no protocol is specified, it defaults to `tcp`.
+
 Specify fixed host port bindings (**not recommended**):
 
 ```javascript
@@ -609,12 +632,12 @@ expect(response.status).toBe(200);
 expect(await response.text()).toBe("PONG");
 ```
 
-The example above starts a `testcontainers/helloworld` container and a `socat` container. 
+The example above starts a `testcontainers/helloworld` container and a `socat` container.
 The `socat` container is configured to forward traffic from port `8081` to the `testcontainers/helloworld` container on port `8080`.
 
 ## Running commands
 
-To run a command inside an already started container, use the exec method. 
+To run a command inside an already started container, use the exec method.
 The command will be run in the container's working directory,
 returning the combined output (`output`), standard output (`stdout`), standard error (`stderr`), and exit code (`exitCode`).
 

--- a/docs/features/containers.md
+++ b/docs/features/containers.md
@@ -581,6 +581,7 @@ const container = await new GenericContainer("alpine")
     protocol: "udp"
   })
   .start();
+
 const httpPort = container.getMappedPort(80, "udp");
 ```
 
@@ -590,6 +591,7 @@ Alternatively, specify the protocol using a string with the format `port/protoco
 const container = await new GenericContainer("alpine")
   .withExposedPorts("80/udp")
   .start();
+
 const httpPort = container.getMappedPort("80/udp");
 ```
 

--- a/packages/modules/azurite/src/azurite-container.ts
+++ b/packages/modules/azurite/src/azurite-container.ts
@@ -1,6 +1,7 @@
 import {
   AbstractStartedContainer,
   GenericContainer,
+  getContainerPort,
   hasHostBinding,
   PortWithOptionalBinding,
   StartedTestContainer,
@@ -171,7 +172,8 @@ export class StartedAzuriteContainer extends AbstractStartedContainer {
     if (hasHostBinding(this.blobPort)) {
       return this.blobPort.host;
     } else {
-      return this.getMappedPort(this.blobPort);
+      const containerPort = getContainerPort(this.blobPort);
+      return this.getMappedPort(containerPort);
     }
   }
 
@@ -179,7 +181,8 @@ export class StartedAzuriteContainer extends AbstractStartedContainer {
     if (hasHostBinding(this.queuePort)) {
       return this.queuePort.host;
     } else {
-      return this.getMappedPort(this.queuePort);
+      const containerPort = getContainerPort(this.queuePort);
+      return this.getMappedPort(containerPort);
     }
   }
 
@@ -187,7 +190,8 @@ export class StartedAzuriteContainer extends AbstractStartedContainer {
     if (hasHostBinding(this.tablePort)) {
       return this.tablePort.host;
     } else {
-      return this.getMappedPort(this.tablePort);
+      const containerPort = getContainerPort(this.tablePort);
+      return this.getMappedPort(containerPort);
     }
   }
 

--- a/packages/testcontainers/src/generic-container/abstract-started-container.ts
+++ b/packages/testcontainers/src/generic-container/abstract-started-container.ts
@@ -43,7 +43,7 @@ export class AbstractStartedContainer implements StartedTestContainer {
     return this.startedTestContainer.getFirstMappedPort();
   }
 
-  public getMappedPort(port: number, protocol?: string): number {
+  public getMappedPort(port: string | number, protocol?: string): number {
     return this.startedTestContainer.getMappedPort(port, protocol);
   }
 

--- a/packages/testcontainers/src/generic-container/abstract-started-container.ts
+++ b/packages/testcontainers/src/generic-container/abstract-started-container.ts
@@ -43,8 +43,13 @@ export class AbstractStartedContainer implements StartedTestContainer {
     return this.startedTestContainer.getFirstMappedPort();
   }
 
-  public getMappedPort(port: string | number, protocol?: string): number {
-    return this.startedTestContainer.getMappedPort(port, protocol);
+  public getMappedPort(port: number, protocol?: string): number;
+  public getMappedPort(portWithProtocol: `${number}/${"tcp" | "udp"}`): number;
+  public getMappedPort(port: number | `${number}/${"tcp" | "udp"}`, protocol?: string): number {
+    if (typeof port === "number") {
+      return this.startedTestContainer.getMappedPort(port, protocol);
+    }
+    return this.startedTestContainer.getMappedPort(port);
   }
 
   public getName(): string {

--- a/packages/testcontainers/src/generic-container/abstract-started-container.ts
+++ b/packages/testcontainers/src/generic-container/abstract-started-container.ts
@@ -43,8 +43,8 @@ export class AbstractStartedContainer implements StartedTestContainer {
     return this.startedTestContainer.getFirstMappedPort();
   }
 
-  public getMappedPort(port: number): number {
-    return this.startedTestContainer.getMappedPort(port);
+  public getMappedPort(port: number, protocol?: string): number {
+    return this.startedTestContainer.getMappedPort(port, protocol);
   }
 
   public getName(): string {

--- a/packages/testcontainers/src/generic-container/generic-container.test.ts
+++ b/packages/testcontainers/src/generic-container/generic-container.test.ts
@@ -5,6 +5,7 @@ import { getContainerRuntimeClient } from "../container-runtime";
 import { PullPolicy } from "../utils/pull-policy";
 import {
   checkContainerIsHealthy,
+  checkContainerIsHealthyUdp,
   getDockerEventStream,
   getRunningContainerNames,
   waitForDockerEvent,
@@ -24,6 +25,7 @@ describe("GenericContainer", { timeout: 180_000 }, () => {
 
   it("should return first mapped port with regardless of protocol", async () => {
     await using container = await new GenericContainer("mendhak/udp-listener").withExposedPorts("5005/udp").start();
+    await checkContainerIsHealthyUdp(container);
     expect(container.getFirstMappedPort()).toBe(container.getMappedPort("5005/udp"));
   });
 
@@ -49,6 +51,7 @@ describe("GenericContainer", { timeout: 180_000 }, () => {
         protocol: "udp",
       })
       .start();
+    await checkContainerIsHealthyUdp(container);
     expect(container.getMappedPort("5005/udp")).toBe(hostPort);
     expect(container.getMappedPort(5005, "udp")).toBe(hostPort);
   });

--- a/packages/testcontainers/src/generic-container/generic-container.test.ts
+++ b/packages/testcontainers/src/generic-container/generic-container.test.ts
@@ -22,6 +22,11 @@ describe("GenericContainer", { timeout: 180_000 }, () => {
     expect(container.getFirstMappedPort()).toBe(container.getMappedPort(8080));
   });
 
+  it("should return first mapped port with regardless of protocol", async () => {
+    await using container = await new GenericContainer("mendhak/udp-listener").withExposedPorts("5005/udp").start();
+    expect(container.getFirstMappedPort()).toBe(container.getMappedPort("5005/udp"));
+  });
+
   it("should bind to specified host port", async () => {
     const hostPort = await getPort();
     await using container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
@@ -33,6 +38,19 @@ describe("GenericContainer", { timeout: 180_000 }, () => {
 
     await checkContainerIsHealthy(container);
     expect(container.getMappedPort(8080)).toBe(hostPort);
+  });
+
+  it("should bind to specified host port with a different protocol", async () => {
+    const hostPort = await getPort();
+    await using container = await new GenericContainer("mendhak/udp-listener")
+      .withExposedPorts({
+        container: 5005,
+        host: hostPort,
+        protocol: "udp",
+      })
+      .start();
+    expect(container.getMappedPort("5005/udp")).toBe(hostPort);
+    expect(container.getMappedPort(5005, "udp")).toBe(hostPort);
   });
 
   it("should execute a command on a running container", async () => {

--- a/packages/testcontainers/src/generic-container/generic-container.ts
+++ b/packages/testcontainers/src/generic-container/generic-container.ts
@@ -27,7 +27,7 @@ import {
 import { BoundPorts } from "../utils/bound-ports";
 import { createLabels, LABEL_TESTCONTAINERS_CONTAINER_HASH, LABEL_TESTCONTAINERS_SESSION_ID } from "../utils/labels";
 import { mapInspectResult } from "../utils/map-inspect-result";
-import { getContainerPort, hasHostBinding, PortWithOptionalBinding } from "../utils/port";
+import { getContainerPort, getProtocol, hasHostBinding, PortWithOptionalBinding } from "../utils/port";
 import { ImagePullPolicy, PullPolicy } from "../utils/pull-policy";
 import { Wait } from "../wait-strategies/wait";
 import { waitForContainer } from "../wait-strategies/wait-for-container";
@@ -364,7 +364,9 @@ export class GenericContainer implements TestContainer {
   public withExposedPorts(...ports: PortWithOptionalBinding[]): this {
     const exposedPorts: { [port: string]: Record<string, never> } = {};
     for (const exposedPort of ports) {
-      exposedPorts[`${getContainerPort(exposedPort).toString()}/tcp`] = {};
+      const containerPort = getContainerPort(exposedPort);
+      const protocol = getProtocol(exposedPort);
+      exposedPorts[`${containerPort}/${protocol}`] = {};
     }
 
     this.exposedPorts = [...this.exposedPorts, ...ports];
@@ -376,9 +378,12 @@ export class GenericContainer implements TestContainer {
     const portBindings: Record<string, Array<Record<string, string>>> = {};
     for (const exposedPort of ports) {
       if (hasHostBinding(exposedPort)) {
-        portBindings[`${exposedPort.container}/tcp`] = [{ HostPort: exposedPort.host.toString() }];
+        const protocol = getProtocol(exposedPort);
+        portBindings[`${exposedPort.container}/${protocol}`] = [{ HostPort: exposedPort.host.toString() }];
       } else {
-        portBindings[`${exposedPort}/tcp`] = [{ HostPort: "0" }];
+        const containerPort = getContainerPort(exposedPort);
+        const protocol = getProtocol(exposedPort);
+        portBindings[`${containerPort}/${protocol}`] = [{ HostPort: "0" }];
       }
     }
 

--- a/packages/testcontainers/src/generic-container/generic-container.ts
+++ b/packages/testcontainers/src/generic-container/generic-container.ts
@@ -377,12 +377,11 @@ export class GenericContainer implements TestContainer {
 
     const portBindings: Record<string, Array<Record<string, string>>> = {};
     for (const exposedPort of ports) {
+      const protocol = getProtocol(exposedPort);
       if (hasHostBinding(exposedPort)) {
-        const protocol = getProtocol(exposedPort);
         portBindings[`${exposedPort.container}/${protocol}`] = [{ HostPort: exposedPort.host.toString() }];
       } else {
         const containerPort = getContainerPort(exposedPort);
-        const protocol = getProtocol(exposedPort);
         portBindings[`${containerPort}/${protocol}`] = [{ HostPort: "0" }];
       }
     }

--- a/packages/testcontainers/src/generic-container/inspect-container-util-ports-exposed.test.ts
+++ b/packages/testcontainers/src/generic-container/inspect-container-util-ports-exposed.test.ts
@@ -72,3 +72,122 @@ describe.sequential("inspectContainerUntilPortsExposed", () => {
     );
   });
 });
+
+test("correctly handles protocol parameter when specified as string", async () => {
+  const data = mockInspectResult({ "8080/udp": [{ HostIp: "0.0.0.0", HostPort: "45000" }] });
+  const inspectFn = vi.fn().mockResolvedValueOnce(data.inspectResult);
+
+  const result = await inspectContainerUntilPortsExposed(inspectFn, ["8080/udp"], "container-id");
+
+  expect(result).toEqual(data);
+});
+
+test("correctly handles protocol parameter when specified in object format", async () => {
+  const data = mockInspectResult({ "8080/udp": [{ HostIp: "0.0.0.0", HostPort: "45000" }] });
+  const inspectFn = vi.fn().mockResolvedValueOnce(data.inspectResult);
+
+  const result = await inspectContainerUntilPortsExposed(
+    inspectFn,
+    [{ container: 8080, host: 45000, protocol: "udp" }],
+    "container-id"
+  );
+
+  expect(result).toEqual(data);
+});
+
+test("uses tcp as default protocol when not specified", async () => {
+  const data = mockInspectResult({ "8080/tcp": [{ HostIp: "0.0.0.0", HostPort: "45000" }] });
+  const inspectFn = vi.fn().mockResolvedValueOnce(data.inspectResult);
+
+  const result = await inspectContainerUntilPortsExposed(inspectFn, [8080], "container-id");
+
+  expect(result).toEqual(data);
+});
+
+test("handles multiple ports with different protocols", async () => {
+  const ports = {
+    "8080/tcp": [{ HostIp: "0.0.0.0", HostPort: "45000" }],
+    "9090/udp": [{ HostIp: "0.0.0.0", HostPort: "46000" }],
+  };
+  const data = mockInspectResult(ports);
+  const inspectFn = vi.fn().mockResolvedValueOnce(data.inspectResult);
+
+  const result = await inspectContainerUntilPortsExposed(inspectFn, [8080, "9090/udp"], "container-id");
+
+  expect(result).toEqual(data);
+});
+
+test("fails when protocol doesn't match exposed port", async () => {
+  // Container exposes TCP port but we're looking for UDP
+  const data = mockInspectResult({ "8080/tcp": [{ HostIp: "0.0.0.0", HostPort: "45000" }] });
+  const inspectFn = vi.fn().mockResolvedValue(data.inspectResult);
+
+  await expect(inspectContainerUntilPortsExposed(inspectFn, ["8080/udp"], "container-id", 0)).rejects.toThrow(
+    "Container did not expose all ports after starting"
+  );
+});
+
+test("ignores ports with wrong protocol", async () => {
+  const ports = {
+    "8080/tcp": [{ HostIp: "0.0.0.0", HostPort: "45000" }],
+    "8080/udp": [{ HostIp: "0.0.0.0", HostPort: "46000" }],
+  };
+  const data = mockInspectResult(ports);
+  const inspectFn = vi.fn().mockResolvedValueOnce(data.inspectResult);
+
+  // Should only match the UDP port
+  const result = await inspectContainerUntilPortsExposed(inspectFn, ["8080/udp"], "container-id");
+
+  expect(result).toEqual(data);
+});
+
+test("handles mixed protocol specifications in different formats", async () => {
+  const ports = {
+    "8080/tcp": [{ HostIp: "0.0.0.0", HostPort: "45000" }],
+    "9090/udp": [{ HostIp: "0.0.0.0", HostPort: "46000" }],
+    "7070/tcp": [{ HostIp: "0.0.0.0", HostPort: "47000" }],
+  };
+  const data = mockInspectResult(ports);
+  const inspectFn = vi.fn().mockResolvedValueOnce(data.inspectResult);
+
+  const result = await inspectContainerUntilPortsExposed(
+    inspectFn,
+    [
+      8080, // number (default tcp)
+      "9090/udp", // string with protocol
+      { container: 7070, host: 47000 }, // object (default tcp)
+    ],
+    "container-id"
+  );
+
+  expect(result).toEqual(data);
+});
+
+test("retry with gradually exposed ports of different protocols", async () => {
+  // First call: No ports exposed
+  const data1 = mockInspectResult({});
+
+  // Second call: Only TCP port exposed
+  const data2 = mockInspectResult({ "8080/tcp": [{ HostIp: "0.0.0.0", HostPort: "45000" }] });
+
+  // Third call: Both TCP and UDP ports exposed
+  const data3 = mockInspectResult({
+    "8080/tcp": [{ HostIp: "0.0.0.0", HostPort: "45000" }],
+    "8080/udp": [{ HostIp: "0.0.0.0", HostPort: "46000" }],
+  });
+
+  const inspectFn = vi
+    .fn()
+    .mockResolvedValueOnce(data1.inspectResult)
+    .mockResolvedValueOnce(data2.inspectResult)
+    .mockResolvedValueOnce(data3.inspectResult);
+
+  const result = await inspectContainerUntilPortsExposed(
+    inspectFn,
+    [8080, "8080/udp"], // Need both TCP and UDP ports
+    "container-id"
+  );
+
+  expect(result).toEqual(data3);
+  expect(inspectFn).toHaveBeenCalledTimes(3);
+});

--- a/packages/testcontainers/src/generic-container/inspect-container-util-ports-exposed.test.ts
+++ b/packages/testcontainers/src/generic-container/inspect-container-util-ports-exposed.test.ts
@@ -17,7 +17,10 @@ function mockInspectResult(
 
 describe.sequential("inspectContainerUntilPortsExposed", () => {
   it("returns the inspect result when all ports are exposed", async () => {
-    const data = mockInspectResult({ "8080/tcp": [] }, { "8080/tcp": [{ HostIp: "0.0.0.0", HostPort: "45000" }] });
+    const data = mockInspectResult(
+      { "8080/tcp": [], "8081/udp": [] },
+      { "8080/tcp": [{ HostIp: "0.0.0.0", HostPort: "45000" }], "8081/udp": [{ HostIp: "0.0.0.0", HostPort: "45001" }] }
+    );
     const inspectFn = vi.fn().mockResolvedValueOnce(data);
 
     const result = await inspectContainerUntilPortsExposed(inspectFn, "container-id");
@@ -70,24 +73,5 @@ describe.sequential("inspectContainerUntilPortsExposed", () => {
     await expect(inspectContainerUntilPortsExposed(inspectFn, "container-id", 0)).rejects.toThrow(
       "Timed out after 0ms while waiting for container ports to be bound to the host"
     );
-  });
-
-  test("handles multiple ports with different protocols", async () => {
-    const data = mockInspectResult(
-      {
-        "8080/tcp": [{ HostIp: "0.0.0.0", HostPort: "45000" }],
-        "9090/udp": [{ HostIp: "0.0.0.0", HostPort: "46000" }],
-      },
-      {
-        "8080/tcp": [{ HostIp: "0.0.0.0", HostPort: "45000" }],
-        "9090/udp": [{ HostIp: "0.0.0.0", HostPort: "46000" }],
-      }
-    );
-
-    const inspectFn = vi.fn().mockResolvedValueOnce(data);
-
-    const result = await inspectContainerUntilPortsExposed(inspectFn, "container-id");
-
-    expect(result).toEqual(data);
   });
 });

--- a/packages/testcontainers/src/generic-container/started-generic-container.ts
+++ b/packages/testcontainers/src/generic-container/started-generic-container.ts
@@ -10,6 +10,7 @@ import { CommitOptions, ContentToCopy, DirectoryToCopy, ExecOptions, ExecResult,
 import { BoundPorts } from "../utils/bound-ports";
 import { LABEL_TESTCONTAINERS_SESSION_ID } from "../utils/labels";
 import { mapInspectResult } from "../utils/map-inspect-result";
+import { PortWithOptionalBinding } from "../utils/port";
 import { waitForContainer } from "../wait-strategies/wait-for-container";
 import { WaitStrategy } from "../wait-strategies/wait-strategy";
 import { inspectContainerUntilPortsExposed } from "./inspect-container-util-ports-exposed";
@@ -95,7 +96,10 @@ export class StartedGenericContainer implements StartedTestContainer {
     }
 
     this.boundPorts = BoundPorts.fromInspectResult(client.info.containerRuntime.hostIps, mappedInspectResult).filter(
-      Array.from(this.boundPorts.iterator()).map((port) => port[0])
+      Array.from(this.boundPorts.iterator()).map((port) => {
+        const [portNumber, protocol] = port[0].split("/");
+        return `${portNumber}/${protocol}` as PortWithOptionalBinding;
+      })
     );
 
     await waitForContainer(client, this.container, this.waitStrategy, this.boundPorts, startTime);

--- a/packages/testcontainers/src/generic-container/started-generic-container.ts
+++ b/packages/testcontainers/src/generic-container/started-generic-container.ts
@@ -136,8 +136,8 @@ export class StartedGenericContainer implements StartedTestContainer {
     return this.boundPorts.getFirstBinding();
   }
 
-  public getMappedPort(port: number): number {
-    return this.boundPorts.getBinding(port);
+  public getMappedPort(port: number, protocol: string = "tcp"): number {
+    return this.boundPorts.getBinding(port, protocol);
   }
 
   public getId(): string {

--- a/packages/testcontainers/src/generic-container/started-generic-container.ts
+++ b/packages/testcontainers/src/generic-container/started-generic-container.ts
@@ -136,7 +136,7 @@ export class StartedGenericContainer implements StartedTestContainer {
     return this.boundPorts.getFirstBinding();
   }
 
-  public getMappedPort(port: number, protocol: string = "tcp"): number {
+  public getMappedPort(port: string | number, protocol: string = "tcp"): number {
     return this.boundPorts.getBinding(port, protocol);
   }
 

--- a/packages/testcontainers/src/test-container.ts
+++ b/packages/testcontainers/src/test-container.ts
@@ -71,7 +71,7 @@ export interface StartedTestContainer extends AsyncDisposable {
   getHost(): string;
   getHostname(): string;
   getFirstMappedPort(): number;
-  getMappedPort(port: number, protocol?: string): number;
+  getMappedPort(port: string | number, protocol?: string): number;
   getName(): string;
   getLabels(): Labels;
   getId(): string;

--- a/packages/testcontainers/src/test-container.ts
+++ b/packages/testcontainers/src/test-container.ts
@@ -71,7 +71,7 @@ export interface StartedTestContainer extends AsyncDisposable {
   getHost(): string;
   getHostname(): string;
   getFirstMappedPort(): number;
-  getMappedPort(port: number): number;
+  getMappedPort(port: number, protocol?: string): number;
   getName(): string;
   getLabels(): Labels;
   getId(): string;

--- a/packages/testcontainers/src/test-container.ts
+++ b/packages/testcontainers/src/test-container.ts
@@ -71,7 +71,8 @@ export interface StartedTestContainer extends AsyncDisposable {
   getHost(): string;
   getHostname(): string;
   getFirstMappedPort(): number;
-  getMappedPort(port: string | number, protocol?: string): number;
+  getMappedPort(port: number, protocol?: string): number;
+  getMappedPort(portWithProtocol: `${number}/${"tcp" | "udp"}`): number;
   getName(): string;
   getLabels(): Labels;
   getId(): string;

--- a/packages/testcontainers/src/types.ts
+++ b/packages/testcontainers/src/types.ts
@@ -69,7 +69,7 @@ export type ExtraHost = {
 export type Labels = { [key: string]: string };
 
 export type HostPortBindings = Array<{ hostIp: string; hostPort: number }>;
-export type Ports = { [containerPort: number]: HostPortBindings };
+export type Ports = { [containerPortWithProtocol: string]: HostPortBindings };
 
 export type AuthConfig = {
   username: string;

--- a/packages/testcontainers/src/utils/bound-ports.test.ts
+++ b/packages/testcontainers/src/utils/bound-ports.test.ts
@@ -15,9 +15,7 @@ describe("BoundPorts", () => {
     boundPorts.setBinding(1, 1000, "tcp");
     boundPorts.setBinding(1, 2000, "udp");
 
-    // Default protocol is tcp
     expect(boundPorts.getBinding(1)).toBe(1000);
-    // Can explicitly specify protocol
     expect(boundPorts.getBinding(1, "tcp")).toBe(1000);
     expect(boundPorts.getBinding(1, "udp")).toBe(2000);
   });
@@ -29,7 +27,6 @@ describe("BoundPorts", () => {
 
     expect(boundPorts.getBinding("8080/tcp")).toBe(1000);
     expect(boundPorts.getBinding("8080/udp")).toBe(2000);
-    // Can also specify as number + protocol
     expect(boundPorts.getBinding(8080, "tcp")).toBe(1000);
     expect(boundPorts.getBinding(8080, "udp")).toBe(2000);
   });
@@ -79,10 +76,8 @@ describe("BoundPorts", () => {
 
       const boundPorts = BoundPorts.fromInspectResult(hostIps, inspectResult as InspectResult);
 
-      // Default to TCP
       expect(boundPorts.getBinding(8080)).toBe(10000);
       expect(boundPorts.getBinding(8081)).toBe(10001);
-      // Explicitly specify protocol
       expect(boundPorts.getBinding(8080, "tcp")).toBe(10000);
       expect(boundPorts.getBinding(8080, "udp")).toBe(10002);
     });
@@ -104,18 +99,12 @@ describe("BoundPorts", () => {
       boundPorts.setBinding(8080, 2000, "udp");
       boundPorts.setBinding(9090, 3000, "tcp");
 
-      // Create a simplified filter test
-      let filtered = boundPorts.filter([8080]); // Just filter TCP port
-
-      // Should only include the TCP binding
+      let filtered = boundPorts.filter([8080]);
       expect(filtered.getBinding(8080)).toBe(1000);
       expect(() => filtered.getBinding(8080, "udp")).toThrowError("No port binding found for :8080/udp");
       expect(() => filtered.getBinding(9090)).toThrowError("No port binding found for :9090/tcp");
 
-      // Now filter only the UDP port
       filtered = boundPorts.filter(["8080/udp"]);
-
-      // Should only include the UDP binding
       expect(filtered.getBinding(8080, "udp")).toBe(2000);
       expect(() => filtered.getBinding(8080, "tcp")).toThrowError("No port binding found for :8080/tcp");
     });
@@ -123,11 +112,8 @@ describe("BoundPorts", () => {
     it("should handle case-insensitive protocols", () => {
       const boundPorts = new BoundPorts();
       boundPorts.setBinding(8080, 1000, "tcp");
-
-      // Should be able to retrieve with uppercase protocol
       expect(boundPorts.getBinding(8080, "TCP")).toBe(1000);
 
-      // Also works with uppercase in the key
       boundPorts.setBinding("9090/TCP", 2000);
       expect(boundPorts.getBinding(9090, "tcp")).toBe(2000);
       expect(boundPorts.getBinding("9090/tcp")).toBe(2000);

--- a/packages/testcontainers/src/utils/bound-ports.ts
+++ b/packages/testcontainers/src/utils/bound-ports.ts
@@ -10,8 +10,6 @@ export class BoundPorts {
     const normalizedProtocol = protocol.toLowerCase();
     const key = typeof port === "string" ? port : `${port}/${normalizedProtocol}`;
     let binding = this.ports.get(key);
-
-    // Try case-insensitive lookup if not found and port is a string that might contain a protocol
     if (!binding && typeof port === "string" && port.includes("/")) {
       const [portNumber, portProtocol] = port.split("/");
       const normalizedKey = `${portNumber}/${portProtocol.toLowerCase()}`;
@@ -36,16 +34,13 @@ export class BoundPorts {
   }
 
   public setBinding(key: string | number, value: number, protocol: string = "tcp"): void {
-    // Normalize protocol to lowercase for consistency
     const normalizedProtocol = protocol.toLowerCase();
 
     if (typeof key === "string" && key.includes("/")) {
-      // If key contains protocol, normalize it
       const [portNumber, portProtocol] = key.split("/");
       const normalizedKey = `${portNumber}/${portProtocol.toLowerCase()}`;
       this.ports.set(normalizedKey, value);
     } else {
-      // Otherwise use the provided key/protocol
       const portKey = typeof key === "string" ? key : `${key}/${normalizedProtocol}`;
       this.ports.set(portKey, value);
     }
@@ -57,8 +52,6 @@ export class BoundPorts {
 
   public filter(ports: PortWithOptionalBinding[]): BoundPorts {
     const boundPorts = new BoundPorts();
-
-    // Create map of port to protocol for lookup
     const containerPortsWithProtocol = new Map<number, string>();
     ports.forEach((port) => {
       const containerPort = getContainerPort(port);
@@ -69,8 +62,6 @@ export class BoundPorts {
     for (const [internalPortWithProtocol, hostPort] of this.iterator()) {
       const [internalPortStr, protocol] = internalPortWithProtocol.split("/");
       const internalPort = parseInt(internalPortStr, 10);
-
-      // Case-insensitive protocol comparison
       if (
         containerPortsWithProtocol.has(internalPort) &&
         containerPortsWithProtocol.get(internalPort)?.toLowerCase() === protocol?.toLowerCase()

--- a/packages/testcontainers/src/utils/bound-ports.ts
+++ b/packages/testcontainers/src/utils/bound-ports.ts
@@ -7,14 +7,16 @@ export class BoundPorts {
   private readonly ports = new Map<string, number>();
 
   public getBinding(port: number | string, protocol: string = "tcp"): number {
-    const normalizedProtocol = protocol.toLowerCase();
-    const key = typeof port === "string" ? port : `${port}/${normalizedProtocol}`;
-    let binding = this.ports.get(key);
-    if (!binding && typeof port === "string" && port.includes("/")) {
+    let key: string;
+
+    if (typeof port === "string" && port.includes("/")) {
       const [portNumber, portProtocol] = port.split("/");
-      const normalizedKey = `${portNumber}/${portProtocol.toLowerCase()}`;
-      binding = this.ports.get(normalizedKey);
+      key = `${portNumber}/${portProtocol.toLowerCase()}`;
+    } else {
+      key = `${port}/${protocol.toLowerCase()}`;
     }
+
+    const binding = this.ports.get(key);
 
     if (!binding) {
       throw new Error(`No port binding found for :${key}`);

--- a/packages/testcontainers/src/utils/map-inspect-result.ts
+++ b/packages/testcontainers/src/utils/map-inspect-result.ts
@@ -24,9 +24,10 @@ function mapPorts(inspectInfo: ContainerInspectInfo): Ports {
   return Object.entries(inspectInfo.NetworkSettings.Ports)
     .filter(([, hostPorts]) => hostPorts !== null)
     .map(([containerPortAndProtocol, hostPorts]) => {
-      const containerPort = parseInt(containerPortAndProtocol.split("/")[0]);
+      const [port, protocol] = containerPortAndProtocol.split("/");
+      const containerPort = parseInt(port);
       return {
-        [containerPort]: hostPorts.map((hostPort) => ({
+        [`${containerPort}/${protocol}`]: hostPorts.map((hostPort) => ({
           hostIp: hostPort.HostIp,
           hostPort: parseInt(hostPort.HostPort),
         })),

--- a/packages/testcontainers/src/utils/port.test.ts
+++ b/packages/testcontainers/src/utils/port.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "vitest";
+import { getContainerPort, getProtocol, hasHostBinding } from "./port";
+
+describe("port utilities", () => {
+  describe("getContainerPort", () => {
+    test("returns number as is", () => {
+      expect(getContainerPort(8080)).toBe(8080);
+    });
+
+    test("parses port from string", () => {
+      expect(getContainerPort("8080")).toBe(8080);
+    });
+
+    test("parses port from string with protocol", () => {
+      expect(getContainerPort("8080/tcp")).toBe(8080);
+      expect(getContainerPort("8080/udp")).toBe(8080);
+    });
+
+    test("returns container port from object", () => {
+      expect(getContainerPort({ container: 8080, host: 49000 })).toBe(8080);
+    });
+
+    test("throws error for invalid port format", () => {
+      expect(() => getContainerPort("invalid")).toThrow("Invalid port format: invalid");
+    });
+  });
+
+  describe("hasHostBinding", () => {
+    test("returns true for object with host binding", () => {
+      expect(hasHostBinding({ container: 8080, host: 49000 })).toBe(true);
+    });
+
+    test("returns false for number", () => {
+      expect(hasHostBinding(8080)).toBe(false);
+    });
+
+    test("returns false for string", () => {
+      expect(hasHostBinding("8080")).toBe(false);
+      expect(hasHostBinding("8080/tcp")).toBe(false);
+    });
+  });
+
+  describe("getProtocol", () => {
+    test("returns tcp for number", () => {
+      expect(getProtocol(8080)).toBe("tcp");
+    });
+
+    test("returns tcp for string without protocol", () => {
+      expect(getProtocol("8080")).toBe("tcp");
+    });
+
+    test("returns protocol from string", () => {
+      expect(getProtocol("8080/tcp")).toBe("tcp");
+      expect(getProtocol("8080/udp")).toBe("udp");
+    });
+
+    test("returns protocol from object", () => {
+      expect(getProtocol({ container: 8080, host: 49000 })).toBe("tcp");
+      expect(getProtocol({ container: 8080, host: 49000, protocol: "udp" })).toBe("udp");
+    });
+
+    test("handles protocol case-insensitively", () => {
+      expect(getProtocol({ container: 8080, host: 49000, protocol: "TCP" })).toBe("tcp");
+      expect(getProtocol({ container: 8080, host: 49000, protocol: "UDP" })).toBe("udp");
+      expect(getProtocol("8080/TCP")).toBe("tcp");
+      expect(getProtocol("8080/UDP")).toBe("udp");
+    });
+  });
+});

--- a/packages/testcontainers/src/utils/port.test.ts
+++ b/packages/testcontainers/src/utils/port.test.ts
@@ -1,88 +1,75 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect } from "vitest";
 import { getContainerPort, getProtocol, hasHostBinding } from "./port";
 
 describe("port utilities", () => {
   describe("getContainerPort", () => {
-    test("returns number as is", () => {
+    it("returns number as is", () => {
       expect(getContainerPort(8080)).toBe(8080);
     });
 
-    test("parses port from string", () => {
+    it("parses port from string", () => {
       expect(getContainerPort("8080")).toBe(8080);
     });
 
-    test("parses port from string with protocol", () => {
+    it("parses port from string with protocol", () => {
       expect(getContainerPort("8080/tcp")).toBe(8080);
       expect(getContainerPort("8080/udp")).toBe(8080);
     });
 
-    test("returns container port from object", () => {
+    it("returns container port from object", () => {
       expect(getContainerPort({ container: 8080, host: 49000 })).toBe(8080);
     });
 
-    test("throws error for invalid port format", () => {
+    it("throws error for invalid port format", () => {
       expect(() => getContainerPort("invalid")).toThrow("Invalid port format: invalid");
     });
   });
 
   describe("hasHostBinding", () => {
-    test("returns true for object with host binding", () => {
+    it("returns true for object with host binding", () => {
       expect(hasHostBinding({ container: 8080, host: 49000 })).toBe(true);
     });
 
-    test("returns false for number", () => {
+    it("returns false for number", () => {
       expect(hasHostBinding(8080)).toBe(false);
     });
 
-    test("returns false for string", () => {
+    it("returns false for string", () => {
       expect(hasHostBinding("8080")).toBe(false);
       expect(hasHostBinding("8080/tcp")).toBe(false);
     });
   });
 
   describe("getProtocol", () => {
-    test("returns tcp for number", () => {
+    it("returns tcp for number", () => {
       expect(getProtocol(8080)).toBe("tcp");
     });
 
-    test("returns tcp for string without protocol", () => {
+    it("returns tcp for string without protocol", () => {
       expect(getProtocol("8080")).toBe("tcp");
     });
 
-    test("returns protocol from string", () => {
+    it("returns protocol from string", () => {
       expect(getProtocol("8080/tcp")).toBe("tcp");
       expect(getProtocol("8080/udp")).toBe("udp");
     });
 
-    test("returns protocol from object", () => {
+    it("returns protocol from object", () => {
       expect(getProtocol({ container: 8080, host: 49000 })).toBe("tcp");
       expect(getProtocol({ container: 8080, host: 49000, protocol: "udp" })).toBe("udp");
     });
 
-    test("handles protocol case-insensitively", () => {
+    it("handles protocol case-insensitively", () => {
       expect(getProtocol({ container: 8080, host: 49000, protocol: "TCP" })).toBe("tcp");
       expect(getProtocol({ container: 8080, host: 49000, protocol: "UDP" })).toBe("udp");
       expect(getProtocol("8080/TCP")).toBe("tcp");
       expect(getProtocol("8080/UDP")).toBe("udp");
     });
 
-    test("maintains backward compatibility", () => {
+    it("maintains backward compatibility", () => {
       expect(getProtocol(8080)).toBe("tcp");
       expect(getProtocol("8080")).toBe("tcp");
       expect(getProtocol({ container: 8080, host: 49000 })).toBe("tcp");
-    });
-
-    test("supports protocol specification in all formats", () => {
-      expect(getProtocol("8080/udp")).toBe("udp");
-      expect(getProtocol({ container: 8080, host: 49000, protocol: "udp" })).toBe("udp");
-    });
-
-    test("note about UDP port checks", () => {
-      // Note: While we support specifying UDP protocols for ports,
-      // port availability checks for UDP ports are skipped since UDP
-      // is connectionless and doesn't allow for the same verification
-      // methods as TCP. The system will assume UDP ports are ready.
-      expect(getProtocol("8080/udp")).toBe("udp");
     });
   });
 });

--- a/packages/testcontainers/src/utils/port.test.ts
+++ b/packages/testcontainers/src/utils/port.test.ts
@@ -67,16 +67,14 @@ describe("port utilities", () => {
     });
 
     test("maintains backward compatibility", () => {
-      // Original usage patterns should still work
-      expect(getProtocol(8080)).toBe("tcp"); // Number defaults to TCP
-      expect(getProtocol("8080")).toBe("tcp"); // Simple string defaults to TCP
-      expect(getProtocol({ container: 8080, host: 49000 })).toBe("tcp"); // Object without protocol defaults to TCP
+      expect(getProtocol(8080)).toBe("tcp");
+      expect(getProtocol("8080")).toBe("tcp");
+      expect(getProtocol({ container: 8080, host: 49000 })).toBe("tcp");
     });
 
     test("supports protocol specification in all formats", () => {
-      // New usage patterns with protocols
-      expect(getProtocol("8080/udp")).toBe("udp"); // String with protocol
-      expect(getProtocol({ container: 8080, host: 49000, protocol: "udp" })).toBe("udp"); // Object with protocol
+      expect(getProtocol("8080/udp")).toBe("udp");
+      expect(getProtocol({ container: 8080, host: 49000, protocol: "udp" })).toBe("udp");
     });
 
     test("note about UDP port checks", () => {

--- a/packages/testcontainers/src/utils/port.test.ts
+++ b/packages/testcontainers/src/utils/port.test.ts
@@ -3,73 +3,50 @@ import { getContainerPort, getProtocol, hasHostBinding } from "./port";
 
 describe("port utilities", () => {
   describe("getContainerPort", () => {
-    it("returns number as is", () => {
+    it("should return the container port when defined as a number", () => {
       expect(getContainerPort(8080)).toBe(8080);
     });
 
-    it("parses port from string", () => {
-      expect(getContainerPort("8080")).toBe(8080);
-    });
-
-    it("parses port from string with protocol", () => {
+    it("should return the port when defined as a string with format `port/protocol`", () => {
       expect(getContainerPort("8080/tcp")).toBe(8080);
       expect(getContainerPort("8080/udp")).toBe(8080);
     });
 
-    it("returns container port from object", () => {
+    it("should return the container port from when defined as `PortWithBinding`", () => {
       expect(getContainerPort({ container: 8080, host: 49000 })).toBe(8080);
-    });
-
-    it("throws error for invalid port format", () => {
-      expect(() => getContainerPort("invalid")).toThrow("Invalid port format: invalid");
     });
   });
 
   describe("hasHostBinding", () => {
-    it("returns true for object with host binding", () => {
+    it("should return true for `PortWithBinding` with defined `host` parameter", () => {
       expect(hasHostBinding({ container: 8080, host: 49000 })).toBe(true);
     });
 
-    it("returns false for number", () => {
+    it("should return false when querying for a number", () => {
       expect(hasHostBinding(8080)).toBe(false);
     });
 
-    it("returns false for string", () => {
-      expect(hasHostBinding("8080")).toBe(false);
+    it("should return false when querying for a string with format `port/protocol`", () => {
       expect(hasHostBinding("8080/tcp")).toBe(false);
     });
   });
 
   describe("getProtocol", () => {
-    it("returns tcp for number", () => {
+    it("should return the default `tcp` for a number", () => {
       expect(getProtocol(8080)).toBe("tcp");
     });
 
-    it("returns tcp for string without protocol", () => {
-      expect(getProtocol("8080")).toBe("tcp");
-    });
-
-    it("returns protocol from string", () => {
+    it("should return the protocol part of a string with format `port/protocol`", () => {
       expect(getProtocol("8080/tcp")).toBe("tcp");
       expect(getProtocol("8080/udp")).toBe("udp");
     });
 
-    it("returns protocol from object", () => {
+    it("should maintain backwards compatibility when defined as `PortWithBinding` without protocol", () => {
       expect(getProtocol({ container: 8080, host: 49000 })).toBe("tcp");
+    });
+
+    it("should return the protocol parameter when defined as `PortWithBinding`", () => {
       expect(getProtocol({ container: 8080, host: 49000, protocol: "udp" })).toBe("udp");
-    });
-
-    it("handles protocol case-insensitively", () => {
-      expect(getProtocol({ container: 8080, host: 49000, protocol: "TCP" })).toBe("tcp");
-      expect(getProtocol({ container: 8080, host: 49000, protocol: "UDP" })).toBe("udp");
-      expect(getProtocol("8080/TCP")).toBe("tcp");
-      expect(getProtocol("8080/UDP")).toBe("udp");
-    });
-
-    it("maintains backward compatibility", () => {
-      expect(getProtocol(8080)).toBe("tcp");
-      expect(getProtocol("8080")).toBe("tcp");
-      expect(getProtocol({ container: 8080, host: 49000 })).toBe("tcp");
     });
   });
 });

--- a/packages/testcontainers/src/utils/port.test.ts
+++ b/packages/testcontainers/src/utils/port.test.ts
@@ -65,5 +65,26 @@ describe("port utilities", () => {
       expect(getProtocol("8080/TCP")).toBe("tcp");
       expect(getProtocol("8080/UDP")).toBe("udp");
     });
+
+    test("maintains backward compatibility", () => {
+      // Original usage patterns should still work
+      expect(getProtocol(8080)).toBe("tcp"); // Number defaults to TCP
+      expect(getProtocol("8080")).toBe("tcp"); // Simple string defaults to TCP
+      expect(getProtocol({ container: 8080, host: 49000 })).toBe("tcp"); // Object without protocol defaults to TCP
+    });
+
+    test("supports protocol specification in all formats", () => {
+      // New usage patterns with protocols
+      expect(getProtocol("8080/udp")).toBe("udp"); // String with protocol
+      expect(getProtocol({ container: 8080, host: 49000, protocol: "udp" })).toBe("udp"); // Object with protocol
+    });
+
+    test("note about UDP port checks", () => {
+      // Note: While we support specifying UDP protocols for ports,
+      // port availability checks for UDP ports are skipped since UDP
+      // is connectionless and doesn't allow for the same verification
+      // methods as TCP. The system will assume UDP ports are ready.
+      expect(getProtocol("8080/udp")).toBe("udp");
+    });
   });
 });

--- a/packages/testcontainers/src/utils/port.ts
+++ b/packages/testcontainers/src/utils/port.ts
@@ -1,13 +1,39 @@
 export type PortWithBinding = {
   container: number;
   host: number;
+  protocol?: string;
 };
 
-export type PortWithOptionalBinding = number | PortWithBinding;
+export type PortWithOptionalBinding = number | string | PortWithBinding;
 
-export const getContainerPort = (port: PortWithOptionalBinding): number =>
-  typeof port === "number" ? port : port.container;
+export const getContainerPort = (port: PortWithOptionalBinding): number => {
+  if (typeof port === "number") {
+    return port;
+  } else if (typeof port === "string") {
+    const match = port.match(/^(\d+)(?:\/(udp|tcp))?$/);
+    if (match) {
+      return parseInt(match[1], 10);
+    }
+    throw new Error(`Invalid port format: ${port}`);
+  } else {
+    return port.container;
+  }
+};
 
 export const hasHostBinding = (port: PortWithOptionalBinding): port is PortWithBinding => {
   return typeof port === "object" && port.host !== undefined;
+};
+
+export const getProtocol = (port: PortWithOptionalBinding): string => {
+  if (typeof port === "number") {
+    return "tcp";
+  } else if (typeof port === "string") {
+    const match = port.match(/^(\d+)(?:\/(udp|tcp))?$/i);
+    if (match && match[2]) {
+      return match[2].toLowerCase();
+    }
+    return "tcp";
+  } else {
+    return port.protocol ? port.protocol.toLowerCase() : "tcp";
+  }
 };

--- a/packages/testcontainers/src/utils/port.ts
+++ b/packages/testcontainers/src/utils/port.ts
@@ -1,10 +1,12 @@
 export type PortWithBinding = {
   container: number;
   host: number;
-  protocol?: string;
+  protocol?: "tcp" | "udp";
 };
 
-export type PortWithOptionalBinding = number | string | PortWithBinding;
+export type PortWithOptionalBinding = number | `${number}/${"tcp" | "udp"}` | PortWithBinding;
+
+const portWithProtocolRegex = RegExp(/^(\d+)(?:\/(udp|tcp))?$/i);
 
 export const getContainerPort = (port: PortWithOptionalBinding): number => {
   if (typeof port === "number") {

--- a/packages/testcontainers/src/utils/port.ts
+++ b/packages/testcontainers/src/utils/port.ts
@@ -12,7 +12,7 @@ export const getContainerPort = (port: PortWithOptionalBinding): number => {
   if (typeof port === "number") {
     return port;
   } else if (typeof port === "string") {
-    const match = port.match(/^(\d+)(?:\/(udp|tcp))?$/);
+    const match = portWithProtocolRegex.exec(port);
     if (match) {
       return parseInt(match[1], 10);
     }
@@ -30,8 +30,8 @@ export const getProtocol = (port: PortWithOptionalBinding): string => {
   if (typeof port === "number") {
     return "tcp";
   } else if (typeof port === "string") {
-    const match = port.match(/^(\d+)(?:\/(udp|tcp))?$/i);
-    if (match && match[2]) {
+    const match = portWithProtocolRegex.exec(port);
+    if (match?.[2]) {
       return match[2].toLowerCase();
     }
     return "tcp";

--- a/packages/testcontainers/src/wait-strategies/host-port-wait-strategy.test.ts
+++ b/packages/testcontainers/src/wait-strategies/host-port-wait-strategy.test.ts
@@ -20,7 +20,7 @@ describe("HostPortWaitStrategy", { timeout: 180_000 }, () => {
         .withExposedPorts(8081)
         .withStartupTimeout(0)
         .start()
-    ).rejects.toThrowError(/Port \d+ not bound after 0ms/);
+    ).rejects.toThrowError(/Port (?:\d+|\d+\/\w+) not bound after 0ms/);
 
     expect(await getRunningContainerNames()).not.toContain(containerName);
   });

--- a/packages/testcontainers/src/wait-strategies/host-port-wait-strategy.test.ts
+++ b/packages/testcontainers/src/wait-strategies/host-port-wait-strategy.test.ts
@@ -20,7 +20,7 @@ describe("HostPortWaitStrategy", { timeout: 180_000 }, () => {
         .withExposedPorts(8081)
         .withStartupTimeout(0)
         .start()
-    ).rejects.toThrowError(/Port (?:\d+|\d+\/\w+) not bound after 0ms/);
+    ).rejects.toThrowError(/Port \d+\/(tcp|udp) not bound after 0ms/);
 
     expect(await getRunningContainerNames()).not.toContain(containerName);
   });

--- a/packages/testcontainers/src/wait-strategies/host-port-wait-strategy.ts
+++ b/packages/testcontainers/src/wait-strategies/host-port-wait-strategy.ts
@@ -23,12 +23,10 @@ export class HostPortWaitStrategy extends AbstractWaitStrategy {
     boundPorts: BoundPorts
   ): Promise<void> {
     for (const [portKey, hostPort] of boundPorts.iterator()) {
-      // Skip waiting for host ports that are mapped from UDP container ports
       if (portKey.toLowerCase().includes("/udp")) {
         log.debug(`Skipping wait for host port ${hostPort} (mapped from UDP port ${portKey})`, {
           containerId: container.id,
         });
-        console.log(`*** SKIPPING WAIT FOR HOST PORT ${hostPort} (mapped from ${portKey}) ***`);
         continue;
       }
       log.debug(`Waiting for host port ${hostPort}...`, { containerId: container.id });
@@ -44,12 +42,10 @@ export class HostPortWaitStrategy extends AbstractWaitStrategy {
     boundPorts: BoundPorts
   ): Promise<void> {
     for (const [internalPort] of boundPorts.iterator()) {
-      // Skip waiting for internal UDP ports
       if (typeof internalPort === "string" && internalPort.toLowerCase().includes("/udp")) {
         log.debug(`Skipping wait for internal UDP port ${internalPort}`, {
           containerId: container.id,
         });
-        console.log(`*** SKIPPING WAIT FOR INTERNAL UDP PORT ${internalPort} ***`);
         continue;
       }
       log.debug(`Waiting for internal port ${internalPort}...`, { containerId: container.id });
@@ -66,14 +62,11 @@ export class HostPortWaitStrategy extends AbstractWaitStrategy {
   ): Promise<void> {
     // Skip waiting for UDP ports
     if (typeof port === "string" && port.toLowerCase().includes("/udp")) {
-      // Make this very obvious in the logs
-      console.log(`*** SKIPPING WAIT FOR UDP PORT ${port} ***`);
       log.debug(`Skipping wait for UDP port ${port} (UDP port checks not supported)`, { containerId: container.id });
       return;
     }
 
-    // Log TCP port checks
-    console.log(`Checking availability for port: ${port}`);
+    log.debug(`Checking availability for port: ${port}`);
 
     try {
       await new IntervalRetry<boolean, Error>(100).retryUntil(
@@ -95,9 +88,9 @@ export class HostPortWaitStrategy extends AbstractWaitStrategy {
         },
         this.startupTimeoutMs
       );
-    } catch (error: any) {
-      console.log(`Error checking port ${port}: ${error.message}`);
-      throw error;
+    } catch (err) {
+      log.error(`Error checking port ${port} with error ${err}`);
+      throw err;
     }
   }
 }

--- a/packages/testcontainers/src/wait-strategies/host-port-wait-strategy.ts
+++ b/packages/testcontainers/src/wait-strategies/host-port-wait-strategy.ts
@@ -23,7 +23,7 @@ export class HostPortWaitStrategy extends AbstractWaitStrategy {
     boundPorts: BoundPorts
   ): Promise<void> {
     for (const [portKey, hostPort] of boundPorts.iterator()) {
-      if (portKey.toLowerCase().includes("/udp")) {
+      if (portKey.toLowerCase().endsWith("/udp")) {
         log.debug(`Skipping wait for host port ${hostPort} (mapped from UDP port ${portKey})`, {
           containerId: container.id,
         });
@@ -42,7 +42,7 @@ export class HostPortWaitStrategy extends AbstractWaitStrategy {
     boundPorts: BoundPorts
   ): Promise<void> {
     for (const [internalPort] of boundPorts.iterator()) {
-      if (internalPort.toLowerCase().includes("/udp")) {
+      if (internalPort.toLowerCase().endsWith("/udp")) {
         log.debug(`Skipping wait for internal UDP port ${internalPort}`, {
           containerId: container.id,
         });

--- a/packages/testcontainers/src/wait-strategies/utils/port-check.test.ts
+++ b/packages/testcontainers/src/wait-strategies/utils/port-check.test.ts
@@ -31,8 +31,6 @@ describe.sequential("PortCheck", () => {
       // @ts-ignore
       client = new ContainerRuntimeClient();
       portCheck = new InternalPortCheck(client, mockContainer);
-
-      // Make sure logging is enabled to capture all logs
       mockLogger.enabled.mockImplementation(() => true);
     });
 

--- a/packages/testcontainers/src/wait-strategies/utils/port-check.ts
+++ b/packages/testcontainers/src/wait-strategies/utils/port-check.ts
@@ -11,7 +11,7 @@ export class HostPortCheck implements PortCheck {
   constructor(private readonly client: ContainerRuntimeClient) {}
 
   public isBound(port: number | string): Promise<boolean> {
-    if (typeof port === "string" && port.toLowerCase().includes("/udp")) {
+    if (typeof port === "string" && port.toLowerCase().endsWith("/udp")) {
       log.debug(`Skipping host port check for UDP port ${port} (UDP port checks not supported)`);
       return Promise.resolve(true);
     }

--- a/packages/testcontainers/src/wait-strategies/utils/port-check.ts
+++ b/packages/testcontainers/src/wait-strategies/utils/port-check.ts
@@ -11,7 +11,6 @@ export class HostPortCheck implements PortCheck {
   constructor(private readonly client: ContainerRuntimeClient) {}
 
   public isBound(port: number | string): Promise<boolean> {
-    // Skip check for UDP ports as they can't be verified with a TCP socket connection
     if (typeof port === "string" && port.toLowerCase().includes("/udp")) {
       log.debug(`Skipping host port check for UDP port ${port} (UDP port checks not supported)`);
       return Promise.resolve(true);
@@ -48,7 +47,6 @@ export class InternalPortCheck implements PortCheck {
   ) {}
 
   public async isBound(port: number | string): Promise<boolean> {
-    // Skip check for UDP ports as they require different verification methods
     if (typeof port === "string" && port.toLowerCase().includes("/udp")) {
       log.debug(`Skipping internal port check for UDP port ${port} (UDP port checks not supported)`, {
         containerId: this.container.id,

--- a/packages/testcontainers/src/wait-strategies/utils/port-check.ts
+++ b/packages/testcontainers/src/wait-strategies/utils/port-check.ts
@@ -4,15 +4,22 @@ import { log } from "../../common";
 import { ContainerRuntimeClient } from "../../container-runtime";
 
 export interface PortCheck {
-  isBound(port: number): Promise<boolean>;
+  isBound(port: number | string): Promise<boolean>;
 }
 
 export class HostPortCheck implements PortCheck {
   constructor(private readonly client: ContainerRuntimeClient) {}
 
-  public isBound(port: number): Promise<boolean> {
+  public isBound(port: number | string): Promise<boolean> {
+    // Skip check for UDP ports as they can't be verified with a TCP socket connection
+    if (typeof port === "string" && port.toLowerCase().includes("/udp")) {
+      log.debug(`Skipping host port check for UDP port ${port} (UDP port checks not supported)`);
+      return Promise.resolve(true);
+    }
+
     return new Promise((resolve) => {
       const socket = new Socket();
+      const portNumber = typeof port === "string" ? parseInt(port.split("/")[0], 10) : port;
       socket
         .setTimeout(1000)
         .on("error", () => {
@@ -23,7 +30,7 @@ export class HostPortCheck implements PortCheck {
           socket.destroy();
           resolve(false);
         })
-        .connect(port, this.client.info.containerRuntime.host, () => {
+        .connect(portNumber, this.client.info.containerRuntime.host, () => {
           socket.end();
           resolve(true);
         });
@@ -40,12 +47,21 @@ export class InternalPortCheck implements PortCheck {
     private readonly container: Dockerode.Container
   ) {}
 
-  public async isBound(port: number): Promise<boolean> {
-    const portHex = port.toString(16).padStart(4, "0");
+  public async isBound(port: number | string): Promise<boolean> {
+    // Skip check for UDP ports as they require different verification methods
+    if (typeof port === "string" && port.toLowerCase().includes("/udp")) {
+      log.debug(`Skipping internal port check for UDP port ${port} (UDP port checks not supported)`, {
+        containerId: this.container.id,
+      });
+      return Promise.resolve(true);
+    }
+
+    const portNumber = typeof port === "string" ? parseInt(port.split("/")[0], 10) : port;
+    const portHex = portNumber.toString(16).padStart(4, "0");
     const commands = [
       ["/bin/sh", "-c", `cat /proc/net/tcp* | awk '{print $2}' | grep -i :${portHex}`],
-      ["/bin/sh", "-c", `nc -vz -w 1 localhost ${port}`],
-      ["/bin/bash", "-c", `</dev/tcp/localhost/${port}`],
+      ["/bin/sh", "-c", `nc -vz -w 1 localhost ${portNumber}`],
+      ["/bin/bash", "-c", `</dev/tcp/localhost/${portNumber}`],
     ];
 
     const commandResults = await Promise.all(


### PR DESCRIPTION
Relates to #556. 

Follows the commonly known Docker format for specifying ports with a protocol. Backwards compatibility has been tested. If no protocol is specified, it'll default to `tcp` which is all that was possible with `testcontainers-node` up until now anyway.