### PR TITLE
Copy Redpanda runtime assets during build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,6 @@ It captures practical rules that prevent avoidable CI and PR churn.
 - Tests should verify observable behavior changes, not only internal/config state.
   - Example: for a security option, assert a real secure/insecure behavior difference.
 - Test-only helper files under `src` (for example `*-test-utils.ts`) must be explicitly excluded from package `tsconfig.build.json` so they are not emitted into `build` and accidentally published.
-- Runtime assets required by compiled code must be copied during the normal build lifecycle, not only during `prepack`, so local workspace builds produce usable output.
 - For substantial changes to GitHub Actions, runner images, Node/npm versions, or release/publish automation, consider running the manual `Node.js Package` workflow as a dry-run publish sanity check.
   - Select the PR branch as the workflow ref to test publish workflow changes before merging.
   - Use a representative version input, for example the next planned semver.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ It captures practical rules that prevent avoidable CI and PR churn.
 - Tests should verify observable behavior changes, not only internal/config state.
   - Example: for a security option, assert a real secure/insecure behavior difference.
 - Test-only helper files under `src` (for example `*-test-utils.ts`) must be explicitly excluded from package `tsconfig.build.json` so they are not emitted into `build` and accidentally published.
+- Runtime assets required by compiled code must be copied during the normal build lifecycle, not only during `prepack`, so local workspace builds produce usable output.
 - For substantial changes to GitHub Actions, runner images, Node/npm versions, or release/publish automation, consider running the manual `Node.js Package` workflow as a dry-run publish sanity check.
   - Select the PR branch as the workflow ref to test publish workflow changes before merging.
   - Use a representative version input, for example the next planned semver.

--- a/packages/modules/redpanda/package.json
+++ b/packages/modules/redpanda/package.json
@@ -25,8 +25,9 @@
     "access": "public"
   },
   "scripts": {
-    "prepack": "shx cp ../../../README.md . && shx cp ../../../LICENSE . && shx cp -r src/assets build",
-    "build": "tsc --project tsconfig.build.json"
+    "prepack": "shx cp ../../../README.md . && shx cp ../../../LICENSE .",
+    "build": "tsc --project tsconfig.build.json",
+    "postbuild": "shx cp -r src/assets build"
   },
   "dependencies": {
     "handlebars": "^4.7.9",


### PR DESCRIPTION
## Summary
- copy Redpanda runtime assets during `postbuild` so normal workspace builds produce usable output
- keep `prepack` focused on package metadata files
- document that runtime assets required by compiled code must be copied during the normal build lifecycle

## Verification
- `npm run build --ignore-scripts --workspace packages/testcontainers -- --project tsconfig.json`
- `npm run build --ignore-scripts --workspace packages/modules/redpanda -- --project tsconfig.json --noEmit`
- `npm run build --workspace packages/modules/redpanda`
- `npm_config_cache=/private/tmp/testcontainers-node-npm-cache npm pack --dry-run --json --workspace @testcontainers/redpanda`
- `npm test -- packages/modules/redpanda/src/redpanda-container.test.ts`
- `npm run format`
- `npm run lint`
- `npm run check-compiles`
- `git diff --check`

## Test results
- Red: a normal Redpanda workspace build left `build/assets` absent before this change.
- Green: a normal Redpanda workspace build now creates `build/assets/bootstrap.yaml` and `build/assets/redpanda.yaml.hbs`.
- Green: the compile-only invocation keeps CI-provided flags attached to `tsc` and does not run `postbuild`.
- Green: the dry-run package archive includes both runtime assets.
- Green: the focused Redpanda suite passed (`4 passed`).

## Compatibility
This is a backward-compatible bug fix. The public API is unchanged. Published packages retain the same runtime assets, while local workspace builds now produce the complete runtime output without relying on `prepack`.