### PR TITLE
Read `RYUK_CONTAINER_IMAGE` lazily so dotenv / other runtime overrides work

### DIFF
--- a/packages/testcontainers/src/generic-container/generic-container.ts
+++ b/packages/testcontainers/src/generic-container/generic-container.ts
@@ -8,7 +8,7 @@ import { ContainerRuntimeClient, getContainerRuntimeClient, ImageName } from "..
 import { CONTAINER_STATUSES } from "../container-runtime/clients/container/types";
 import { StartedNetwork } from "../network/network";
 import { PortForwarderInstance, SSHD_IMAGE } from "../port-forwarder/port-forwarder";
-import { getReaper, REAPER_IMAGE } from "../reaper/reaper";
+import { getReaper, getReaperImage } from "../reaper/reaper";
 import { StartedTestContainer, TestContainer } from "../test-container";
 import {
   ArchiveToCopy,
@@ -70,7 +70,7 @@ export class GenericContainer implements TestContainer {
   constructor(image: string) {
     this.imageName = ImageName.fromString(image);
     this.createOpts = { Image: this.imageName.string };
-    this.hostConfig = { AutoRemove: this.imageName.string === REAPER_IMAGE };
+    this.hostConfig = { AutoRemove: this.imageName.string === getReaperImage() };
   }
 
   private isHelperContainer() {
@@ -78,7 +78,7 @@ export class GenericContainer implements TestContainer {
   }
 
   private isReaper() {
-    return this.imageName.string === REAPER_IMAGE;
+    return this.imageName.string === getReaperImage();
   }
 
   protected beforeContainerCreated?(): Promise<void>;

--- a/packages/testcontainers/src/reaper/reaper.ts
+++ b/packages/testcontainers/src/reaper/reaper.ts
@@ -7,9 +7,18 @@ import { GenericContainer } from "../generic-container/generic-container";
 import { LABEL_TESTCONTAINERS_RYUK, LABEL_TESTCONTAINERS_SESSION_ID } from "../utils/labels";
 import { Wait } from "../wait-strategies/wait";
 
-export const REAPER_IMAGE = process.env["RYUK_CONTAINER_IMAGE"]
-  ? ImageName.fromString(process.env["RYUK_CONTAINER_IMAGE"]).string
-  : ImageName.fromString("testcontainers/ryuk:0.14.0").string;
+/**
+ * Resolve the Ryuk reaper image name. Read lazily so that callers (and tests)
+ * can set `process.env.RYUK_CONTAINER_IMAGE` _after_ this module is imported —
+ * including via `.env` files loaded by `dotenv` at runtime.
+ *
+ * See https://github.com/testcontainers/testcontainers-node/issues/1310.
+ */
+export function getReaperImage(): string {
+  return process.env["RYUK_CONTAINER_IMAGE"]
+    ? ImageName.fromString(process.env["RYUK_CONTAINER_IMAGE"]).string
+    : ImageName.fromString("testcontainers/ryuk:0.14.0").string;
+}
 
 export interface Reaper {
   sessionId: string;
@@ -87,7 +96,7 @@ async function useExistingReaper(reaperContainer: ContainerInfo, sessionId: stri
 async function createNewReaper(sessionId: string, remoteSocketPath: string): Promise<Reaper> {
   log.debug(`Creating new Reaper for session "${sessionId}" with socket path "${remoteSocketPath}"...`);
 
-  const container = new GenericContainer(REAPER_IMAGE)
+  const container = new GenericContainer(getReaperImage())
     .withName(`testcontainers-ryuk-${sessionId}`)
     .withExposedPorts(
       process.env["TESTCONTAINERS_RYUK_PORT"]


### PR DESCRIPTION
## Summary

Fixes #1310.

`reaper.ts` exports `REAPER_IMAGE` as a top-level `const` whose initializer reads `process.env.RYUK_CONTAINER_IMAGE` at **module load time**. As @reporter pointed out, that means anything that mutates the environment _after_ the module is imported — most commonly a `dotenv.config()` call in user code, or an explicit `process.env.RYUK_CONTAINER_IMAGE = ...` in a test setup file — is silently ignored, and the user gets the default `testcontainers/ryuk:0.14.0` image regardless.

This is inconsistent with every other `RYUK_*` / `TESTCONTAINERS_RYUK_*` env var in the same file (lines 36, 93, 100, 103, 106, 109…), all of which are read lazily inside `createNewReaper()`.

## Fix

Convert `REAPER_IMAGE` (eager const) → `getReaperImage()` (lazy function), matching the existing pattern. Two files touched:

- `packages/testcontainers/src/reaper/reaper.ts` — export becomes a function, call site at the bottom of `createNewReaper` uses `getReaperImage()`.
- `packages/testcontainers/src/generic-container/generic-container.ts` — the two `=== REAPER_IMAGE` comparisons become `=== getReaperImage()`.

The function is cheap (one env lookup + an `ImageName.fromString` parse), and both comparisons happen at construction / `isReaper()` check time — not in a hot loop — so the lazy evaluation has no measurable overhead.

## API surface

`REAPER_IMAGE` was an exported symbol, so this is technically a breaking change for any external consumer that imports it directly. Two notes:

1. Public docs at `docs/configuration.md` and the README don't mention `REAPER_IMAGE` — only the env var `RYUK_CONTAINER_IMAGE` — so the export was effectively internal.
2. If maintainers prefer to keep the old name for back-compat, I can re-export `getReaperImage` as `REAPER_IMAGE` via an accessor (`Object.defineProperty` getter on the module's namespace), but that adds complexity for a name that wasn't documented. Happy to switch on request.

## Test plan

- [x] `grep` confirms no other `REAPER_IMAGE` references remain in the repo
- [x] All other env-var reads in `reaper.ts` already use the lazy pattern; this change brings `RYUK_CONTAINER_IMAGE` into alignment
- [ ] CI green
- [ ] (optional follow-up) regression test in `reaper.test.ts` using `vi.stubEnv("RYUK_CONTAINER_IMAGE", "...")` + `vi.resetModules()` — happy to add if maintainers want it in this PR
