### PR TITLE
Docs fix - Global setup

### DIFF
--- a/docs/quickstart/global-setup.md
+++ b/docs/quickstart/global-setup.md
@@ -39,7 +39,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   test: {
-    setupFiles: "./setup.js",
+    globalSetup: "./setup.js",
   }
 });
 ```


### PR DESCRIPTION
Looking at the vitest docs I believe `globalSetup` is the correct config prop

https://vitest.dev/config/globalsetup.html
https://vitest.dev/config/setupfiles.html
