### PR TITLE
Fix Redis container to accept command override

### DIFF
--- a/packages/modules/redis/src/redis-container.test.ts
+++ b/packages/modules/redis/src/redis-container.test.ts
@@ -122,7 +122,7 @@ describe("RedisContainer", { timeout: 240_000 }, () => {
 
   it("should start redis with custom command", async () => {
     const container = new RedisContainer(IMAGE).withCommand(["redis-server", "--loglevel", "verbose"]);
-    const startedContainer = await container.start();
+    await using startedContainer = await container.start();
 
     // @ts-expect-error - accessing private property for testing
     expect(container.createOpts.Cmd).toEqual(["redis-server", "--loglevel", "verbose"]);
@@ -138,7 +138,7 @@ describe("RedisContainer", { timeout: 240_000 }, () => {
 
   it("should start redis-stack with custom env", async () => {
     const container = new RedisContainer(REDISSTACK_IMAGE).withEnvironment({ REDIS_ARGS: "--loglevel verbose" });
-    const startedContainer = await container.start();
+    await using startedContainer = await container.start();
 
     // @ts-expect-error - accessing private property for testing
     expect(container.createOpts.Env).toEqual(["REDIS_ARGS=--loglevel verbose"]);
@@ -158,7 +158,7 @@ describe("RedisContainer", { timeout: 240_000 }, () => {
     const container = new RedisContainer(IMAGE)
       .withCommand(["redis-server", "--loglevel", "verbose"])
       .withPersistence(sourcePath);
-    const startedContainer = await container.start();
+    await using startedContainer = await container.start();
 
     // @ts-expect-error - accessing private property for testing
     expect(container.createOpts.Cmd).toEqual([
@@ -185,7 +185,7 @@ describe("RedisContainer", { timeout: 240_000 }, () => {
     const container = new RedisContainer(REDISSTACK_IMAGE)
       .withEnvironment({ REDIS_ARGS: "--loglevel verbose" })
       .withPersistence(sourcePath);
-    const startedContainer = await container.start();
+    await using startedContainer = await container.start();
 
     // @ts-expect-error - accessing private property for testing
     expect(container.createOpts.Env).toEqual(["REDIS_ARGS=--loglevel verbose --save 1 1  --appendonly yes"]);

--- a/packages/modules/redis/src/redis-container.ts
+++ b/packages/modules/redis/src/redis-container.ts
@@ -44,8 +44,7 @@ export class RedisContainer extends GenericContainer {
       ...(this.persistenceVolume ? ["--save 1 1 ", "--appendonly yes"] : []),
     ];
     if (this.imageName.image.includes("redis-stack")) {
-      const existingRedisArgs =
-        (this.createOpts.Env || []).find((e) => e.startsWith("REDIS_ARGS="))?.split("=", 2)[1] || "";
+      const existingRedisArgs = this.environment["REDIS_ARGS"] ?? "";
 
       // merge with filter to remove empty items
       const mergedRedisArgs = [existingRedisArgs, ...redisArgs].filter(Boolean).join(" ");


### PR DESCRIPTION
Hi,

Here's a small fix to resolve the Redis container startup issue with custom commands (#1150).

I noticed a similar issue with the redis-stack image that also overrides `this.createOpts.Env`. 
Would you prefer I include this fix in the same PR, or should I create a separate issue to track it first?