### PR TITLE
Fix resource quota being rejected when contains decimals

### DIFF
--- a/packages/testcontainers/src/generic-container/generic-container-resources-quota.test.ts
+++ b/packages/testcontainers/src/generic-container/generic-container-resources-quota.test.ts
@@ -44,6 +44,18 @@ describe("GenericContainer resources quota", { timeout: 180_000 }, () => {
     expect(containerInfo.HostConfig.NanoCpus).toEqual(0);
   });
 
+  it("should round values to match target int64 type", async () => {
+    await using container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+      .withResourcesQuota({ memory: 0.2, cpu: 0.3 })
+      .start();
+
+    const dockerContainer = await client.container.getById(container.getId());
+    const containerInfo = await dockerContainer.inspect();
+
+    expect(containerInfo.HostConfig.Memory).toEqual(214748365);
+    expect(containerInfo.HostConfig.NanoCpus).toEqual(300000000);
+  });
+
   if (!process.env["CI_ROOTLESS"]) {
     it("should set resources quota cpu only, memory should be 0", async () => {
       await using container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")

--- a/packages/testcontainers/src/generic-container/generic-container-resources-quota.test.ts
+++ b/packages/testcontainers/src/generic-container/generic-container-resources-quota.test.ts
@@ -11,7 +11,7 @@ describe("GenericContainer resources quota", { timeout: 180_000 }, () => {
   if (!process.env["CI_ROOTLESS"]) {
     it("should set resources quota", async () => {
       await using container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-        .withResourcesQuota({ memory: 0.5, cpu: 1 })
+        .withResourcesQuota({ cpu: 1, memory: 0.5 })
         .start();
 
       const dockerContainer = await client.container.getById(container.getId());
@@ -44,17 +44,19 @@ describe("GenericContainer resources quota", { timeout: 180_000 }, () => {
     expect(containerInfo.HostConfig.NanoCpus).toEqual(0);
   });
 
-  it("should round values to match target int64 type", async () => {
-    await using container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-      .withResourcesQuota({ memory: 0.2, cpu: 0.3 })
-      .start();
+  if (!process.env["CI_ROOTLESS"]) {
+    it("should round values to match target int64 type", async () => {
+      await using container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+        .withResourcesQuota({ cpu: 0.3, memory: 0.2 })
+        .start();
 
-    const dockerContainer = await client.container.getById(container.getId());
-    const containerInfo = await dockerContainer.inspect();
+      const dockerContainer = await client.container.getById(container.getId());
+      const containerInfo = await dockerContainer.inspect();
 
-    expect(containerInfo.HostConfig.Memory).toEqual(214748365);
-    expect(containerInfo.HostConfig.NanoCpus).toEqual(300000000);
-  });
+      expect(containerInfo.HostConfig.Memory).toEqual(214748365);
+      expect(containerInfo.HostConfig.NanoCpus).toEqual(300000000);
+    });
+  }
 
   if (!process.env["CI_ROOTLESS"]) {
     it("should set resources quota cpu only, memory should be 0", async () => {

--- a/packages/testcontainers/src/generic-container/generic-container.ts
+++ b/packages/testcontainers/src/generic-container/generic-container.ts
@@ -484,8 +484,8 @@ export class GenericContainer implements TestContainer {
   }
 
   public withResourcesQuota({ memory, cpu }: ResourcesQuota): this {
-    this.hostConfig.Memory = memory !== undefined ? memory * 1024 ** 3 : undefined;
-    this.hostConfig.NanoCpus = cpu !== undefined ? cpu * 10 ** 9 : undefined;
+    this.hostConfig.Memory = memory !== undefined ? Math.ceil(memory * 1024 ** 3) : undefined;
+    this.hostConfig.NanoCpus = cpu !== undefined ? Math.ceil(cpu * 10 ** 9) : undefined;
     return this;
   }
 


### PR DESCRIPTION
Resolves #734 

The [target types](https://docs.docker.com/reference/api/engine/version/v1.37/#tag/Container/operation/ContainerUpdate) for `memory` and `nanoCpus` are `int64`. When specifying decimal values, the scaling operation results in a number with decimal places, which the Docker engine API rejects with a 400. Let's round the values up in these cases.