### PR TITLE
Export KafkaContainer's SaslSslListenerOptions

### DIFF
--- a/packages/modules/kafka/src/index.ts
+++ b/packages/modules/kafka/src/index.ts
@@ -1,1 +1,1 @@
-export { KafkaContainer, StartedKafkaContainer } from "./kafka-container";
+export { KafkaContainer, SaslSslListenerOptions, StartedKafkaContainer } from "./kafka-container";

--- a/packages/modules/kafka/src/kafka-container-7.test.ts
+++ b/packages/modules/kafka/src/kafka-container-7.test.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 import { GenericContainer, Network } from "testcontainers";
 import { KafkaContainer } from "./kafka-container";
 import { assertMessageProducedAndConsumed } from "./test-helper";
@@ -89,12 +89,13 @@ describe("KafkaContainer", { timeout: 240_000 }, () => {
         {
           brokers: [`${container.getHost()}:${container.getMappedPort(9096)}`],
           ssl: true,
+          sasl: {
+            mechanism: "scram-sha-512",
+            username: "app-user",
+            password: "userPassword",
+          },
         },
         {
-          "sasl.mechanism": "SCRAM-SHA-512",
-          "sasl.username": "app-user",
-          "sasl.password": "userPassword",
-          "security.protocol": "sasl_ssl",
           "ssl.ca.location": path.resolve(certificatesDir, "kafka.client.truststore.pem"),
         }
       );
@@ -129,12 +130,13 @@ describe("KafkaContainer", { timeout: 240_000 }, () => {
         {
           brokers: [`${container.getHost()}:${container.getMappedPort(9096)}`],
           ssl: true,
+          sasl: {
+            mechanism: "scram-sha-512",
+            username: "app-user",
+            password: "userPassword",
+          },
         },
         {
-          "sasl.mechanism": "SCRAM-SHA-512",
-          "sasl.username": "app-user",
-          "sasl.password": "userPassword",
-          "security.protocol": "sasl_ssl",
           "ssl.ca.location": path.resolve(certificatesDir, "kafka.client.truststore.pem"),
         }
       );

--- a/packages/modules/kafka/src/kafka-container-latest.test.ts
+++ b/packages/modules/kafka/src/kafka-container-latest.test.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 import { GenericContainer, Network } from "testcontainers";
 import { getImage } from "../../../testcontainers/src/utils/test-helper";
 import { KafkaContainer, SaslSslListenerOptions } from "./kafka-container";
@@ -60,12 +60,13 @@ describe("KafkaContainer", { timeout: 240_000 }, () => {
       {
         brokers: [`${container.getHost()}:${container.getMappedPort(9096)}`],
         ssl: true,
+        sasl: {
+          mechanism: "scram-sha-512",
+          username: "app-user",
+          password: "userPassword",
+        },
       },
       {
-        "sasl.mechanism": "SCRAM-SHA-512",
-        "sasl.username": "app-user",
-        "sasl.password": "userPassword",
-        "security.protocol": "sasl_ssl",
         "ssl.ca.location": path.resolve(certificatesDir, "kafka.client.truststore.pem"),
       }
     );


### PR DESCRIPTION
KafkaContainer changes:
* Export SaslSslListenerOptions
* Simplify SASL/SSL tests for readability

Working with the published container it became apparent that SaslSslListenerOptions in `.withSaslSslListener(options)` was not exported from the module.

All of these tests pass locally.