### PR TITLE
Reject failed Docker image builds instead of hanging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,8 @@ It captures practical rules that prevent avoidable CI and PR churn.
 - In docs Markdown, keep `<!--codeinclude-->` blocks tight with no blank lines between the markers and the include line, or the rendered snippet will contain blank lines between code lines.
 - Tests should verify observable behavior changes, not only internal/config state.
   - Example: for a security option, assert a real secure/insecure behavior difference.
+- Docker build failures may arrive as JSON progress entries before the stream ends normally.
+  - When handling build streams, reject `errorDetail` or `error` entries explicitly; `followProgress` alone only reports transport errors.
 - Test-only helper files under `src` (for example `*-test-utils.ts`) must be explicitly excluded from package `tsconfig.build.json` so they are not emitted into `build` and accidentally published.
 - For substantial changes to GitHub Actions, runner images, Node/npm versions, or release/publish automation, consider running the manual `Node.js Package` workflow as a dry-run publish sanity check.
   - Select the PR branch as the workflow ref to test publish workflow changes before merging.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,6 @@ It captures practical rules that prevent avoidable CI and PR churn.
 - In docs Markdown, keep `<!--codeinclude-->` blocks tight with no blank lines between the markers and the include line, or the rendered snippet will contain blank lines between code lines.
 - Tests should verify observable behavior changes, not only internal/config state.
   - Example: for a security option, assert a real secure/insecure behavior difference.
-- Docker build failures may arrive as JSON progress entries before the stream ends normally.
-  - When handling build streams, reject `errorDetail` or `error` entries explicitly; `followProgress` alone only reports transport errors.
 - Test-only helper files under `src` (for example `*-test-utils.ts`) must be explicitly excluded from package `tsconfig.build.json` so they are not emitted into `build` and accidentally published.
 - For substantial changes to GitHub Actions, runner images, Node/npm versions, or release/publish automation, consider running the manual `Node.js Package` workflow as a dry-run publish sanity check.
   - Select the PR branch as the workflow ref to test publish workflow changes before merging.

--- a/packages/testcontainers/src/container-runtime/clients/image/docker-image-client.test.ts
+++ b/packages/testcontainers/src/container-runtime/clients/image/docker-image-client.test.ts
@@ -1,0 +1,47 @@
+import Dockerode from "dockerode";
+import { Readable } from "stream";
+import { DockerImageClient } from "./docker-image-client";
+
+describe("DockerImageClient", () => {
+  it("rejects when the Docker image build cannot start", async () => {
+    const dockerode = {
+      buildImage: vi.fn((stream: Readable) => {
+        stream.destroy();
+        return Promise.reject(new Error("build failed"));
+      }),
+    } as unknown as Dockerode;
+    const imageClient = new DockerImageClient(dockerode, "");
+
+    const result = await Promise.race([
+      imageClient.build(__dirname, { t: "image" }).then(
+        () => "resolved",
+        () => "rejected"
+      ),
+      new Promise((resolve) => setTimeout(() => resolve("timeout"), 100)),
+    ]);
+
+    expect(result).toBe("rejected");
+  });
+
+  it("rejects when the Docker image build stream errors", async () => {
+    const buildStream = new Readable({ read() {} });
+    const dockerode = {
+      buildImage: vi.fn((stream: Readable) => {
+        stream.destroy();
+        setTimeout(() => buildStream.destroy(new Error("build failed")), 0);
+        return Promise.resolve(buildStream);
+      }),
+    } as unknown as Dockerode;
+    const imageClient = new DockerImageClient(dockerode, "");
+
+    const result = await Promise.race([
+      imageClient.build(__dirname, { t: "image" }).then(
+        () => "resolved",
+        () => "rejected"
+      ),
+      new Promise((resolve) => setTimeout(() => resolve("timeout"), 100)),
+    ]);
+
+    expect(result).toBe("rejected");
+  });
+});

