### PR TITLE
Add stale issue workflow

### DIFF
--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -1,0 +1,23 @@
+name: Close inactive issues
+
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-22.04
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v10
+        with:
+          days-before-issue-stale: 90
+          days-before-issue-close: 30
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 90 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 30 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,7 +7,7 @@ permissions:
 jobs:
   dependency-review:
     name: Run
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: "Checkout Repository"
         uses: actions/checkout@v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,8 @@ It captures practical rules that prevent avoidable CI and PR churn.
 5. Verify git diff only contains intended files.
 6. Never commit, push, or post on GitHub (issues, PRs, or comments) without first sharing the proposed diff/message and getting explicit user approval.
 7. Commit with focused message(s), using `git commit --no-verify`.
+   - Never bypass signing (for example, do not use `--no-gpg-sign`).
+   - If signing fails (for example, passphrase/key issues), stop and ask the user to resolve signing, then retry.
 8. Push branch. Ask for explicit user permission before any force push.
 9. Open PR against `main` using a human-readable title (no `feat(...)` / `fix(...)` prefixes).
 10. Add labels for both change type and semantic version impact.
@@ -45,7 +47,7 @@ It captures practical rules that prevent avoidable CI and PR churn.
     - verification commands run
     - test results summary
     - if semver impact is not `major`, evidence that the change is not breaking
-    - `Closes #<issue>`
+    - `Closes #<issue>` only when the PR is intended to close a specific issue
 
 ## Labels
 


### PR DESCRIPTION
## Summary of changes
- add a new GitHub Actions workflow to mark stale issues and close inactive issues (`actions/stale@v10`)
- configure stale timing to 90 days and close timing to 30 days
- disable stale/close handling for pull requests in that workflow
- pin workflow runners to `ubuntu-22.04` in both stale-issues and dependency-review workflows

## Verification commands run
- `npm run format`
- `npm run lint`

## Test results summary
- format: pass
- lint: pass
- targeted tests: not run (workflow/docs changes only)

## Non-breaking evidence
- changes are limited to repository automation/workflow config and contributor process documentation
- no runtime source code or public API changes
