### PR TITLE
Apply custom MSSQL startup wait messages

### DIFF
--- a/packages/modules/mssqlserver/src/mssqlserver-container.test.ts
+++ b/packages/modules/mssqlserver/src/mssqlserver-container.test.ts
@@ -86,4 +86,12 @@ describe("MSSQLServerContainer", { timeout: 180_000 }, () => {
     expect(exitCode).toBe(0);
     expect(output).toContain("Express Edition");
   });
+
+  it("should use custom wait message", async () => {
+    await using _ = await new MSSQLServerContainer("alpine")
+      .withCommand(["/bin/sh", "-c", 'echo "custom ready"; sleep 5'])
+      .withWaitForMessage("custom ready")
+      .withStartupTimeout(1_000)
+      .start();
+  });
 });

--- a/packages/modules/mssqlserver/src/mssqlserver-container.ts
+++ b/packages/modules/mssqlserver/src/mssqlserver-container.ts
@@ -31,7 +31,7 @@ export class MSSQLServerContainer extends GenericContainer {
 
   public withWaitForMessage(message: string | RegExp): this {
     this.message = message;
-    return this;
+    return this.withWaitStrategy(Wait.forLogMessage(this.message, 1));
   }
 
   public override async start(): Promise<StartedMSSQLServerContainer> {


### PR DESCRIPTION
## Summary
- apply custom MSSQL startup wait messages to the active wait strategy
- add a Docker-backed regression proving startup uses the configured message

## Verification
- `npm test -- packages/modules/mssqlserver/src/mssqlserver-container.test.ts -t "should use custom wait message"`
- `npm run format`
- `npm run lint`
- `npm run check-compiles`
- `git diff --check`

## Compatibility
This is a backward-compatible bug fix. Default MSSQL startup behavior remains unchanged.