### PR TITLE
Replace in-memory locks with file locks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7478,12 +7478,6 @@
         "@types/readdir-glob": "*"
       }
     },
-    "node_modules/@types/async-lock": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@types/async-lock/-/async-lock-1.4.2.tgz",
-      "integrity": "sha512-HlZ6Dcr205BmNhwkdXqrg2vkFMN2PluI7Lgr8In3B3wE5PiQHhjRqtW/lGdVU9gw+sM0JcIDx2AN+cW8oSWIcw==",
-      "dev": true
-    },
     "node_modules/@types/big.js": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/@types/big.js/-/big.js-6.2.2.tgz",
@@ -9117,7 +9111,8 @@
     "node_modules/async-lock": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
-      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ=="
+      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+      "dev": true
     },
     "node_modules/async-mutex": {
       "version": "0.5.0",
@@ -22430,7 +22425,6 @@
         "@balena/dockerignore": "^1.0.2",
         "@types/dockerode": "^3.3.43",
         "archiver": "^7.0.1",
-        "async-lock": "^1.4.1",
         "byline": "^5.0.0",
         "debug": "^4.4.3",
         "docker-compose": "^1.3.0",
@@ -22445,7 +22439,6 @@
       },
       "devDependencies": {
         "@types/archiver": "^6.0.3",
-        "@types/async-lock": "^1.4.2",
         "@types/byline": "^4.2.36",
         "@types/debug": "^4.1.12",
         "@types/proper-lockfile": "^4.1.4",

--- a/packages/testcontainers/package.json
+++ b/packages/testcontainers/package.json
@@ -33,7 +33,6 @@
     "@balena/dockerignore": "^1.0.2",
     "@types/dockerode": "^3.3.43",
     "archiver": "^7.0.1",
-    "async-lock": "^1.4.1",
     "byline": "^5.0.0",
     "debug": "^4.4.3",
     "docker-compose": "^1.3.0",
@@ -48,7 +47,6 @@
   },
   "devDependencies": {
     "@types/archiver": "^6.0.3",
-    "@types/async-lock": "^1.4.2",
     "@types/byline": "^4.2.36",
     "@types/debug": "^4.1.12",
     "@types/proper-lockfile": "^4.1.4",

--- a/packages/testcontainers/src/container-runtime/utils/image-exists.ts
+++ b/packages/testcontainers/src/container-runtime/utils/image-exists.ts
@@ -1,12 +1,11 @@
-import AsyncLock from "async-lock";
 import Dockerode from "dockerode";
+import { hash, withFileLock } from "../../common";
 import { ImageName } from "../image-name";
 
 const existingImages = new Set<string>();
-const imageCheckLock = new AsyncLock();
 
 export async function imageExists(dockerode: Dockerode, imageName: ImageName): Promise<boolean> {
-  return imageCheckLock.acquire(imageName.string, async () => {
+  return withFileLock(`testcontainers-node-image-${hash(imageName.string)}.lock`, async () => {
     if (existingImages.has(imageName.string)) {
       return true;
     }

--- a/packages/testcontainers/src/container-runtime/utils/image-exists.ts
+++ b/packages/testcontainers/src/container-runtime/utils/image-exists.ts
@@ -5,7 +5,7 @@ import { ImageName } from "../image-name";
 const existingImages = new Set<string>();
 
 export async function imageExists(dockerode: Dockerode, imageName: ImageName): Promise<boolean> {
-  return withFileLock(`testcontainers-node-image-${hash(imageName.string)}.lock`, async () => {
+  return withFileLock(`testcontainers-node-image-exists-${hash(imageName.string).substring(0, 12)}.lock`, async () => {
     if (existingImages.has(imageName.string)) {
       return true;
     }

--- a/packages/testcontainers/src/generic-container/started-generic-container.ts
+++ b/packages/testcontainers/src/generic-container/started-generic-container.ts
@@ -31,7 +31,7 @@ export class StartedGenericContainer implements StartedTestContainer {
   protected containerIsStopping?(): Promise<void>;
 
   public async stop(options: Partial<StopOptions> = {}): Promise<StoppedTestContainer> {
-    return withFileLock(`testcontainers-node-stop-${this.container.id}.lock`, async () => {
+    return withFileLock(`testcontainers-node-stop-${this.container.id.substring(0, 12)}.lock`, async () => {
       if (this.stoppedContainer) {
         return this.stoppedContainer;
       }


### PR DESCRIPTION
In-memory [`async-lock`](https://github.com/rogierschouten/async-lock) works nicely when testcontainers code is used in a single Node process, but when multiple processes are used then, for instance, reusable containers can run into race conditions.
We're using jest for testing and it runs test files in separate workers that don't share the same module cache and thus bypass in-memory locks, because they don't "see" each other. The race condition we're seeing is that when one of the workers is in the middle of starting a Postgres container (`containerStarted` lifecycle hook hasn't completed yet, where we initialize the database), then other worker(s) think that the pending container is already ready for use and once queries are made against the uninitialized DB, errors are propagated back.

The workaround we came up with was to implement file locking in the container itself, something along the lines of this:
```ts
public class PostgresContainer extends GenericContainer {

  async start() {
    const startedContainer = await super.start();
    await startedContainer.exec(['/bin/sh', '-c', 'while [ ! -f /initialize.done ]; do sleep 0.1; done']);
    return startedContainer;
  }

  async containerStarted(startedContainer) {
    await initializeDatabase();
    await startedContainer.exec(['/bin/sh', '-c', 'touch /initialize.done']);
  }
}
```

But then I figured why not try to fix it in the library itself, for everyone. And so this PR proposes to replace all usages of `async-lock` with [`proper-lockfile`](https://github.com/moxystudio/node-proper-lockfile), which apparently was already used in a few places via [`withFileLock`](https://github.com/abendi/testcontainers-node/blob/4d53e540ac788e542d8ce3ff9d803ac2a01b1054/packages/testcontainers/src/common/file-lock.ts#L6). Something that scares me a little bit there is the 3 second `maxTimeout`, which can add extra delay to various callsites, depending on how unlucky one gets with the timings and race conditions. Maybe I should also make this timeout a little bit more aggressive?

If you'd like I can also add a test to showcase the fix, but it can get quite messy as I'd have to use `child_process.fork` + IPC to synchronize with the main process to correctly simulate a race condition in parallel process setup (unless there's some cleaner way that I'm not aware of?).