--- a/packages/testcontainers/src/container-runtime/clients/image/docker-image-client.test.ts
+++ b/packages/testcontainers/src/container-runtime/clients/image/docker-image-client.test.ts
@@ -11,10 +11,19 @@ describe("DockerImageClient", () => {
       }),
       modem: {
         followProgress: vi.fn(
-          (stream: Readable, onFinished: (error: Error | null) => void, onProgress: (event: unknown) => void) => {
-            stream.on("data", (line) => onProgress(JSON.parse(line.toString())));
-            stream.on("error", onFinished);
-            stream.on("end", () => onFinished(null));
+          (
+            stream: Readable,
+            onFinished: (error: Error | null, output: unknown[]) => void,
+            onProgress: (event: unknown) => void
+          ) => {
+            const output: unknown[] = [];
+            stream.on("data", (line) => {
+              const event = JSON.parse(line.toString());
+              output.push(event);
+              onProgress(event);
+            });
+            stream.on("error", (error) => onFinished(error, output));
+            stream.on("end", () => onFinished(null, output));
           }
         ),
       },

--- a/packages/testcontainers/src/container-runtime/clients/image/docker-image-client.test.ts
+++ b/packages/testcontainers/src/container-runtime/clients/image/docker-image-client.test.ts
@@ -3,6 +3,23 @@ import { Readable } from "stream";
 import { DockerImageClient } from "./docker-image-client";
 
 describe("DockerImageClient", () => {
+  const createDockerode = (buildStream: Readable): Dockerode =>
+    ({
+      buildImage: vi.fn((stream: Readable) => {
+        stream.destroy();
+        return Promise.resolve(buildStream);
+      }),
+      modem: {
+        followProgress: vi.fn(
+          (stream: Readable, onFinished: (error: Error | null) => void, onProgress: (event: unknown) => void) => {
+            stream.on("data", (line) => onProgress(JSON.parse(line.toString())));
+            stream.on("error", onFinished);
+            stream.on("end", () => onFinished(null));
+          }
+        ),
+      },
+    }) as unknown as Dockerode;
+
   it("rejects when the Docker image build cannot start", async () => {
     const dockerode = {
       buildImage: vi.fn((stream: Readable) => {
@@ -25,14 +42,9 @@ describe("DockerImageClient", () => {
 
   it("rejects when the Docker image build stream errors", async () => {
     const buildStream = new Readable({ read() {} });
-    const dockerode = {
-      buildImage: vi.fn((stream: Readable) => {
-        stream.destroy();
-        setTimeout(() => buildStream.destroy(new Error("build failed")), 0);
-        return Promise.resolve(buildStream);
-      }),
-    } as unknown as Dockerode;
+    const dockerode = createDockerode(buildStream);
     const imageClient = new DockerImageClient(dockerode, "");
+    setTimeout(() => buildStream.destroy(new Error("build failed")), 0);
 
     const result = await Promise.race([
       imageClient.build(__dirname, { t: "image" }).then(
@@ -43,5 +55,13 @@ describe("DockerImageClient", () => {
     ]);
 
     expect(result).toBe("rejected");
+  });
+
+  it("rejects when the Docker image build progress reports an error", async () => {
+    const buildStream = Readable.from([`${JSON.stringify({ errorDetail: { message: "build failed" } })}\n`]);
+    const dockerode = createDockerode(buildStream);
+    const imageClient = new DockerImageClient(dockerode, "");
+
+    await expect(imageClient.build(__dirname, { t: "image" })).rejects.toThrow("build failed");
   });
 });

--- a/packages/testcontainers/src/container-runtime/clients/image/docker-image-client.ts
+++ b/packages/testcontainers/src/container-runtime/clients/image/docker-image-client.ts
@@ -26,17 +26,20 @@ export class DockerImageClient implements ImageClient {
       const tarStream = tar.pack(context, tarPackOptions);
       const buildStream = await this.dockerode.buildImage(tarStream, opts);
       await new Promise<void>((resolve, reject) => {
-        buildStream.on("error", reject);
+        this.dockerode.modem.followProgress(
+          buildStream,
+          (err) => (err ? reject(err) : resolve()),
+          (event) => {
+            if (buildLog.enabled()) {
+              buildLog.trace(JSON.stringify(event), { imageName: opts.t });
+            }
 
-        const lineStream = byline(buildStream);
-        lineStream.setEncoding("utf-8");
-        lineStream.on("data", (line) => {
-          if (buildLog.enabled()) {
-            buildLog.trace(line, { imageName: opts.t });
+            const error = event.errorDetail?.message ?? event.error;
+            if (error !== undefined) {
+              reject(new Error(error));
+            }
           }
-        });
-        lineStream.on("error", reject);
-        lineStream.on("end", resolve);
+        );
       });
       log.debug(`Built image "${opts.t}" with context "${context}"`);
     } catch (err) {

--- a/packages/testcontainers/src/container-runtime/clients/image/docker-image-client.ts
+++ b/packages/testcontainers/src/container-runtime/clients/image/docker-image-client.ts
@@ -24,19 +24,19 @@ export class DockerImageClient implements ImageClient {
       log.debug(`Building image "${opts.t}" with context "${context}"...`);
       const tarPackOptions = await this.createTarPackOptions(context, opts.dockerfile ?? "Dockerfile");
       const tarStream = tar.pack(context, tarPackOptions);
-      await new Promise<void>((resolve) => {
-        this.dockerode
-          .buildImage(tarStream, opts)
-          .then((stream) => byline(stream))
-          .then((stream) => {
-            stream.setEncoding("utf-8");
-            stream.on("data", (line) => {
-              if (buildLog.enabled()) {
-                buildLog.trace(line, { imageName: opts.t });
-              }
-            });
-            stream.on("end", () => resolve());
-          });
+      const buildStream = await this.dockerode.buildImage(tarStream, opts);
+      await new Promise<void>((resolve, reject) => {
+        buildStream.on("error", reject);
+
+        const lineStream = byline(buildStream);
+        lineStream.setEncoding("utf-8");
+        lineStream.on("data", (line) => {
+          if (buildLog.enabled()) {
+            buildLog.trace(line, { imageName: opts.t });
+          }
+        });
+        lineStream.on("error", reject);
+        lineStream.on("end", resolve);
       });
       log.debug(`Built image "${opts.t}" with context "${context}"`);
     } catch (err) {

--- a/packages/testcontainers/src/container-runtime/clients/image/docker-image-client.ts
+++ b/packages/testcontainers/src/container-runtime/clients/image/docker-image-client.ts
@@ -10,6 +10,15 @@ import { getAuthConfig } from "../../auth/get-auth-config";
 import { ImageName } from "../../image-name";
 import { ImageClient } from "./image-client";
 
+type DockerBuildEvent = {
+  error?: string;
+  errorDetail?: {
+    message?: string;
+  };
+};
+
+const getBuildError = (event: DockerBuildEvent): string | undefined => event.errorDetail?.message ?? event.error;
+
 export class DockerImageClient implements ImageClient {
   private readonly existingImages = new Set<string>();
   private readonly imageExistsLock = new AsyncLock();
@@ -25,22 +34,21 @@ export class DockerImageClient implements ImageClient {
       const tarPackOptions = await this.createTarPackOptions(context, opts.dockerfile ?? "Dockerfile");
       const tarStream = tar.pack(context, tarPackOptions);
       const buildStream = await this.dockerode.buildImage(tarStream, opts);
-      await new Promise<void>((resolve, reject) => {
+      const buildEvents = await new Promise<DockerBuildEvent[]>((resolve, reject) => {
         this.dockerode.modem.followProgress(
           buildStream,
-          (err) => (err ? reject(err) : resolve()),
+          (err, output) => (err ? reject(err) : resolve(output)),
           (event) => {
             if (buildLog.enabled()) {
               buildLog.trace(JSON.stringify(event), { imageName: opts.t });
             }
-
-            const error = event.errorDetail?.message ?? event.error;
-            if (error !== undefined) {
-              reject(new Error(error));
-            }
           }
         );
       });
+      const error = buildEvents.map(getBuildError).find((error) => error !== undefined);
+      if (error !== undefined) {
+        throw new Error(error);
+      }
       log.debug(`Built image "${opts.t}" with context "${context}"`);
     } catch (err) {
       log.error(`Failed to build image: ${err}`);

--- a/packages/testcontainers/src/generic-container/generic-container.test.ts
+++ b/packages/testcontainers/src/generic-container/generic-container.test.ts
@@ -665,10 +665,8 @@ describe("GenericContainer", { timeout: 180_000 }, () => {
     expect(container.getHostname()).toEqual("hostname");
   });
 
-  // failing to build an image hangs within the DockerImageClient.build method,
-  // that change might be larger so leave it out of this commit but skip the failing test
-  it.skip("should throw an error for a target stage that does not exist", async () => {
+  it("should throw an error for a target stage that does not exist", async () => {
     const context = path.resolve(fixtures, "docker-multi-stage");
-    await GenericContainer.fromDockerfile(context).withTarget("invalid").build();
+    await expect(GenericContainer.fromDockerfile(context).withTarget("invalid").build()).rejects.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- propagate Docker image build startup failures to callers
- reject when Docker image build streams emit errors
- add focused unit coverage for both rejection paths
- enable the invalid Docker target integration regression

## Verification
- red: added the build-start rejection regression against the pre-fix implementation; it received `"timeout"` instead of `"rejected"` and Vitest reported an unhandled `build failed` rejection
- red: added the build-stream error regression with stream error listeners temporarily removed; it received `"timeout"` instead of `"rejected"` and Vitest reported an unhandled `build failed` exception
- red: the invalid Docker target integration path previously hung until terminated
- green: `npm test -- packages/testcontainers/src/container-runtime/clients/image/docker-image-client.test.ts packages/testcontainers/src/generic-container/generic-container.test.ts -t "rejects when the Docker image build cannot start|rejects when the Docker image build stream errors|should throw an error for a target stage that does not exist"`
- `npm run format`
- `npm run lint`
- `npm run check-compiles`
- `git diff --check`

## Test results
- focused green suite: 3 passed, 49 skipped

## Compatibility
This is a backward-compatible bug fix. Successful Docker image builds retain their existing behavior.