### PR TITLE
Improve module compile checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ It captures practical rules that prevent avoidable CI and PR churn.
 1. Start from `main`.
 2. Create a branch prefixed with `codex/`.
 3. Implement scoped changes only.
-4. Run required checks: `npm run format`, `npm run lint`, and targeted tests.
+4. Run required checks: `npm run format`, `npm run lint`, `npm run check-compiles` when touching `packages/testcontainers` APIs consumed by modules, and targeted tests.
 5. Verify git diff only contains intended files.
 6. Never commit, push, or post on GitHub (issues, PRs, or comments) without first sharing the proposed diff/message and getting explicit user approval.
 7. Commit with focused message(s), using `git commit --no-verify`.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint --fix package.json \"packages/**/*.ts\"",
     "lint:ci": "eslint package.json \"${WORKSPACE_PATH}/**/*.ts\" --max-warnings=0",
     "update-deps": "npm-check-updates --workspaces --root -u",
-    "check-compiles": "npm run build --ignore-scripts --ws -- --project tsconfig.json --noEmit"
+    "check-compiles": "tsc -b packages/testcontainers packages/modules/* --force"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint --fix package.json \"packages/**/*.ts\"",
     "lint:ci": "eslint package.json \"${WORKSPACE_PATH}/**/*.ts\" --max-warnings=0",
     "update-deps": "npm-check-updates --workspaces --root -u",
-    "check-compiles": "tsc -b packages/testcontainers packages/modules/* --force"
+    "check-compiles": "tsc -b packages/testcontainers packages/modules/*"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Summary

- Update `check-compiles` to use TypeScript build mode across `packages/testcontainers` and `packages/modules/*`, so referenced package declarations are built before dependent modules compile.
- Update `AGENTS.md` to require `npm run check-compiles` when touching `packages/testcontainers` APIs consumed by modules.

## Verification

- `npm run check-compiles`

## Test results

- `npm run check-compiles` passed.

## Semver impact

- Patch. This is a maintenance-only change to repository checks and contributor instructions; it does not change runtime behavior or public package APIs.
