### PR TITLE
Configure Azurite custom service ports

### DIFF
--- a/packages/modules/azurite/src/azurite-container.test.ts
+++ b/packages/modules/azurite/src/azurite-container.test.ts
@@ -104,9 +104,9 @@ describe("AzuriteContainer", { timeout: 240_000 }, () => {
 
     await using container = await new AzuriteContainer(IMAGE)
       .withSkipApiVersionCheck()
-      .withBlobPort({ container: 10001, host: blobPort })
-      .withQueuePort({ container: 10002, host: queuePort })
-      .withTablePort({ container: 10003, host: tablePort })
+      .withBlobPort({ container: 11000, host: blobPort })
+      .withQueuePort({ container: 11001, host: queuePort })
+      .withTablePort({ container: 11002, host: tablePort })
       .start();
 
     expect(container.getBlobPort()).toBe(blobPort);
@@ -122,6 +122,14 @@ describe("AzuriteContainer", { timeout: 240_000 }, () => {
     const serviceClient = BlobServiceClient.fromConnectionString(connectionString);
     const containerClient = serviceClient.getContainerClient("test");
     await containerClient.createIfNotExists();
+
+    const queueServiceClient = QueueServiceClient.fromConnectionString(connectionString);
+    await queueServiceClient.createQueue("test-queue");
+
+    const tableClient = TableClient.fromConnectionString(connectionString, "testTable", {
+      allowInsecureConnection: true,
+    });
+    await tableClient.createTable();
   });
 
   it("should be able to enable HTTPS with PEM certificate and key", async () => {

--- a/packages/modules/azurite/src/azurite-container.test.ts
+++ b/packages/modules/azurite/src/azurite-container.test.ts
@@ -3,6 +3,7 @@ import { BlobServiceClient, StorageSharedKeyCredential } from "@azure/storage-bl
 import { QueueServiceClient } from "@azure/storage-queue";
 import fs from "node:fs";
 import path from "node:path";
+import { RandomPortGenerator } from "testcontainers";
 import { getImage } from "../../../testcontainers/src/utils/test-helper";
 import { AzuriteContainer } from "./azurite-container";
 import { createOAuthToken, createTokenCredential, getTlsPipelineOptions } from "./azurite-test-utils";
@@ -98,9 +99,10 @@ describe("AzuriteContainer", { timeout: 240_000 }, () => {
 
   it("should be able to specify custom ports", async () => {
     // customPorts {
-    const blobPort = 13000;
-    const queuePort = 14000;
-    const tablePort = 15000;
+    const portGenerator = new RandomPortGenerator();
+    const blobPort = await portGenerator.generatePort();
+    const queuePort = await portGenerator.generatePort();
+    const tablePort = await portGenerator.generatePort();
 
     await using container = await new AzuriteContainer(IMAGE)
       .withSkipApiVersionCheck()
@@ -115,10 +117,11 @@ describe("AzuriteContainer", { timeout: 240_000 }, () => {
     // }
 
     const connectionString = container.getConnectionString();
-    expect(connectionString).toContain("13000");
-    expect(connectionString).toContain("14000");
-    expect(connectionString).toContain("15000");
+    expect(connectionString).toContain(`:${blobPort}/`);
+    expect(connectionString).toContain(`:${queuePort}/`);
+    expect(connectionString).toContain(`:${tablePort}/`);
 
+    // Exercise each service because Azurite configures their listener ports independently.
     const serviceClient = BlobServiceClient.fromConnectionString(connectionString);
     const containerClient = serviceClient.getContainerClient("test");
     await containerClient.createIfNotExists();

--- a/packages/modules/azurite/src/azurite-container.ts
+++ b/packages/modules/azurite/src/azurite-container.ts
@@ -159,7 +159,20 @@ export class AzuriteContainer extends GenericContainer {
   }
 
   public override async start(): Promise<StartedAzuriteContainer> {
-    const command = ["--blobHost", "0.0.0.0", "--queueHost", "0.0.0.0", "--tableHost", "0.0.0.0"];
+    const command = [
+      "--blobHost",
+      "0.0.0.0",
+      "--blobPort",
+      getContainerPort(this.blobPort).toString(),
+      "--queueHost",
+      "0.0.0.0",
+      "--queuePort",
+      getContainerPort(this.queuePort).toString(),
+      "--tableHost",
+      "0.0.0.0",
+      "--tablePort",
+      getContainerPort(this.tablePort).toString(),
+    ];
 
     if (this.oauthEnabled && this.cert === undefined) {
       throw new Error("OAuth requires HTTPS endpoint. Configure SSL first with withSsl() or withSslPfx().");


### PR DESCRIPTION
## Summary
- pass configured blob, queue, and table container ports to the Azurite CLI
- strengthen the custom-port regression test to use non-default internal ports and perform blob, queue, and table operations

## Verification
- `npm run format`
- `npm run lint`
- `npm run check-compiles`
- `npm test -- packages/modules/azurite/src/azurite-container.test.ts -t "should be able to specify custom ports"`
- `npm test -- packages/modules/azurite/src/azurite-container.test.ts`

## Test results
- Red: with only the regression test change, the focused custom-port test failed with `read ECONNRESET`; Azurite logs showed listeners still bound to `10000`, `10001`, and `10002`.
- Green: after passing `--blobPort`, `--queuePort`, and `--tablePort`, the focused regression passed and the complete Azurite module suite passed (`9 passed`).

## Compatibility
This is a backward-compatible bug fix. Default service ports remain unchanged, while explicitly configured service ports now take effect inside the Azurite container.