### PR TITLE
Use `/tmp` for Kafka startup script

### DIFF
--- a/packages/modules/kafka/src/kafka-container-7.test.ts
+++ b/packages/modules/kafka/src/kafka-container-7.test.ts
@@ -18,6 +18,14 @@ describe("KafkaContainer", { timeout: 240_000 }, () => {
     await using container = await new KafkaContainer(IMAGE).start();
 
     await assertMessageProducedAndConsumed(container);
+
+    const { exitCode } = await container.exec([
+      "sh",
+      "-c",
+      "test -f /tmp/testcontainers_start.sh && test ! -f /testcontainers_start.sh",
+    ]);
+
+    expect(exitCode).toBe(0);
   });
 
   it("should connect using in-built zoo-keeper and custom network", async () => {

--- a/packages/modules/kafka/src/kafka-container.ts
+++ b/packages/modules/kafka/src/kafka-container.ts
@@ -19,7 +19,7 @@ const KAFKA_BROKER_PORT = 9092;
 const KAFKA_CONTROLLER_PORT = 9094;
 const DEFAULT_ZOOKEEPER_PORT = 2181;
 const DEFAULT_CLUSTER_ID = "4L6g3nShT-eMCtK--X86sw";
-const STARTER_SCRIPT = "/testcontainers_start.sh";
+const STARTER_SCRIPT = "/tmp/testcontainers_start.sh";
 const WAIT_FOR_SCRIPT_MESSAGE = "Waiting for script...";
 
 // https://docs.confluent.io/platform/7.0.0/release-notes/index.html#ak-raft-kraft


### PR DESCRIPTION
## Summary

- move the Kafka startup script from `/testcontainers_start.sh` to `/tmp/testcontainers_start.sh`
- add a Kafka integration assertion that verifies the script is copied to `/tmp`

## Why

KubeDock/rootless environments can reject writes to the container root filesystem. The Kafka module currently writes its generated startup script to `/`, so startup can fail before the script is ever executed. Using `/tmp` avoids that root-level write requirement.

## Impact

This is a backward-compatible bug fix for Kafka container startup in restricted runtimes.

## Verification

- `npm run format`
- `npm run lint`
- `npm test -- packages/modules/kafka/src/kafka-container-7.test.ts`

Closes #1301