### PR TITLE
Replace archiver usage with tar-fs for container copy paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7339,16 +7339,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/archiver": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-7.0.0.tgz",
-      "integrity": "sha512-/3vwGwx9n+mCQdYZ2IKGGHEFL30I96UgBlk8EtRDDFQ9uxM1l4O5Ci6r00EMAkiDaTqD9DQ6nVrWRICnBPtzzg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/readdir-glob": "*"
-      }
-    },
     "node_modules/@types/async-lock": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@types/async-lock/-/async-lock-1.4.2.tgz",
@@ -7683,15 +7673,6 @@
       "integrity": "sha512-19eKVv9tugr03IgfXlA9UVUVRbW6IuqRO5B92Dl4a6pT7K8uaGrNS0GkxiZD0BOk6PLuXl5FhWl//eX/pzYdTQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/readdir-glob": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
-      "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -19609,7 +19590,6 @@
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",
         "@types/dockerode": "^4.0.1",
-        "archiver": "^7.0.1",
         "async-lock": "^1.4.1",
         "byline": "^5.0.0",
         "debug": "^4.4.3",
@@ -19624,7 +19604,6 @@
         "undici": "^7.22.0"
       },
       "devDependencies": {
-        "@types/archiver": "^7.0.0",
         "@types/async-lock": "^1.4.2",
         "@types/byline": "^4.2.36",
         "@types/debug": "^4.1.12",

--- a/packages/testcontainers/package.json
+++ b/packages/testcontainers/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "@balena/dockerignore": "^1.0.2",
     "@types/dockerode": "^4.0.1",
-    "archiver": "^7.0.1",
     "async-lock": "^1.4.1",
     "byline": "^5.0.0",
     "debug": "^4.4.3",
@@ -47,7 +46,6 @@
     "undici": "^7.22.0"
   },
   "devDependencies": {
-    "@types/archiver": "^7.0.0",
     "@types/async-lock": "^1.4.2",
     "@types/byline": "^4.2.36",
     "@types/debug": "^4.1.12",

--- a/packages/testcontainers/src/generic-container/create-archive-to-copy-to-container.ts
+++ b/packages/testcontainers/src/generic-container/create-archive-to-copy-to-container.ts
@@ -36,7 +36,7 @@ export async function createArchiveToCopyToContainer({
     throw error;
   }
 
-  const archive = tar.pack(stagingDirectory.name, { dereference: true, umask: 0 });
+  const archive = tar.pack(stagingDirectory.name, { dereference: true, umask: 0 } as tar.PackOptions);
   let cleanedUp = false;
   const cleanup = () => {
     if (cleanedUp) {

--- a/packages/testcontainers/src/generic-container/create-archive-to-copy-to-container.ts
+++ b/packages/testcontainers/src/generic-container/create-archive-to-copy-to-container.ts
@@ -1,0 +1,142 @@
+import { createWriteStream, promises as fs } from "fs";
+import path from "path";
+import { Readable } from "stream";
+import { pipeline } from "stream/promises";
+import tar from "tar-fs";
+import tmp from "tmp";
+import { Content, ContentToCopy, DirectoryToCopy, FileToCopy } from "../types";
+
+type ArchiveToCopyToContainer = {
+  filesToCopy?: FileToCopy[];
+  directoriesToCopy?: DirectoryToCopy[];
+  contentsToCopy?: ContentToCopy[];
+};
+
+export async function createArchiveToCopyToContainer({
+  filesToCopy = [],
+  directoriesToCopy = [],
+  contentsToCopy = [],
+}: ArchiveToCopyToContainer): Promise<Readable> {
+  const stagingDirectory = tmp.dirSync({ unsafeCleanup: true });
+
+  try {
+    for (const { source, target, mode } of filesToCopy) {
+      await copyFileToStagingDirectory(stagingDirectory.name, source, target, mode);
+    }
+
+    for (const { source, target, mode } of directoriesToCopy) {
+      await copyDirectoryToStagingDirectory(stagingDirectory.name, source, target, mode);
+    }
+
+    for (const { content, target, mode } of contentsToCopy) {
+      await copyContentToStagingDirectory(stagingDirectory.name, content, target, mode);
+    }
+  } catch (error) {
+    stagingDirectory.removeCallback();
+    throw error;
+  }
+
+  const archive = tar.pack(stagingDirectory.name, { dereference: true, umask: 0 });
+  let cleanedUp = false;
+  const cleanup = () => {
+    if (cleanedUp) {
+      return;
+    }
+
+    cleanedUp = true;
+    stagingDirectory.removeCallback();
+  };
+
+  archive.once("end", cleanup);
+  archive.once("close", cleanup);
+  archive.once("error", cleanup);
+
+  return archive;
+}
+
+async function copyFileToStagingDirectory(
+  stagingDirectory: string,
+  source: string,
+  target: string,
+  mode: number | undefined
+): Promise<void> {
+  const targetPath = getArchiveTargetPath(stagingDirectory, target);
+  await fs.mkdir(path.dirname(targetPath), { recursive: true });
+  await fs.cp(source, targetPath, { dereference: true });
+
+  if (mode !== undefined) {
+    await fs.chmod(targetPath, mode);
+  }
+}
+
+async function copyDirectoryToStagingDirectory(
+  stagingDirectory: string,
+  source: string,
+  target: string,
+  mode: number | undefined
+): Promise<void> {
+  const targetPath = getArchiveTargetPath(stagingDirectory, target);
+  await fs.mkdir(targetPath, { recursive: true });
+
+  const entries = await fs.readdir(source);
+  await Promise.all(
+    entries.map((entry) =>
+      fs.cp(path.resolve(source, entry), path.resolve(targetPath, entry), { recursive: true, dereference: true })
+    )
+  );
+
+  if (mode !== undefined) {
+    await setModeRecursively(targetPath, mode);
+  }
+}
+
+async function copyContentToStagingDirectory(
+  stagingDirectory: string,
+  content: Content,
+  target: string,
+  mode: number | undefined
+): Promise<void> {
+  const targetPath = getArchiveTargetPath(stagingDirectory, target);
+  await fs.mkdir(path.dirname(targetPath), { recursive: true });
+  await writeContentToFile(content, targetPath);
+
+  if (mode !== undefined) {
+    await fs.chmod(targetPath, mode);
+  }
+}
+
+async function writeContentToFile(content: Content, targetPath: string): Promise<void> {
+  if (content instanceof Readable) {
+    await pipeline(content, createWriteStream(targetPath));
+  } else {
+    await fs.writeFile(targetPath, content);
+  }
+}
+
+async function setModeRecursively(targetPath: string, mode: number): Promise<void> {
+  await fs.chmod(targetPath, mode);
+
+  const entries = await fs.readdir(targetPath, { withFileTypes: true });
+  await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.resolve(targetPath, entry.name);
+
+      if (entry.isDirectory()) {
+        await setModeRecursively(entryPath, mode);
+      } else {
+        await fs.chmod(entryPath, mode);
+      }
+    })
+  );
+}
+
+function getArchiveTargetPath(stagingDirectory: string, target: string): string {
+  const normalizedTarget = path.posix.resolve("/", target.replace(/\\/gu, "/"));
+  const relativeTarget = normalizedTarget.slice(1);
+
+  if (relativeTarget.length === 0) {
+    return stagingDirectory;
+  }
+
+  return path.resolve(stagingDirectory, ...relativeTarget.split("/"));
+}

--- a/packages/testcontainers/src/generic-container/create-archive-to-copy-to-container.ts
+++ b/packages/testcontainers/src/generic-container/create-archive-to-copy-to-container.ts
@@ -65,7 +65,7 @@ async function copyFileToStagingDirectory(
   await fs.cp(source, targetPath, { dereference: true });
 
   if (mode !== undefined) {
-    await fs.chmod(targetPath, mode);
+    await fs.chmod(targetPath, normalizeArchiveMode(mode));
   }
 }
 
@@ -86,7 +86,7 @@ async function copyDirectoryToStagingDirectory(
   );
 
   if (mode !== undefined) {
-    await setModeRecursively(targetPath, mode);
+    await setModeRecursively(targetPath, normalizeArchiveMode(mode));
   }
 }
 
