### PR TITLE
Add configuration for `TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,16 +32,17 @@ Configuration of the Docker daemon:
 
 Configuration of Testcontainers and its behaviours:
 
-| Variable                              | Example                    | Description                                  |
-| ------------------------------------- |----------------------------| -------------------------------------------- |
-| TESTCONTAINERS_HOST_OVERRIDE          | tcp://docker:2375          | Docker's host on which ports are exposed     |
-| TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE | /var/run/docker.sock       | Path to Docker's socket used by ryuk         |
-| TESTCONTAINERS_RYUK_PRIVILEGED        | true                       | Run ryuk as a privileged container           |
-| TESTCONTAINERS_RYUK_DISABLED          | true                       | Disable ryuk                                 |
-| TESTCONTAINERS_RYUK_PORT              | 65515                      | Set ryuk host port (not recommended)         |
-| TESTCONTAINERS_SSHD_PORT              | 65515                      | Set SSHd host port (not recommended)         |
-| TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX  | mycompany.com/registry     | Set default image registry                   |
-| RYUK_CONTAINER_IMAGE                  | testcontainers/ryuk:0.14.0 | Custom image for ryuk                        |
-| SSHD_CONTAINER_IMAGE                  | testcontainers/sshd:1.3.0  | Custom image for SSHd                        |
-| TESTCONTAINERS_REUSE_ENABLE           | true                       | Enable reusable containers                   |
-| TESTCONTAINERS_RYUK_VERBOSE           | true                       | Sets RYUK_VERBOSE env var in ryuk container  |
+| Variable                                 | Example                    | Description                                              |
+|------------------------------------------|----------------------------|----------------------------------------------------------|
+| TESTCONTAINERS_HOST_OVERRIDE             | tcp://docker:2375          | Docker's host on which ports are exposed                 |
+| TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE    | /var/run/docker.sock       | Path to Docker's socket used by ryuk                     |
+| TESTCONTAINERS_RYUK_PRIVILEGED           | true                       | Run ryuk as a privileged container                       |
+| TESTCONTAINERS_RYUK_DISABLED             | true                       | Disable ryuk                                             |
+| TESTCONTAINERS_RYUK_PORT                 | 65515                      | Set ryuk host port (not recommended)                     |
+| TESTCONTAINERS_SSHD_PORT                 | 65515                      | Set SSHd host port (not recommended)                     |
+| TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX     | mycompany.com/registry     | Set default image registry                               |
+| RYUK_CONTAINER_IMAGE                     | testcontainers/ryuk:0.14.0 | Custom image for ryuk                                    |
+| SSHD_CONTAINER_IMAGE                     | testcontainers/sshd:1.3.0  | Custom image for SSHd                                    |
+| TESTCONTAINERS_REUSE_ENABLE              | true                       | Enable reusable containers                               |
+| TESTCONTAINERS_RYUK_VERBOSE              | true                       | Sets RYUK_VERBOSE env var in ryuk container              |
+| TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT | 30s                        | Sets RYUK_RECONNECTION_TIMEOUT env var in ryuk container |

--- a/packages/testcontainers/src/reaper/reaper.test.ts
+++ b/packages/testcontainers/src/reaper/reaper.test.ts
@@ -85,4 +85,14 @@ describe.sequential("Reaper", { timeout: 120_000 }, () => {
     const reaperContainer = client.container.getById(reaper.containerId);
     expect((await reaperContainer.inspect()).Config.Env).toContain("RYUK_VERBOSE=true");
   });
+
+  it("should propagate TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT into Reaper container", async () => {
+    vi.stubEnv("TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT", "30s");
+    vi.spyOn(client.container, "list").mockResolvedValue([]);
+
+    const reaper = await getReaper();
+
+    const reaperContainer = client.container.getById(reaper.containerId);
+    expect((await reaperContainer.inspect()).Config.Env).toContain("RYUK_RECONNECTION_TIMEOUT=30s");
+  });
 });

--- a/packages/testcontainers/src/reaper/reaper.ts
+++ b/packages/testcontainers/src/reaper/reaper.ts
@@ -84,6 +84,9 @@ async function createNewReaper(sessionId: string, remoteSocketPath: string): Pro
   if (process.env["TESTCONTAINERS_RYUK_VERBOSE"]) {
     container.withEnvironment({ RYUK_VERBOSE: process.env["TESTCONTAINERS_RYUK_VERBOSE"] });
   }
+  if (process.env["TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT"]) {
+    container.withEnvironment({ RYUK_RECONNECTION_TIMEOUT: process.env["TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT"] });
+  }
   if (process.env["TESTCONTAINERS_RYUK_PRIVILEGED"] === "true") {
     container.withPrivilegedMode();
   }


### PR DESCRIPTION
We have a use case where we'd like the reaper to stay alive between processes for longer than the default 10s. `RYUK_RECONNECTION_TIMEOUT` helps us do that.