### PR TITLE
Revert default wait strategy hook

### DIFF
--- a/docs/features/containers.md
+++ b/docs/features/containers.md
@@ -582,24 +582,6 @@ class CustomStartedContainer extends AbstractStartedContainer {
 }
 ```
 
-### Default wait strategy for custom containers
-
-Custom containers can define a fallback wait strategy by overriding `getDefaultWaitStrategy`. Testcontainers uses this when the user has not explicitly set a wait strategy and neither the container nor its image defines a health check:
-
-```ts
-import { GenericContainer, Wait, WaitStrategy } from "testcontainers";
-
-class CustomContainer extends GenericContainer {
-  constructor() {
-    super("custom/image:1.0.0");
-  }
-
-  protected override getDefaultWaitStrategy(): WaitStrategy {
-    return Wait.forLogMessage("ready");
-  }
-}
-```
-
 ## Exposing container ports
 
 Specify which container ports you want accessible by the host:

--- a/packages/testcontainers/src/generic-container/generic-container.ts
+++ b/packages/testcontainers/src/generic-container/generic-container.ts
@@ -87,8 +87,6 @@ export class GenericContainer implements TestContainer {
 
   protected containerStarting?(inspectResult: InspectResult, reused: boolean): Promise<void>;
 
-  protected getDefaultWaitStrategy?(): WaitStrategy;
-
   public async start(): Promise<StartedTestContainer> {
     const client = await getContainerRuntimeClient();
     await client.image.pull(this.imageName, {
@@ -134,7 +132,6 @@ export class GenericContainer implements TestContainer {
       waitStrategy,
       healthCheck: this.healthCheck,
       imageNames: [this.imageName.string],
-      defaultWaitStrategy: this.getDefaultWaitStrategy?.(),
     });
   }
 

--- a/packages/testcontainers/src/wait-strategies/utils/wait-strategy-selector.test.ts
+++ b/packages/testcontainers/src/wait-strategies/utils/wait-strategy-selector.test.ts
@@ -143,19 +143,6 @@ describe("wait strategy selector", () => {
     ).resolves.toBeInstanceOf(HostPortWaitStrategy);
   });
 
-  it("should select the default wait strategy when no healthcheck is configured", async () => {
-    const defaultWaitStrategy = Wait.forLogMessage("ready");
-
-    await expect(
-      selectWaitStrategy({
-        client: client({} as ImageInspectInfo),
-        inspectResult: containerInspectResult(),
-        imageNames: ["image:latest"],
-        defaultWaitStrategy,
-      })
-    ).resolves.toBe(defaultWaitStrategy);
-  });
-
   it("should select image healthcheck when container inspect omits healthcheck config", async () => {
     await expect(
       selectWaitStrategy({

--- a/packages/testcontainers/src/wait-strategies/utils/wait-strategy-selector.ts
+++ b/packages/testcontainers/src/wait-strategies/utils/wait-strategy-selector.ts
@@ -17,7 +17,6 @@ type WaitStrategySelectorOptions = {
   waitStrategy?: WaitStrategy;
   healthCheck?: HealthCheck;
   imageNames?: string[];
-  defaultWaitStrategy?: WaitStrategy;
 };
 
 export const selectWaitStrategy = async ({
@@ -26,14 +25,13 @@ export const selectWaitStrategy = async ({
   waitStrategy,
   healthCheck,
   imageNames = getImageNames(inspectResult),
-  defaultWaitStrategy = Wait.forListeningPorts(),
 }: WaitStrategySelectorOptions): Promise<WaitStrategy> => {
   if (waitStrategy) return waitStrategy;
   if (hasHealthCheck(healthCheck)) return Wait.forHealthCheck();
   if (hasDisabledHealthCheckConfig(inspectResult)) return Wait.forListeningPorts();
   if (hasHealthCheckConfig(inspectResult) || hasHealthCheckStatus(inspectResult)) return Wait.forHealthCheck();
   if (await imageHasHealthCheck(client, imageNames)) return Wait.forHealthCheck();
-  return defaultWaitStrategy;
+  return Wait.forListeningPorts();
 };
 
 const getImageNames = (inspectResult: ContainerInspectInfo): string[] => {


### PR DESCRIPTION
## Summary

- Reverts #1340 and removes the default wait strategy hook that is no longer needed for the MockServer update.
- Restores the wait strategy selector fallback to `Wait.forListeningPorts()`.
- Removes the associated docs and selector unit test for the reverted hook.

## Verification

- `npm run format`
- `npm run lint`
- `npm run check-compiles`
- `npm test -- packages/testcontainers/src/wait-strategies/utils/wait-strategy-selector.test.ts`

## Test results

All verification commands passed locally.

## Semver impact

Patch. This restores the behavior from before #1340. The latest published release marked by GitHub is `v12.0.0`, published on 2026-05-19, before #1340 merged on 2026-05-27, so this does not remove an API from the latest published release.