### PR TITLE
Follow symlinks when copying files into containers

### DIFF
--- a/docs/features/containers.md
+++ b/docs/features/containers.md
@@ -160,6 +160,8 @@ container.copyContentToContainer([{
 container.copyArchiveToContainer(nodeReadable, "/some/nested/remotedir");
 ```
 
+When copying files, symbolic links in `source` are followed and the linked file content is copied into the container.
+
 An optional `mode` can be specified in octal for setting file permissions:
 
 ```js

--- a/packages/testcontainers/src/utils/test-helper.ts
+++ b/packages/testcontainers/src/utils/test-helper.ts
@@ -2,7 +2,7 @@ import { GetEventsOptions, ImageInspectInfo } from "dockerode";
 import { createServer, Server } from "http";
 import { createSocket } from "node:dgram";
 import fs from "node:fs";
-import { EOL } from "node:os";
+import { EOL, tmpdir } from "node:os";
 import path from "node:path";
 import { Readable } from "stream";
 import { Agent, request } from "undici";
@@ -202,3 +202,21 @@ export async function createTestServer(port: number): Promise<Server> {
   await new Promise<void>((resolve) => server.listen(port, resolve));
   return server;
 }
+
+export const createTempSymlinkedFile = async (
+  content: string
+): Promise<{ source: string; symlink: string } & AsyncDisposable> => {
+  const directory = await fs.promises.mkdtemp(path.join(tmpdir(), "testcontainers-"));
+  const source = path.join(directory, "source.txt");
+  const symlink = path.join(directory, "symlink.txt");
+  await fs.promises.writeFile(source, content);
+  await fs.promises.symlink(source, symlink);
+
+  return {
+    source,
+    symlink,
+    [Symbol.asyncDispose]: async () => {
+      await fs.promises.rm(directory, { recursive: true, force: true });
+    },
+  };
+};


### PR DESCRIPTION
## Summary of changes
- Follow symbolic links when copying files via `withCopyFilesToContainer` before container start.
- Follow symbolic links when copying files via `copyFilesToContainer` on started containers.
- Add integration coverage for both paths to assert observable behavior in-container: copied file content is present and target is not a symlink.
- Extract reusable symlink test fixture setup/cleanup into test helper utilities.
- Document that file copy follows symbolic links.

## Verification commands run
- `npm run format`
- `npm run lint`
- `npm test -- packages/testcontainers/src/generic-container/generic-container.test.ts -t "copy file to container|copy file to started container|follow symlink"`

## Test results summary
- Targeted `generic-container` file-copy tests passed, including the two new symlink scenarios.

Closes #713