@@ -101,7 +101,7 @@ async function copyContentToStagingDirectory(
   await writeContentToFile(content, targetPath);
 
   if (mode !== undefined) {
-    await fs.chmod(targetPath, mode);
+    await fs.chmod(targetPath, normalizeArchiveMode(mode));
   }
 }
 
@@ -139,4 +139,16 @@ function getArchiveTargetPath(stagingDirectory: string, target: string): string 
   }
 
   return path.resolve(stagingDirectory, ...relativeTarget.split("/"));
+}
+
+function normalizeArchiveMode(mode: number): number {
+  if (mode <= 0o777) {
+    return mode;
+  }
+
+  if (mode <= 0o7777 && /^[0-7]+$/u.test(String(mode))) {
+    return parseInt(String(mode), 8);
+  }
+
+  return mode;
 }

--- a/packages/testcontainers/src/generic-container/generic-container.test.ts
+++ b/packages/testcontainers/src/generic-container/generic-container.test.ts
@@ -29,7 +29,7 @@ async function createArchiveWithOwnership(target: string, uid: number, gid: numb
       entries: [fileName],
       umask: 0,
       map: (header) => ({ ...header, name: archiveEntryName, uid, gid }),
-    });
+    } as tar.PackOptions);
 
     let cleanedUp = false;
     const cleanup = () => {


### PR DESCRIPTION
## Summary
- replace `archiver` usage in generic container copy flows with the existing `tar-fs` archive helper
- keep copy behavior for files, directories, inline content, and `copyUIDGID` archive scenarios
- remove direct `archiver` and `@types/archiver` dependencies from `packages/testcontainers`

## Verification Commands
- `npm run format`
- `npm run lint`
- `npm run test -- packages/testcontainers/src/generic-container/generic-container.test.ts`

## Test Results
- `packages/testcontainers/src/generic-container/generic-container.test.ts`: 49 passed, 1 skipped

## Non-Breaking Evidence
- no public API signatures changed
- existing generic-container copy behavior tests remain green, including permissions and ownership (`copyUIDGID`) paths
- dependency removal is internal to archive construction implementation

---

Closes #1135 