### PR TITLE
Repair npm publish version updates

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,9 +24,18 @@ jobs:
 
       - name: Update versions
         run: |
-          npm version ${{ github.event.release.tag_name }} --ws --allow-same-version
-          for module in packages/modules/*; do npm install testcontainers@${{ github.event.release.tag_name }} --save -w $module; done
-          sed -i -E "s/(sonar.projectVersion)=.+/\1=${{ github.event.release.tag_name }}/" sonar-project.properties
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+
+          npm version "$VERSION" --ws --allow-same-version --no-git-tag-version
+
+          for module in packages/modules/*; do
+            npm pkg set "dependencies.testcontainers=^$VERSION" -w "$module"
+          done
+
+          npm install --package-lock-only --ignore-scripts
+
+          sed -i -E "s/(sonar.projectVersion)=.+/\1=$TAG/" sonar-project.properties
 
       - name: Build packages
         run: |


### PR DESCRIPTION
## Summary
- Update the npm publish workflow to derive the release version from the tag once.
- Replace per-module `npm install testcontainers@...` calls with manifest-only `npm pkg set` updates for `dependencies.testcontainers`.
- Regenerate `package-lock.json` once with `npm install --package-lock-only --ignore-scripts` before the clean install/build step.

## Verification
- `npm ci --ignore-scripts`
- `npm run format`
- `npm run lint`
- Reproduced the current publish workflow in `/private/tmp/tc-publish-current.upQkMp`; `npm ci --dry-run --ignore-scripts` failed with `Missing: testcontainers@11.14.0 from lock file`.
- Verified the proposed flow in `/private/tmp/tc-publish-fixed.2XRoN4`; `npm ci --dry-run --ignore-scripts` passed.

## Test results summary
- Formatting and linting completed successfully.
- The release lockfile consistency failure was reproduced before the change and the proposed workflow sequence passed the same `npm ci` validation afterward.

## Semver impact
Patch. This changes only the release workflow and does not alter published package runtime APIs or TypeScript public types.