### PR TITLE
Remove ESM-only get-port dependency path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,10 @@ updates:
       - dependency-name: "@types/archiver"
         update-types:
           - "version-update:semver-major"
+      # get-port v6+ is ESM-only; keep CommonJS-compatible major versions.
+      - dependency-name: "get-port"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "docker"
     directories:

--- a/docs/modules/chromadb.md
+++ b/docs/modules/chromadb.md
@@ -18,10 +18,6 @@ These examples use the following libraries:
 
         npm install @chroma-core/default-embed
 
-- [@chroma-core/ollama](https://www.npmjs.com/package/@chroma-core/ollama)
-
-        npm install @chroma-core/ollama
-
 Choose an image from the [container registry](https://hub.docker.com/r/chromadb/chroma) and substitute `IMAGE`.
 
 ### Execute a query

--- a/package-lock.json
+++ b/package-lock.json
@@ -1640,89 +1640,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/@chroma-core/ollama": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@chroma-core/ollama/-/ollama-0.1.8.tgz",
-      "integrity": "sha512-hVVGy1zcDnZ8g4dMORoasy1uS2VE09OqsxYupC1kHGsp2eXHpJkpwzhmWlYmH+sVHC4yJ88gyBJkYf0CgHtqRg==",
-      "dev": true,
-      "dependencies": {
-        "@chroma-core/ai-embeddings-common": "^0.1.9",
-        "ollama": "^0.5.15",
-        "testcontainers": "^10.9.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "chromadb": "^3.1.2"
-      }
-    },
-    "node_modules/@chroma-core/ollama/node_modules/@types/dockerode": {
-      "version": "3.3.47",
-      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.47.tgz",
-      "integrity": "sha512-ShM1mz7rCjdssXt7Xz0u1/R2BJC7piWa3SJpUBiVjCf2A3XNn4cP6pUVaD8bLanpPVVn4IKzJuw3dOvkJ8IbYw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/docker-modem": "*",
-        "@types/node": "*",
-        "@types/ssh2": "*"
-      }
-    },
-    "node_modules/@chroma-core/ollama/node_modules/properties-reader": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/properties-reader/-/properties-reader-2.3.0.tgz",
-      "integrity": "sha512-z597WicA7nDZxK12kZqHr2TcvwNU1GCfA5UwfDY/HDp3hXPoPlb5rlEx9bwGTiJnc0OqbBTkU975jDToth8Gxw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mkdirp": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/steveukx/properties?sponsor=1"
-      }
-    },
-    "node_modules/@chroma-core/ollama/node_modules/testcontainers": {
-      "version": "10.28.0",
-      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-10.28.0.tgz",
-      "integrity": "sha512-1fKrRRCsgAQNkarjHCMKzBKXSJFmzNTiTbhb5E/j5hflRXChEtHvkefjaHlgkNUjfw92/Dq8LTgwQn6RDBFbMg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@balena/dockerignore": "^1.0.2",
-        "@types/dockerode": "^3.3.35",
-        "archiver": "^7.0.1",
-        "async-lock": "^1.4.1",
-        "byline": "^5.0.0",
-        "debug": "^4.3.5",
-        "docker-compose": "^0.24.8",
-        "dockerode": "^4.0.5",
-        "get-port": "^7.1.0",
-        "proper-lockfile": "^4.1.2",
-        "properties-reader": "^2.3.0",
-        "ssh-remote-port-forward": "^1.0.4",
-        "tar-fs": "^3.0.7",
-        "tmp": "^0.2.3",
-        "undici": "^5.29.0"
-      }
-    },
-    "node_modules/@chroma-core/ollama/node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
     "node_modules/@clickhouse/client": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/@clickhouse/client/-/client-1.20.0.tgz",
