### PR TITLE
Exempt never-stale issues from stale workflow

### DIFF
--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -16,6 +16,7 @@ jobs:
           days-before-issue-stale: 90
           days-before-issue-close: 30
           stale-issue-label: "stale"
+          exempt-issue-labels: "never-stale"
           stale-issue-message: "This issue is stale because it has been open for 90 days with no activity."
           close-issue-message: "This issue was closed because it has been inactive for 30 days since being marked as stale."
           days-before-pr-stale: -1


### PR DESCRIPTION
## Summary of changes
- update the stale workflow to exempt issues labeled `never-stale` from stale/close automation

## Verification commands run
- `npm run format`
- `npm run lint`

## Test results summary
- format: pass
- lint: pass
- targeted tests: not run (workflow-only configuration change)

## Non-breaking evidence
- change is limited to GitHub Actions workflow configuration
- no runtime source code, package behavior, or public API changes
