### PR TITLE
Use Couchbase SDK readiness waits in tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1765,9 +1765,9 @@
       }
     },
     "node_modules/@couchbase/couchbase-darwin-arm64-napi": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-darwin-arm64-napi/-/couchbase-darwin-arm64-napi-4.7.0.tgz",
-      "integrity": "sha512-GSojqk4zMc39RmrKdjM5N9ovFr8kkzhBTsf70EV+I/iSEjks4woUiKwMi9pm7rgV+nx94rb+WnPLAwwUD22hxQ==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-darwin-arm64-napi/-/couchbase-darwin-arm64-napi-4.7.1.tgz",
+      "integrity": "sha512-vHKbnh00YQLwl306bF6vQ1UvR09B5bPqkJ8BcFEGE8vPaSYZSy6a0BNdq/8+FctFdg29xcP+qsCeihwVvBZfaQ==",
       "cpu": [
         "arm64"
       ],
@@ -1782,9 +1782,9 @@
       }
     },
     "node_modules/@couchbase/couchbase-darwin-x64-napi": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-darwin-x64-napi/-/couchbase-darwin-x64-napi-4.7.0.tgz",
-      "integrity": "sha512-k2N26gl45RbaTN05pGuYCgQhcN++UMqst1JvjU360SvRy7KJeUBvm5IiPWRnASoGvwOYCifR2hR8vfpqhMwNEA==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-darwin-x64-napi/-/couchbase-darwin-x64-napi-4.7.1.tgz",
+      "integrity": "sha512-IOpfVxJ9mwgEaPz6Pu2tBS7hTwnvpxmU2GBITY5toCNIuTjx2io8K+bNIO6YeFang/UZdP7tE+3TUkAokuSoBw==",
       "cpu": [
         "x64"
       ],
@@ -1799,9 +1799,9 @@
       }
     },
     "node_modules/@couchbase/couchbase-linux-arm64-napi": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-linux-arm64-napi/-/couchbase-linux-arm64-napi-4.7.0.tgz",
-      "integrity": "sha512-UA2b1ptgbDVIzWo/NIZMQcleH+NEnhlnRYg1BvpfhVB8MM5yV6qy6VxrIkw9Q88GncSBEzdu8lrQZ/sG/DP0ug==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-linux-arm64-napi/-/couchbase-linux-arm64-napi-4.7.1.tgz",
+      "integrity": "sha512-yDzTzDCZ19ANT3ujgyctkERjGY0WNaHKEW85jbLuc9W8eg40fMccdDkTUFCnbSqgHz8xNBa1YahrWOjr4sHJPw==",
       "cpu": [
         "arm64"
       ],
@@ -1816,9 +1816,9 @@
       }
     },
     "node_modules/@couchbase/couchbase-linux-x64-napi": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-linux-x64-napi/-/couchbase-linux-x64-napi-4.7.0.tgz",
-      "integrity": "sha512-7l/mB9DxIX+3++MJ58eIoioD+07sOYzoqjMyKt9W4PHZmWA7yfscBOIsGqArxq9OtDzKbCqiOl+njRc8Xe4KRQ==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-linux-x64-napi/-/couchbase-linux-x64-napi-4.7.1.tgz",
+      "integrity": "sha512-91b4xA3Rii8AwzmaoIvw42mUiELSBzXTTx8oGkuV4S1ISKdy7yzXw4O1AO6ru/X3u8vcmaw2/2fE9bLj17Teqw==",
       "cpu": [
         "x64"
       ],
@@ -1833,9 +1833,9 @@
       }
     },
     "node_modules/@couchbase/couchbase-linuxmusl-arm64-napi": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-linuxmusl-arm64-napi/-/couchbase-linuxmusl-arm64-napi-4.7.0.tgz",
-      "integrity": "sha512-HSgq5l/TxG6Q0wLGaECBZt0AUO2bJ73JYYPoTeHE+PL6j+tTU6/37czVVkppCS6EIVnU0+HMez/kqdytFD0Jyg==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-linuxmusl-arm64-napi/-/couchbase-linuxmusl-arm64-napi-4.7.1.tgz",
+      "integrity": "sha512-ee7GavI/XXXh0ySwPAiySRraxK5JZksOcsPB45hvIlfD2T+dACaO1jDML85dwzciOW7+PTf/+xtBxAfJuOCLrA==",
       "cpu": [
         "arm64"
       ],
@@ -1850,9 +1850,9 @@
       }
     },
     "node_modules/@couchbase/couchbase-linuxmusl-x64-napi": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-linuxmusl-x64-napi/-/couchbase-linuxmusl-x64-napi-4.7.0.tgz",
-      "integrity": "sha512-OaKwuijC/j9OXcfUdjPrH/nJ1+um4iG3921lZkgEF7G5rDryYKEtbamVM4uhqswi63W6u5bQEGNsI0xTEAE2gw==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-linuxmusl-x64-napi/-/couchbase-linuxmusl-x64-napi-4.7.1.tgz",
+      "integrity": "sha512-o0RTbs3vLMZKge3W7fcMTTMTbfZCogV1Gye8xsN/Yt3Fl4jIWlzqGeeXOCR9pcc3HAR/I5jBY+IGo74D52+KUA==",
       "cpu": [
         "x64"
       ],
@@ -1867,9 +1867,9 @@
       }
     },
     "node_modules/@couchbase/couchbase-win32-x64-napi": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-win32-x64-napi/-/couchbase-win32-x64-napi-4.7.0.tgz",