@@ -2126,16 +2043,6 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@firebase/app-check-interop-types": {
@@ -8393,19 +8300,6 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/docker-compose": {
-      "version": "0.24.8",
-      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.8.tgz",
-      "integrity": "sha512-plizRs/Vf15H+GCVxq2EUvyPK7ei9b/cVesHvjnX4xaXjM9spHe2Ytq0BitndFgvTJ3E3NljPNUEl7BAN43iZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "yaml": "^2.2.2"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/docker-modem": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.7.tgz",
@@ -8419,76 +8313,6 @@
       },
       "engines": {
         "node": ">= 8.0"
-      }
-    },
-    "node_modules/dockerode": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.12.tgz",
-      "integrity": "sha512-/bCZd6KlGcjZO8Buqmi/vXuqEGVEZ0PNjx/biBNqJD3MhK9DmdiAuKxqfNhflgDESDIiBz3qF+0e55+CpnrUcw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@balena/dockerignore": "^1.0.2",
-        "@grpc/grpc-js": "^1.11.1",
-        "@grpc/proto-loader": "^0.7.13",
-        "docker-modem": "^5.0.7",
-        "protobufjs": "^7.3.2",
-        "tar-fs": "^2.1.4",
-        "uuid": "^10.0.0"
-      },
-      "engines": {
-        "node": ">= 8.0"
-      }
-    },
-    "node_modules/dockerode/node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/dockerode/node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/dockerode/node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/dockerode/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/dunder-proto": {
@@ -9971,18 +9795,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-port": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.2.0.tgz",
-      "integrity": "sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-proto": {
@@ -12378,18 +12190,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -13161,16 +12961,6 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
-    },
-    "node_modules/ollama": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/ollama/-/ollama-0.5.16.tgz",
-      "integrity": "sha512-OEbxxOIUZtdZgOaTPAULo051F5y+Z1vosxEYOoABPnQKeW7i4O8tJNlxCB+xioyoorVqgjkdj+TA1f1Hy2ug/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-fetch": "^3.6.20"
-      }
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -16339,12 +16129,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.20",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
-      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
-      "dev": true
-    },
     "node_modules/whatwg-url": {
       "version": "14.2.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
@@ -16878,7 +16662,6 @@
       },
       "devDependencies": {
         "@chroma-core/default-embed": "^0.1.9",
-        "@chroma-core/ollama": "^0.1.8",
         "chromadb": "^3.4.3"
       }
     },
@@ -16914,7 +16697,20 @@
       },
       "devDependencies": {
         "couchbase": "^4.7.1",
-        "get-port": "^7.2.0"
+        "get-port": "^5.1.1"
+      }
+    },
+    "packages/modules/couchbase/node_modules/get-port": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/modules/couchdb": {
@@ -17264,30 +17060,6 @@
         "toxiproxy-node-client": "^4.1.0"
       }
     },
