### PR TITLE
Fix Couchbase service configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16931,7 +16931,8 @@
         "testcontainers": "^12.0.1"
       },
       "devDependencies": {
-        "couchbase": "^4.7.0"
+        "couchbase": "^4.7.0",
+        "get-port": "^7.2.0"
       }
     },
     "packages/modules/couchdb": {

--- a/packages/modules/couchbase/package.json
+++ b/packages/modules/couchbase/package.json
@@ -32,6 +32,7 @@
     "testcontainers": "^12.0.1"
   },
   "devDependencies": {
-    "couchbase": "^4.7.0"
+    "couchbase": "^4.7.0",
+    "get-port": "^7.2.0"
   }
 }

--- a/packages/modules/couchbase/src/couchbase-container.test.ts
+++ b/packages/modules/couchbase/src/couchbase-container.test.ts
@@ -86,4 +86,32 @@ describe("CouchbaseContainer", { timeout: 180_000 }, () => {
       "The Eventing Service is only supported with the Enterprise version"
     );
   });
+
+  it("should start with analytics service enabled", async () => {
+    await using container = await new CouchbaseContainer(ENTERPRISE_IMAGE)
+      .withEnabledServices(CouchbaseService.KV, CouchbaseService.ANALYTICS)
+      .start();
+
+    expect(container.getConnectionString()).toContain("couchbase://");
+  });
+
+  it("should create and use a bucket with KV service only", async () => {
+    const bucketDefinition = new BucketDefinition("kvbucket").withPrimaryIndex(false);
+    await using container = await new CouchbaseContainer(COMMUNITY_IMAGE)
+      .withEnabledServices(CouchbaseService.KV)
+      .withBucket(bucketDefinition)
+      .withStartupTimeout(30_000)
+      .start();
+
+    const cluster = await couchbase.Cluster.connect(container.getConnectionString(), {
+      username: container.getUsername(),
+      password: container.getPassword(),
+    });
+
+    const coll = cluster.bucket(bucketDefinition.getName()).defaultCollection();
+    await coll.upsert("testdoc", { foo: "bar" });
+    expect((await coll.get("testdoc")).content).toEqual({ foo: "bar" });
+
+    await cluster.close();
+  });
 });

--- a/packages/modules/couchbase/src/couchbase-container.test.ts
+++ b/packages/modules/couchbase/src/couchbase-container.test.ts
@@ -1,8 +1,10 @@
 import couchbase, { Bucket, Cluster } from "couchbase";
+import getPort from "get-port";
 import { getImage } from "../../../testcontainers/src/utils/test-helper";
 import { BucketDefinition } from "./bucket-definition";
 import { CouchbaseContainer } from "./couchbase-container";
 import { CouchbaseService } from "./couchbase-service";
+import PORTS from "./ports";
 
 const ENTERPRISE_IMAGE = getImage(__dirname, 0);
 const COMMUNITY_IMAGE = getImage(__dirname, 1);
@@ -113,5 +115,15 @@ describe("CouchbaseContainer", { timeout: 180_000 }, () => {
     expect((await coll.get("testdoc")).content).toEqual({ foo: "bar" });
 
     await cluster.close();
+  });
+
+  it("should preserve fixed host port binding", async () => {
+    const hostPort = await getPort();
+    await using container = await new CouchbaseContainer(COMMUNITY_IMAGE)
+      .withEnabledServices(CouchbaseService.KV)
+      .withExposedPorts({ container: PORTS.MGMT_PORT, host: hostPort })
+      .start();
+
+    expect(container.getMappedPort(PORTS.MGMT_PORT)).toBe(hostPort);
   });
 });

--- a/packages/modules/couchbase/src/couchbase-container.ts
+++ b/packages/modules/couchbase/src/couchbase-container.ts
@@ -572,7 +572,8 @@ export class CouchbaseContainer extends GenericContainer {
   }
 
   public override async start(): Promise<StartedCouchbaseContainer> {
-    this.withExposedPorts(...this.getPortsToExpose());
+    const exposedPorts = this.createOpts.ExposedPorts ?? {};
+    this.withExposedPorts(...this.getPortsToExpose().filter((port) => exposedPorts[`${port}/tcp`] === undefined));
     return new StartedCouchbaseContainer(await super.start(), this.username, this.password);
   }
 }