-      "integrity": "sha512-gtvcCJ1mUVVJMxs7heDvS8mtGCNrRmbAJdsSTKQe6UUlEpcvbq4Tp4/z77cqqAweE9YGIGSHPCSpOtMHbtegxA==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-win32-x64-napi/-/couchbase-win32-x64-napi-4.7.1.tgz",
+      "integrity": "sha512-qE3Y364oGlQnbOaLURakpg6+xEMqQrrozBq0IKmWveUZ83iiBzghenUrRdPMZIXbhQ/LNnnzv5U7HIXpL2c56Q==",
       "cpu": [
         "x64"
       ],
@@ -8083,9 +8083,9 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/couchbase": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/couchbase/-/couchbase-4.7.0.tgz",
-      "integrity": "sha512-0qfuZVpDiP4oaSpWt/GQURlXTWKQVopqK0VxstTpjjQVFO0ZsbpFpG0ghAdJFWbeZV64B7+07fk4Xe2cWvlfLA==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/couchbase/-/couchbase-4.7.1.tgz",
+      "integrity": "sha512-KVryIxsBY55rc0k1G2camniXVX/55RiU1TwWWN7j2e56X42vm7vQynkdOv6jkItmIpekZc3BjZchw0HffX0rPA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -8099,13 +8099,13 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@couchbase/couchbase-darwin-arm64-napi": "4.7.0",
-        "@couchbase/couchbase-darwin-x64-napi": "4.7.0",
-        "@couchbase/couchbase-linux-arm64-napi": "4.7.0",
-        "@couchbase/couchbase-linux-x64-napi": "4.7.0",
-        "@couchbase/couchbase-linuxmusl-arm64-napi": "4.7.0",
-        "@couchbase/couchbase-linuxmusl-x64-napi": "4.7.0",
-        "@couchbase/couchbase-win32-x64-napi": "4.7.0"
+        "@couchbase/couchbase-darwin-arm64-napi": "4.7.1",
+        "@couchbase/couchbase-darwin-x64-napi": "4.7.1",
+        "@couchbase/couchbase-linux-arm64-napi": "4.7.1",
+        "@couchbase/couchbase-linux-x64-napi": "4.7.1",
+        "@couchbase/couchbase-linuxmusl-arm64-napi": "4.7.1",
+        "@couchbase/couchbase-linuxmusl-x64-napi": "4.7.1",
+        "@couchbase/couchbase-win32-x64-napi": "4.7.1"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
@@ -16979,7 +16979,7 @@
         "testcontainers": "^12.0.2"
       },
       "devDependencies": {
-        "couchbase": "^4.7.0",
+        "couchbase": "^4.7.1",
         "get-port": "^7.2.0"
       }
     },

--- a/packages/modules/couchbase/package.json
+++ b/packages/modules/couchbase/package.json
@@ -32,7 +32,7 @@
     "testcontainers": "^12.0.2"
   },
   "devDependencies": {
-    "couchbase": "^4.7.0",
+    "couchbase": "^4.7.1",
     "get-port": "^7.2.0"
   }
 }

--- a/packages/modules/couchbase/src/couchbase-container.test.ts
+++ b/packages/modules/couchbase/src/couchbase-container.test.ts
@@ -32,6 +32,9 @@ describe("CouchbaseContainer", { timeout: 180_000 }, () => {
     });
 
     const bucket = cluster.bucket(bucketDefinition.getName());
+    await bucket.waitUntilReady(10_000, {
+      serviceTypes: [couchbase.ServiceType.KeyValue],
+    });
 
     const coll = bucket.defaultCollection();
     await coll.upsert("testdoc", { foo: "bar" });
@@ -56,6 +59,10 @@ describe("CouchbaseContainer", { timeout: 180_000 }, () => {
       });
 
       const bucket = cluster.bucket(bucketDefinition.getName());
+      await bucket.waitUntilReady(10_000, {
+        serviceTypes: [couchbase.ServiceType.KeyValue],
+      });
+
       const coll = bucket.defaultCollection();
 
       await coll.upsert("testdoc", { foo: "bar" });
@@ -110,7 +117,12 @@ describe("CouchbaseContainer", { timeout: 180_000 }, () => {
       password: container.getPassword(),
     });
 
-    const coll = cluster.bucket(bucketDefinition.getName()).defaultCollection();
+    const bucket = cluster.bucket(bucketDefinition.getName());
+    await bucket.waitUntilReady(10_000, {
+      serviceTypes: [couchbase.ServiceType.KeyValue],
+    });
+
+    const coll = bucket.defaultCollection();
     await coll.upsert("testdoc", { foo: "bar" });
     expect((await coll.get("testdoc")).content).toEqual({ foo: "bar" });
 


### PR DESCRIPTION
## Summary

- update the Couchbase SDK dev dependency from 4.7.0 to 4.7.1
- wait for bucket KV readiness before SDK KV operations in Couchbase tests
- update the docs-backed connect/query example to show the same readiness pattern

## Verification

- `npm run format`
- `npm run lint`
- `npm run check-compiles`
- `npm run test -- packages/modules/couchbase/src/couchbase-container.test.ts -t "should create and use a bucket with KV service only"`

## Test results

The focused KV-only Couchbase test passes. A full sequential Couchbase test-file run reached 8/9 passing locally; the remaining failure was a Docker port-bind timeout before Couchbase startup logic, not a failure in the SDK readiness path.

## Breaking change evidence

This is not breaking. The change updates a test-only dev dependency and test/example code only; it does not change the published module API or runtime behavior.
