### PR TITLE
Ignore archiver major updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,14 @@ updates:
       dependencies:
         patterns:
           - "*"
+    ignore:
+      # archiver v8 is ESM-only; keep CommonJS-compatible major versions.
+      - dependency-name: "archiver"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "@types/archiver"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "docker"
     directories:


### PR DESCRIPTION
## Summary

- Ignore semver-major Dependabot updates for `archiver` and `@types/archiver`.
- Keep Dependabot free to propose compatible non-major updates.

## Verification

- `git diff --check`

## Test results

- No runtime tests run; this is a config-only Dependabot change.

## Breaking change evidence

- No package code or public API changes were made, so this is not a breaking change.