### PR TITLE
Bump testcontainers/sshd image from 1.3.0 to 1.4.0

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,7 +42,7 @@ Configuration of Testcontainers and its behaviours:
 | TESTCONTAINERS_SSHD_PORT                 | 65515                      | Set SSHd host port (not recommended)                     |
 | TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX     | mycompany.com/registry     | Set default image registry                               |
 | RYUK_CONTAINER_IMAGE                     | testcontainers/ryuk:0.14.0 | Custom image for ryuk                                    |
-| SSHD_CONTAINER_IMAGE                     | testcontainers/sshd:1.3.0  | Custom image for SSHd                                    |
+| SSHD_CONTAINER_IMAGE                     | testcontainers/sshd:1.4.0  | Custom image for SSHd                                    |
 | TESTCONTAINERS_REUSE_ENABLE              | true                       | Enable reusable containers                               |
 | TESTCONTAINERS_RYUK_VERBOSE              | true                       | Sets RYUK_VERBOSE env var in ryuk container              |
 | TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT | 30s                        | Sets RYUK_RECONNECTION_TIMEOUT env var in ryuk container |

--- a/packages/testcontainers/src/port-forwarder/port-forwarder.ts
+++ b/packages/testcontainers/src/port-forwarder/port-forwarder.ts
@@ -9,7 +9,7 @@ import { PortWithOptionalBinding } from "../utils/port";
 
 export const SSHD_IMAGE = process.env["SSHD_CONTAINER_IMAGE"]
   ? ImageName.fromString(process.env["SSHD_CONTAINER_IMAGE"]).string
-  : ImageName.fromString("testcontainers/sshd:1.3.0").string;
+  : ImageName.fromString("testcontainers/sshd:1.4.0").string;
 
 class PortForwarder {
   constructor(


### PR DESCRIPTION
Bumps the default `testcontainers/sshd` image from `1.3.0` to `1.4.0` in `packages/testcontainers/src/port-forwarder/port-forwarder.ts`.

**What's new in 1.4.0:**
- Base image updated to Alpine 3.23
- `AddressFamily any` added to the sshd config (fixes SSH connections on dual-stack hosts)

**Verification:**

Tests found:
- `packages/testcontainers/src/port-forwarder/port-forwarder.test.ts` (3 tests)
- `packages/testcontainers/src/port-forwarder/port-forwarder-reuse.test.ts` (2 tests)

Tests were run locally. All 5 failed due to sandbox networking constraints (`host.testcontainers.internal` unreachable from inside containers in the local environment) — the same failures occur with `1.3.0` via `SSHD_CONTAINER_IMAGE=testcontainers/sshd:1.3.0`. The `testcontainers/sshd:1.4.0` image was confirmed available on Docker Hub and was successfully pulled during test runs.

Not a breaking change — only the default image tag is updated; users can still override via `SSHD_CONTAINER_IMAGE`.