-    "packages/modules/toxiproxy/node_modules/@testcontainers/redis/node_modules/testcontainers": {
-      "version": "10.28.0",
-      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-10.28.0.tgz",
-      "integrity": "sha512-1fKrRRCsgAQNkarjHCMKzBKXSJFmzNTiTbhb5E/j5hflRXChEtHvkefjaHlgkNUjfw92/Dq8LTgwQn6RDBFbMg==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@balena/dockerignore": "^1.0.2",
-        "@types/dockerode": "^3.3.35",
-        "archiver": "^7.0.1",
-        "async-lock": "^1.4.1",
-        "byline": "^5.0.0",
-        "debug": "^4.3.5",
-        "docker-compose": "^0.24.8",
-        "dockerode": "^4.0.5",
-        "get-port": "^7.1.0",
-        "proper-lockfile": "^4.1.2",
-        "properties-reader": "^2.3.0",
-        "ssh-remote-port-forward": "^1.0.4",
-        "tar-fs": "^3.0.7",
-        "tmp": "^0.2.3",
-        "undici": "^5.29.0"
-      }
-    },
     "packages/modules/valkey": {
       "name": "@testcontainers/valkey",
       "version": "12.0.3",
@@ -17333,7 +17105,7 @@
         "debug": "^4.4.3",
         "docker-compose": "^1.4.2",
         "dockerode": "^5.0.0",
-        "get-port": "^7.2.0",
+        "get-port": "^5.1.1",
         "proper-lockfile": "^4.1.2",
         "properties-reader": "^3.0.1",
         "ssh-remote-port-forward": "^1.0.4",
@@ -17423,6 +17195,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "packages/testcontainers/node_modules/get-port": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/testcontainers/node_modules/undici": {

--- a/packages/modules/chromadb/package.json
+++ b/packages/modules/chromadb/package.json
@@ -30,7 +30,6 @@
   },
   "devDependencies": {
     "@chroma-core/default-embed": "^0.1.9",
-    "@chroma-core/ollama": "^0.1.8",
     "chromadb": "^3.4.3"
   },
   "dependencies": {

--- a/packages/modules/chromadb/src/chromadb-container.test.ts
+++ b/packages/modules/chromadb/src/chromadb-container.test.ts
@@ -1,5 +1,4 @@
-import { OllamaEmbeddingFunction } from "@chroma-core/ollama";
-import { AdminClient, ChromaClient } from "chromadb";
+import { AdminClient, ChromaClient, type EmbeddingFunction } from "chromadb";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -41,10 +40,24 @@ describe("ChromaDBContainer", { timeout: 360_000 }, () => {
     await using ollama = await new GenericContainer(OLLAMA_IMAGE).withExposedPorts(11434).start();
     await ollama.exec(["ollama", "pull", "nomic-embed-text"]);
     const client = new ChromaClient({ ssl: false, host: container.getHost(), port: container.getMappedPort(8000) });
-    const embedder = new OllamaEmbeddingFunction({
-      url: `http://${ollama.getHost()}:${ollama.getMappedPort(11434)}`,
-      model: "nomic-embed-text",
-    });
+    const ollamaUrl = `http://${ollama.getHost()}:${ollama.getMappedPort(11434)}`;
+    const embedder: EmbeddingFunction = {
+      name: "ollama",
+      defaultSpace: () => "cosine",
+      supportedSpaces: () => ["cosine", "l2", "ip"],
+      generate: async (texts) => {
+        const response = await fetch(`${ollamaUrl}/api/embed`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ model: "nomic-embed-text", input: texts }),
+        });
+        if (!response.ok) {
+          throw new Error(`Failed to generate embeddings: ${response.status} ${response.statusText}`);
+        }
+        const result = (await response.json()) as { embeddings: number[][] };
+        return result.embeddings;
+      },
+    };
 
     const collection = await client.createCollection({
       name: "test",

--- a/packages/modules/couchbase/package.json
+++ b/packages/modules/couchbase/package.json
@@ -33,6 +33,6 @@
   },
   "devDependencies": {
     "couchbase": "^4.7.1",
-    "get-port": "^7.2.0"
+    "get-port": "^5.1.1"
   }
 }

--- a/packages/testcontainers/package.json
+++ b/packages/testcontainers/package.json
@@ -38,7 +38,7 @@
     "debug": "^4.4.3",
     "docker-compose": "^1.4.2",
     "dockerode": "^5.0.0",
-    "get-port": "^7.2.0",
+    "get-port": "^5.1.1",
     "proper-lockfile": "^4.1.2",
     "properties-reader": "^3.0.1",
     "ssh-remote-port-forward": "^1.0.4",


### PR DESCRIPTION
## Summary

- Downgrade `get-port` to the CommonJS-compatible `5.1.1` line.
- Add a Dependabot ignore rule so `get-port` is not automatically raised back to ESM-only major versions.
- Remove the ChromaDB module's dev dependency on `@chroma-core/ollama`, which pulled in an older published `testcontainers` package and reintroduced `get-port@7` through a dev-only transitive path.
- Keep the ChromaDB embedding-function example covered by using a small local `EmbeddingFunction` that calls Ollama's `/api/embed` endpoint directly.

## Verification

- `npm install --ignore-scripts`
- `npm run format`
- `npm run lint`
- `npm run -w testcontainers build`
- `npm run -w @testcontainers/chromadb build`

## Test results

- Formatting and linting passed.
- The core `testcontainers` package build passed.
- The `@testcontainers/chromadb` package build passed after building the referenced core package.

## Semver impact

Patch. This does not change the public API. The `get-port` usage in this repository only needs the default port-selection function, which is available in `get-port@5.1.1`; the downgrade removes the ESM-only package surface from CommonJS/Jest consumers. The ChromaDB dependency removal affects only module tests/docs and removes an unnecessary dev dependency path, not published runtime behavior.