--- a/packages/modules/couchbase/src/couchbase-container.ts
+++ b/packages/modules/couchbase/src/couchbase-container.ts
@@ -34,9 +34,7 @@ export class CouchbaseContainer extends GenericContainer {
 
   constructor(image: string) {
     super(image);
-    this.withExposedPorts(...this.getPortsToExpose()).withWaitStrategy(
-      Wait.forLogMessage("Starting Couchbase Server -- Web UI available at http://<ip>:8091")
-    );
+    this.withWaitStrategy(Wait.forLogMessage("Starting Couchbase Server -- Web UI available at http://<ip>:8091"));
   }
 
   withCredentials(username: string, password: string) {
@@ -427,7 +425,7 @@ export class CouchbaseContainer extends GenericContainer {
           BoundPorts.fromInspectResult(client.info.containerRuntime.hostIps, inspectResult)
         );
 
-      if (this.enabledServices.has(CouchbaseService.KV)) {
+      if (this.enabledServices.has(CouchbaseService.QUERY)) {
         await new IntervalRetry<Response | undefined, Error>(1000).retryUntil(
           async () => {
             try {
@@ -574,6 +572,7 @@ export class CouchbaseContainer extends GenericContainer {
   }
 
   public override async start(): Promise<StartedCouchbaseContainer> {
+    this.withExposedPorts(...this.getPortsToExpose());
     return new StartedCouchbaseContainer(await super.start(), this.username, this.password);
   }
 }

--- a/packages/modules/couchbase/src/couchbase-container.ts
+++ b/packages/modules/couchbase/src/couchbase-container.ts
@@ -118,7 +118,7 @@ export class CouchbaseContainer extends GenericContainer {
     if (this.enabledServices.has(CouchbaseService.EVENTING)) {
       exposedPorts.push(PORTS.EVENTING_PORT, PORTS.EVENTING_SSL_PORT);
     }
-    return exposedPorts;
+    return exposedPorts.filter((port) => !this.hasExposedPort(port));
   }
 
   private constructWaitStrategies() {
@@ -572,8 +572,7 @@ export class CouchbaseContainer extends GenericContainer {
   }
 
   public override async start(): Promise<StartedCouchbaseContainer> {
-    const exposedPorts = this.createOpts.ExposedPorts ?? {};
-    this.withExposedPorts(...this.getPortsToExpose().filter((port) => exposedPorts[`${port}/tcp`] === undefined));
+    this.withExposedPorts(...this.getPortsToExpose());
     return new StartedCouchbaseContainer(await super.start(), this.username, this.password);
   }
 }

--- a/packages/testcontainers/src/generic-container/generic-container.ts
+++ b/packages/testcontainers/src/generic-container/generic-container.ts
@@ -425,6 +425,13 @@ export class GenericContainer implements TestContainer {
     return this;
   }
 
+  protected hasExposedPort(port: PortWithOptionalBinding): boolean {
+    const containerPort = getContainerPort(port);
+    const protocol = getProtocol(port);
+
+    return Object.hasOwn(this.createOpts.ExposedPorts ?? {}, `${containerPort}/${protocol}`);
+  }
+
   public withBindMounts(bindMounts: BindMount[]): this {
     this.hostConfig.Binds = bindMounts
       .map((bindMount) => ({ mode: "rw", ...bindMount }))


### PR DESCRIPTION
## Summary
- expose Couchbase service ports at startup after builder customization is complete
- poll Query readiness for bucket creation only when the Query service is enabled
- add observable regressions for Enterprise Analytics startup and KV-only bucket usage

## Verification
- `npm test -- packages/modules/couchbase/src/couchbase-container.test.ts -t "should start with analytics service enabled"`
- `npm test -- packages/modules/couchbase/src/couchbase-container.test.ts -t "should create and use a bucket with KV service only"`
- `npm run format`
- `npm run lint`
- `npm run check-compiles`
- `git diff --check`

## Test results
- Red: Enterprise Analytics startup failed with `No port binding found for :8095/tcp` because optional service ports were selected before builder customization.
- Red: KV-only bucket startup timed out on `/query/service` after `30000ms` because the Query readiness poll was guarded by KV instead of Query.
- Green: both focused Docker-backed regressions passed concurrently after the fix.

## Full Couchbase suite note
A local full concurrent run started all eight Couchbase integration cases together and hit existing Couchbase bootstrap contention: Enterprise cases failed during rebalance and with a closed socket. The focused regressions were rerun concurrently and passed. No suite-level serialization change is included.

## Compatibility
This is a backward-compatible bug fix. Existing builder APIs are unchanged. Configured optional services now expose their required ports, and KV-only configurations no longer require the Query service.