### PR TITLE
Use Docker Hub Redpanda image

### DIFF
--- a/packages/modules/redpanda/Dockerfile
+++ b/packages/modules/redpanda/Dockerfile
@@ -1,1 +1,1 @@
-FROM docker.redpanda.com/redpandadata/redpanda:v26.1.8
+FROM docker.io/redpandadata/redpanda:v26.1.8


### PR DESCRIPTION
## Summary

- Switch the Redpanda module image reference from `docker.redpanda.com/redpandadata/redpanda:v26.1.8` to `docker.io/redpandadata/redpanda:v26.1.8`.
- Avoid the Redpanda registry alias path that hit Docker Hub unauthenticated pull-rate limits in CI.

## Verification

- Confirmed Docker Hub has `redpandadata/redpanda:v26.1.8`.
- `npm run test -- packages/modules/redpanda/src/redpanda-container.test.ts`
- `git diff --check`

## Test results

- Redpanda targeted tests: 4 passed.
- Whitespace check: passed.

## Non-breaking evidence

- This keeps the same Redpanda image tag, `v26.1.8`; only the registry host changes.
- The change is limited to the Redpanda test Dockerfile and does not alter public APIs, exported types, runtime module code, or docs.
