### PR TITLE
Fix Podman image healthcheck detection

### DIFF
--- a/packages/testcontainers/src/wait-strategies/utils/health-check.test.ts
+++ b/packages/testcontainers/src/wait-strategies/utils/health-check.test.ts
@@ -24,6 +24,16 @@ describe("health check utils", () => {
     expect(hasHealthCheckConfig(inspectResult)).toBe(true);
   });
 
+  it("should detect Podman image health check config from HealthCheck field", () => {
+    const inspectResult = {
+      HealthCheck: {
+        Test: ["CMD-SHELL", "test -f /tmp/ready"],
+      },
+    } as unknown as ImageInspectInfo;
+
+    expect(hasHealthCheckConfig(inspectResult)).toBe(true);
+  });
+
   it("should ignore disabled health check config", () => {
     const inspectResult = {
       Config: {

--- a/packages/testcontainers/src/wait-strategies/utils/health-check.ts
+++ b/packages/testcontainers/src/wait-strategies/utils/health-check.ts
@@ -8,11 +8,14 @@ type HealthCheckInspectInfo = ContainerInspectInfo | ImageInspectInfo;
 type InspectWithHealthCheckConfig = {
   Config?: {
     Healthcheck?: HealthConfig;
+    HealthCheck?: HealthConfig;
   };
   ContainerConfig?: {
     Healthcheck?: HealthConfig;
+    HealthCheck?: HealthConfig;
   };
   Healthcheck?: HealthConfig;
+  HealthCheck?: HealthConfig;
 };
 type InspectWithHealthCheckState = {
   State: ContainerInspectInfo["State"] & {
@@ -64,8 +67,11 @@ export const getHealthCheckConfig = (inspectResult: HealthCheckInspectInfo): Hea
 
   return (
     inspectWithHealthCheckConfig.Config?.Healthcheck ??
+    inspectWithHealthCheckConfig.Config?.HealthCheck ??
     inspectWithHealthCheckConfig.ContainerConfig?.Healthcheck ??
-    inspectWithHealthCheckConfig.Healthcheck
+    inspectWithHealthCheckConfig.ContainerConfig?.HealthCheck ??
+    inspectWithHealthCheckConfig.Healthcheck ??
+    inspectWithHealthCheckConfig.HealthCheck
   );
 };
 

--- a/packages/testcontainers/src/wait-strategies/utils/wait-strategy-selector.test.ts
+++ b/packages/testcontainers/src/wait-strategies/utils/wait-strategy-selector.test.ts
@@ -43,6 +43,13 @@ const imageInspectResultWithHealthCheck = (): ImageInspectInfo =>
     },
   }) as unknown as ImageInspectInfo;
 
+const imageInspectResultWithPodmanHealthCheck = (): ImageInspectInfo =>
+  ({
+    HealthCheck: {
+      Test: ["CMD-SHELL", "test -f /tmp/ready"],
+    },
+  }) as unknown as ImageInspectInfo;
+
 const client = (imageInspectResult: ImageInspectInfo): ContainerRuntimeClient =>
   ({
     image: {
@@ -140,6 +147,16 @@ describe("wait strategy selector", () => {
     await expect(
       selectWaitStrategy({
         client: client(imageInspectResultWithHealthCheck()),
+        inspectResult: containerInspectResult(),
+        imageNames: ["image:latest"],
+      })
+    ).resolves.toBeInstanceOf(HealthCheckWaitStrategy);
+  });
+
+  it("should select Podman image healthcheck when container inspect omits healthcheck config", async () => {
+    await expect(
+      selectWaitStrategy({
+        client: client(imageInspectResultWithPodmanHealthCheck()),
         inspectResult: containerInspectResult(),
         imageNames: ["image:latest"],
       })


### PR DESCRIPTION
## Summary

- Detect Podman image healthchecks exposed as `HealthCheck` as well as `Healthcheck`.
- Add regression coverage for the healthcheck parser and wait strategy selector.

## Verification

- `npm run test -- packages/testcontainers/src/wait-strategies/utils/health-check.test.ts packages/testcontainers/src/wait-strategies/utils/wait-strategy-selector.test.ts`
- `npm run check-compiles`
- `npm run lint`
- `npm run format`
- `git diff --check`

## Test Results

All listed checks passed locally.

## Semver Impact

Patch. This fixes Podman image healthcheck detection without changing wait strategy precedence or public APIs.