### PR TITLE
Fix typo in usage example (RedisContainer)

### DIFF
--- a/docs/quickstart/usage.md
+++ b/docs/quickstart/usage.md
@@ -77,7 +77,7 @@ describe("Redis", () => {
   let redisClient: RedisClientType;
 
   beforeAll(async () => {
-    container = await new StartedRedisContainer("redis:8").start();
+    container = await new RedisContainer("redis:8").start();
     redisClient = createClient({ url: container.getConnectionUrl() });
     await redisClient.connect();
   });


### PR DESCRIPTION
The usage example has a typo when initiating a new Redis container. It should use `new RedisContainer` instead of `new StartedRedisContainer`