### PR TITLE
Preserve TCP and UDP bindings for the same container port

### DIFF
--- a/packages/testcontainers/src/utils/bound-ports.test.ts
+++ b/packages/testcontainers/src/utils/bound-ports.test.ts
@@ -107,6 +107,10 @@ describe("BoundPorts", () => {
       filtered = boundPorts.filter(["8080/udp"]);
       expect(filtered.getBinding(8080, "udp")).toBe(2000);
       expect(() => filtered.getBinding(8080, "tcp")).toThrowError("No port binding found for :8080/tcp");
+
+      filtered = boundPorts.filter(["8080/tcp", "8080/udp"]);
+      expect(filtered.getBinding(8080, "tcp")).toBe(1000);
+      expect(filtered.getBinding(8080, "udp")).toBe(2000);
     });
 
     it("should handle case-insensitive protocols", () => {

--- a/packages/testcontainers/src/utils/bound-ports.ts
+++ b/packages/testcontainers/src/utils/bound-ports.ts
@@ -54,20 +54,17 @@ export class BoundPorts {
 
   public filter(ports: PortWithOptionalBinding[]): BoundPorts {
     const boundPorts = new BoundPorts();
-    const containerPortsWithProtocol = new Map<number, string>();
+    const containerPortsWithProtocol = new Set<string>();
     ports.forEach((port) => {
       const containerPort = getContainerPort(port);
-      const protocol = getProtocol(port);
-      containerPortsWithProtocol.set(containerPort, protocol);
+      const protocol = getProtocol(port).toLowerCase();
+      containerPortsWithProtocol.add(`${containerPort}/${protocol}`);
     });
 
     for (const [internalPortWithProtocol, hostPort] of this.iterator()) {
       const [internalPortStr, protocol] = internalPortWithProtocol.split("/");
       const internalPort = parseInt(internalPortStr, 10);
-      if (
-        containerPortsWithProtocol.has(internalPort) &&
-        containerPortsWithProtocol.get(internalPort)?.toLowerCase() === protocol?.toLowerCase()
-      ) {
+      if (containerPortsWithProtocol.has(`${internalPort}/${protocol?.toLowerCase()}`)) {
         boundPorts.setBinding(internalPortWithProtocol, hostPort);
       }
     }


### PR DESCRIPTION
## Summary
- preserve both TCP and UDP bindings when filtering the same numeric container port
- add regression coverage for filtering both protocols together

## Verification
- `npm test -- packages/testcontainers/src/utils/bound-ports.test.ts`
- `npm run format`
- `npm run lint`
- `npm run check-compiles`
- `git diff --check`

## Compatibility
This is a backward-compatible bug fix. Existing single-protocol filtering behavior is unchanged.