### PR TITLE
Use preinstalled Podman in checks

### DIFF
--- a/.github/actions/podman-setup/action.yml
+++ b/.github/actions/podman-setup/action.yml
@@ -3,20 +3,15 @@ description: "Sets up Podman"
 runs:
   using: "composite"
   steps:
-    - name: Install Podman
-      uses: redhat-actions/podman-install@5bc2ecc87c737059124c295845be51ee7297fb89
-      with:
-        ubuntu-repository: questing
+    - name: Verify Podman
+      shell: bash
+      run: podman --version
 
     - name: Configure Podman
       shell: bash
       run: |
-        PODMAN_SOCKET="${RUNNER_TEMP:-/tmp}/podman.sock"
-
-        sudo mkdir -p /etc/systemd/system/podman.socket.d
-        printf '[Socket]\nListenStream=\nListenStream=%s\nSocketUser=%s\nSocketMode=0600\n' "${PODMAN_SOCKET}" "$(id -un)" | sudo tee /etc/systemd/system/podman.socket.d/runner.conf
-        sudo systemctl daemon-reload
-        sudo systemctl restart podman.socket
+        sudo systemctl start podman.socket
+        PODMAN_SOCKET="$(sudo podman info --format '{{ .Host.RemoteSocket.Path }}')"
         podman --url="unix://${PODMAN_SOCKET}" info
         echo "DOCKER_HOST=unix://${PODMAN_SOCKET}" >> $GITHUB_ENV
         echo "CI_PODMAN=true" >> $GITHUB_ENV

--- a/.github/actions/podman-setup/action.yml
+++ b/.github/actions/podman-setup/action.yml
@@ -12,6 +12,7 @@ runs:
       run: |
         sudo systemctl start podman.socket
         PODMAN_SOCKET="$(sudo podman info --format '{{ .Host.RemoteSocket.Path }}')"
+        sudo chown "$(id -u):$(id -g)" "${PODMAN_SOCKET}"
         podman --url="unix://${PODMAN_SOCKET}" info
         echo "DOCKER_HOST=unix://${PODMAN_SOCKET}" >> $GITHUB_ENV
         echo "CI_PODMAN=true" >> $GITHUB_ENV

--- a/.github/actions/podman-setup/action.yml
+++ b/.github/actions/podman-setup/action.yml
@@ -10,9 +10,12 @@ runs:
     - name: Configure Podman
       shell: bash
       run: |
-        sudo systemctl start podman.socket
-        PODMAN_SOCKET="/run/podman/podman.sock"
-        sudo chown "$(id -u):$(id -g)" "${PODMAN_SOCKET}"
+        PODMAN_SOCKET="${RUNNER_TEMP:-/tmp}/podman.sock"
+
+        sudo mkdir -p /etc/systemd/system/podman.socket.d
+        printf '[Socket]\nListenStream=\nListenStream=%s\nSocketUser=%s\nSocketMode=0600\n' "${PODMAN_SOCKET}" "$(id -un)" | sudo tee /etc/systemd/system/podman.socket.d/runner.conf
+        sudo systemctl daemon-reload
+        sudo systemctl restart podman.socket
         podman --url="unix://${PODMAN_SOCKET}" info
         echo "DOCKER_HOST=unix://${PODMAN_SOCKET}" >> $GITHUB_ENV
         echo "CI_PODMAN=true" >> $GITHUB_ENV

--- a/.github/actions/podman-setup/action.yml
+++ b/.github/actions/podman-setup/action.yml
@@ -11,7 +11,7 @@ runs:
       shell: bash
       run: |
         sudo systemctl start podman.socket
-        PODMAN_SOCKET="$(sudo podman info --format '{{ .Host.RemoteSocket.Path }}')"
+        PODMAN_SOCKET="/run/podman/podman.sock"
         sudo chown "$(id -u):$(id -g)" "${PODMAN_SOCKET}"
         podman --url="unix://${PODMAN_SOCKET}" info
         echo "DOCKER_HOST=unix://${PODMAN_SOCKET}" >> $GITHUB_ENV

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -147,6 +147,8 @@ jobs:
     name: Tests
     needs:
       - detect-modules
+      - lint
+      - compile
     strategy:
       fail-fast: false
       max-parallel: 20

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -147,10 +147,9 @@ jobs:
     name: Tests
     needs:
       - detect-modules
-      - lint
-      - compile
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         module: ${{ fromJSON(needs.detect-modules.outputs.modules) }}
         node-version: [22.x, 24.x]


### PR DESCRIPTION
## Summary
- Use the Podman binary already available on Ubuntu runners instead of installing Podman in every Podman test job.
- Keep the existing rootful Podman socket override so the CI runner user can access the socket used by Testcontainers.
- Keep the test matrix gated on lint and compile, and cap test concurrency at 20 jobs.

## Verification
- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |file| YAML.load_file(file); puts file }' .github/workflows/checks.yml .github/actions/podman-setup/action.yml`

## Semver impact
Patch. This is a CI-only maintenance change and does not affect package runtime behavior or public APIs.