### PR TITLE
Restore compose warning test compile after naming simplification

### DIFF
--- a/packages/testcontainers/src/docker-compose-environment/docker-compose-environment.test.ts
+++ b/packages/testcontainers/src/docker-compose-environment/docker-compose-environment.test.ts
@@ -138,7 +138,7 @@ describe("DockerComposeEnvironment", { timeout: 180_000 }, () => {
       .withWaitStrategy(unmatchedWaitStrategyName, Wait.forLogMessage("Listening on port 8080"))
       .up(["container"]);
 
-    await checkEnvironmentContainerIsHealthy(startedEnvironment, await composeContainerName("container"));
+    await checkEnvironmentContainerIsHealthy(startedEnvironment, "container-1");
 
     const warningMessages = warnSpy.mock.calls.map(([message]) => message);
     expect(


### PR DESCRIPTION
## Summary of changes
- Replace a stale `composeContainerName("container")` reference in the compose warning test with the v2 container name `"container-1"`.
- Remove the compile regression on `main` where `packages/testcontainers` failed with `TS2304: Cannot find name 'composeContainerName'`.

## Verification commands run
- `npm run format`
- `npm run lint`
- `npm run test -- packages/testcontainers/src/docker-compose-environment/docker-compose-environment.test.ts -t "should warn when no started containers match configured wait strategy names"`
- `npm run build --ignore-scripts --workspace packages/testcontainers -- --project tsconfig.json`

## Test results summary
- Format and lint completed cleanly.
- Targeted compose warning test passed.
- `packages/testcontainers` compile check passed.

## Non-breaking evidence
- Change is test-only and replaces one unresolved identifier with a concrete container name.
- No runtime/package code paths or public API exports were changed.

Closes #1238
