### PR TITLE
Fix MongoDB container excessive CPU usage

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,8 @@
 {
   "printWidth": 120,
   "trailingComma": "es5",
-  "plugins": ["prettier-plugin-organize-imports"]
+  "plugins": [
+    "prettier-plugin-organize-imports"
+  ],
+  "endOfLine": "auto"
 }

--- a/packages/testcontainers/src/utils/test-helper.ts
+++ b/packages/testcontainers/src/utils/test-helper.ts
@@ -2,6 +2,7 @@ import { GetEventsOptions, ImageInspectInfo } from "dockerode";
 import { createServer, Server } from "http";
 import { createSocket } from "node:dgram";
 import fs from "node:fs";
+import { EOL } from "node:os";
 import path from "node:path";
 import { Readable } from "stream";
 import { Agent, request } from "undici";
@@ -14,7 +15,7 @@ import { StartedTestContainer } from "../test-container";
 export const getImage = (dirname: string, index = 0): string => {
   return fs
     .readFileSync(path.resolve(dirname, "..", "Dockerfile"), "utf-8")
-    .split("\n")
+    .split(EOL)
     [index].split(" ")[1];
 };
 


### PR DESCRIPTION
This fixes #1145

@CodingCanuck can you please try this? My cpu usage became reasonable. I upped HC retry to 5s and made sure we first check replica set status with `rs.status()` (mongo docs says it throws if no rs was initiated) before `rs.initiate()`. For mongo v4 and below I kept previous healthcheck command.

Also, had to touch `.prettierrc` and `test-helper.ts` because I'm on Windows and `\n` just breaks everything here :)
