### PR TITLE
Reset stateful regex log waits between matches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,10 @@ It captures practical rules that prevent avoidable CI and PR churn.
 - In docs Markdown, keep `<!--codeinclude-->` blocks tight with no blank lines between the markers and the include line, or the rendered snippet will contain blank lines between code lines.
 - Tests should verify observable behavior changes, not only internal/config state.
   - Example: for a security option, assert a real secure/insecure behavior difference.
+- When adding a regression test for a bug fix, follow a red-green-refactor workflow.
+  - Run the focused test against the pre-fix implementation and confirm it fails for the expected reason.
+  - Apply the implementation change, rerun the same test, and confirm it passes.
+  - Report the red-green evidence in the PR verification summary.
 - Test-only helper files under `src` (for example `*-test-utils.ts`) must be explicitly excluded from package `tsconfig.build.json` so they are not emitted into `build` and accidentally published.
 - For substantial changes to GitHub Actions, runner images, Node/npm versions, or release/publish automation, consider running the manual `Node.js Package` workflow as a dry-run publish sanity check.
   - Select the PR branch as the workflow ref to test publish workflow changes before merging.

--- a/packages/testcontainers/src/wait-strategies/log-wait-strategy.test.ts
+++ b/packages/testcontainers/src/wait-strategies/log-wait-strategy.test.ts
@@ -26,7 +26,7 @@ describe("LogWaitStrategy", { timeout: 180_000 }, () => {
     const start = new Date();
     await using container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
       .withCommand(["/bin/sh", "-c", 'sleep 2; echo "Ready"'])
-      .withWaitStrategy(Wait.forLogMessage("Ready"))
+      .withWaitStrategy(Wait.forLogMessage(/Ready/g))
       .start();
 
     expect(new Date().getTime() - start.getTime()).toBeGreaterThanOrEqual(2_000);

--- a/packages/testcontainers/src/wait-strategies/log-wait-strategy.ts
+++ b/packages/testcontainers/src/wait-strategies/log-wait-strategy.ts
@@ -28,7 +28,9 @@ export class LogWaitStrategy extends AbstractWaitStrategy {
 
       const comparisonFn: (line: string) => boolean = (line: string) => {
         if (this.message instanceof RegExp) {
-          this.message.lastIndex = 0;
+          if (this.message.global || this.message.sticky) {
+            this.message.lastIndex = 0;
+          }
           return this.message.test(line);
         } else {
           return line.includes(this.message);

--- a/packages/testcontainers/src/wait-strategies/log-wait-strategy.ts
+++ b/packages/testcontainers/src/wait-strategies/log-wait-strategy.ts
@@ -28,6 +28,7 @@ export class LogWaitStrategy extends AbstractWaitStrategy {
 
       const comparisonFn: (line: string) => boolean = (line: string) => {
         if (this.message instanceof RegExp) {
+          this.message.lastIndex = 0;
           return this.message.test(line);
         } else {
           return line.includes(this.message);


### PR DESCRIPTION
## Summary
- reset regular expression cursor state before matching container log lines
- strengthen restart coverage with a global regular expression
- document the red-green-refactor workflow for future bug regression tests in `AGENTS.md`

## Verification
- red: temporarily removed the implementation fix and ran `npm test -- packages/testcontainers/src/wait-strategies/log-wait-strategy.test.ts -t "should wait for a new log after restart"`; it failed after restart with `Log stream ended and message "/Ready/g" was not received`
- green: restored the fix and reran `npm test -- packages/testcontainers/src/wait-strategies/log-wait-strategy.test.ts -t "should wait for a new log after restart"`; it passed
- `npm run format`
- `npm run lint`
- `npm run check-compiles`
- `git diff --check`

## Compatibility
This is a backward-compatible bug fix. String and non-stateful regular expression waits are unchanged.