### PR TITLE
Add npm dependency release age cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
       - "javascript"

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+min-release-age=7

--- a/packages/modules/oraclefree/src/oraclefree-container.test.ts
+++ b/packages/modules/oraclefree/src/oraclefree-container.test.ts
@@ -11,10 +11,10 @@ describe.sequential("OracleFreeContainer", { timeout: 240_000 }, () => {
     // start one container for all tests in this block to save on resources
     beforeAll(async () => {
       container = await new OracleDbContainer(IMAGE).start();
-    }, 120_000);
+    }, 240_000);
 
     afterAll(async () => {
-      await container.stop();
+      await container?.stop();
     });
 
     it("should connect and return a query result", async () => {


### PR DESCRIPTION
## Summary

- Configure npm to avoid resolving package versions published within the last 7 days.
- Configure Dependabot's npm cooldown to wait 7 days before opening version update PRs, matching npm's install policy.
- Stabilize the OracleFree default-configuration test by allowing the shared startup hook enough time for cold image pulls and avoiding a misleading cleanup error when startup fails.

## Verification

- `npm ci`
- `npm run format`
- `npm run lint`
- `git diff --check`
- `npm run test -- packages/modules/oraclefree/src/oraclefree-container.test.ts -t "default configuration"`
- Verified npm 10.9.8 accepts `min-release-age` config without error.

## Test Results

- `npm ci` passed and installed dependencies from the lockfile.
- `npm run format` passed with no formatting changes.
- `npm run lint` passed.
- `git diff --check` passed.
- Focused OracleFree default-configuration test passed: 3 passed, 3 skipped.
- Full local OracleFree test run was attempted but could not complete because local Docker storage is full while creating the custom pluggable database (`ORA-27040: No space left on device`).

## Semver Impact

Patch. This does not change any published package API or runtime behavior. The diff updates repository npm/Dependabot configuration and a test-only OracleFree timeout/cleanup path, so it is not a breaking change.