### PR TITLE
Docker event stream test helper matches both `status` and `Action` fields

### DIFF
--- a/packages/testcontainers/src/utils/test-helper.test.ts
+++ b/packages/testcontainers/src/utils/test-helper.test.ts
@@ -1,0 +1,31 @@
+import { PassThrough } from "stream";
+import { waitForDockerEvent } from "./test-helper";
+
+describe("waitForDockerEvent", () => {
+  it("should resolve when action matches in ndjson stream", async () => {
+    const eventStream = new PassThrough();
+    const waitPromise = waitForDockerEvent(eventStream, "pull");
+
+    eventStream.write('{"Action":"create"}\n{"Action":"pull"}\n');
+
+    await expect(waitPromise).resolves.toBeUndefined();
+  });
+
+  it("should resolve when status matches in ndjson stream", async () => {
+    const eventStream = new PassThrough();
+    const waitPromise = waitForDockerEvent(eventStream, "pull");
+
+    eventStream.write('{"status":"pull"}\n');
+
+    await expect(waitPromise).resolves.toBeUndefined();
+  });
+
+  it("should resolve when action matches in json-seq stream", async () => {
+    const eventStream = new PassThrough();
+    const waitPromise = waitForDockerEvent(eventStream, "pull");
+
+    eventStream.write('\u001e{"Action":"pull"}\n');
+
+    await expect(waitPromise).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
Incompatibility introduced in Docker 29.