### PR TITLE
chore: Bump dockerode from 4.0.7 to 4.0.8

### DIFF
--- a/packages/testcontainers/package.json
+++ b/packages/testcontainers/package.json
@@ -37,7 +37,7 @@
     "byline": "^5.0.0",
     "debug": "^4.4.1",
     "docker-compose": "^1.2.0",
-    "dockerode": "^4.0.7",
+    "dockerode": "^4.0.8",
     "get-port": "^7.1.0",
     "proper-lockfile": "^4.1.2",
     "properties-reader": "^2.3.0",


### PR DESCRIPTION
Fix #1133