### PR TITLE
Fix Redis and Valkey initial data handling

### DIFF
--- a/packages/modules/redis/package.json
+++ b/packages/modules/redis/package.json
@@ -26,7 +26,8 @@
   },
   "scripts": {
     "prepack": "shx cp ../../../README.md . && shx cp ../../../LICENSE .",
-    "build": "tsc --project tsconfig.build.json && shx cp src/import.sh build"
+    "build": "tsc --project tsconfig.build.json",
+    "postbuild": "shx cp src/import.sh build"
   },
   "devDependencies": {
     "redis": "^5.12.1"

--- a/packages/modules/redis/package.json
+++ b/packages/modules/redis/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "prepack": "shx cp ../../../README.md . && shx cp ../../../LICENSE .",
-    "build": "tsc --project tsconfig.build.json"
+    "build": "tsc --project tsconfig.build.json && shx cp src/import.sh build"
   },
   "devDependencies": {
     "redis": "^5.12.1"

--- a/packages/modules/redis/src/initCount.redis
+++ b/packages/modules/redis/src/initCount.redis
@@ -1,0 +1,1 @@
+INCR "import-count"

--- a/packages/modules/redis/src/redis-container.test.ts
+++ b/packages/modules/redis/src/redis-container.test.ts
@@ -77,6 +77,19 @@ describe("RedisContainer", { timeout: 240_000 }, () => {
     // }
   });
 
+  it("should load initial data once", async () => {
+    await using container = await new RedisContainer(IMAGE)
+      .withInitialData(path.join(__dirname, "initCount.redis"))
+      .start();
+
+    const client = createClient({ url: container.getConnectionUrl() });
+    await client.connect();
+
+    expect(await client.get("import-count")).toBe("1");
+
+    client.destroy();
+  });
+
   it("should start with credentials and login", async () => {
     // redisStartWithCredentials {
     const password = "testPassword";

--- a/packages/modules/redis/src/redis-container.ts
+++ b/packages/modules/redis/src/redis-container.ts
@@ -78,7 +78,6 @@ export class RedisContainer extends GenericContainer {
       ]);
     }
     const startedRedisContainer = new StartedRedisContainer(await super.start(), this.password);
-    if (this.initialImportScriptFile) await this.importInitialData(startedRedisContainer);
     return startedRedisContainer;
   }
 

--- a/packages/modules/valkey/package.json
+++ b/packages/modules/valkey/package.json
@@ -26,7 +26,8 @@
   },
   "scripts": {
     "prepack": "shx cp ../../../README.md . && shx cp ../../../LICENSE .",
-    "build": "tsc --project tsconfig.build.json && shx cp src/import.sh build"
+    "build": "tsc --project tsconfig.build.json",
+    "postbuild": "shx cp src/import.sh build"
   },
   "devDependencies": {
     "redis": "^5.12.1"

--- a/packages/modules/valkey/package.json
+++ b/packages/modules/valkey/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "prepack": "shx cp ../../../README.md . && shx cp ../../../LICENSE .",
-    "build": "tsc --project tsconfig.build.json"
+    "build": "tsc --project tsconfig.build.json && shx cp src/import.sh build"
   },
   "devDependencies": {
     "redis": "^5.12.1"


### PR DESCRIPTION
## Summary
- copy Redis and Valkey `import.sh` runtime helpers into `build` as part of each workspace build
- remove the duplicate Redis initial-data import after startup
- add a Redis regression test proving an initial-data script is executed once

## Verification
- `npm test -- packages/modules/redis/src/redis-container.test.ts -t "should load initial data once"`
- `npm run build -w @testcontainers/redis`
- `npm run build -w @testcontainers/valkey`
- `npm test -- packages/modules/redis/src/redis-container.test.ts packages/modules/valkey/src/valkey-container.test.ts`
- `npm run check-compiles`
- `npm_config_cache=/private/tmp/testcontainers-node-npm-cache npm pack --dry-run --json --workspace @testcontainers/redis`
- `npm_config_cache=/private/tmp/testcontainers-node-npm-cache npm pack --dry-run --json --workspace @testcontainers/valkey`
- `npm run format`
- `npm run lint`
- `git diff --check`

## Test results
- Red: the new Redis regression returned `"2"` instead of `"1"`, confirming startup imported the initial-data script twice.
- Red: clean Redis and Valkey workspace builds left both `build/import.sh` files absent.
- Green: the focused Redis regression passed after removing the duplicate import.
- Green: clean workspace builds recreated both `build/import.sh` files, and local `npm pack --dry-run` output listed the helper in both package archives.
- Green: the complete Redis and Valkey module suites passed (`19 passed`).

## Compatibility
This is a backward-compatible bug fix. Existing initial-data APIs are unchanged. Redis now executes initial data once as intended, and packaged Redis and Valkey modules include the runtime helper required by that feature.

No `npm publish` command was run.