### PR TITLE
Throw when FixedPortGenerator runs out of ports

### DIFF
--- a/packages/testcontainers/src/utils/port-generator.test.ts
+++ b/packages/testcontainers/src/utils/port-generator.test.ts
@@ -9,11 +9,13 @@ describe("PortGenerator", () => {
       await expect(fixedPortGenerator.generatePort()).resolves.toBe(1001);
     });
 
-    it("should throw when no more ports are available", async () => {
+    it("should reject when no more ports are available", async () => {
       const fixedPortGenerator = new FixedPortGenerator([1000]);
 
       await expect(fixedPortGenerator.generatePort()).resolves.toBe(1000);
-      expect(() => fixedPortGenerator.generatePort()).toThrowError("FixedPortGenerator has no more ports available");
+      await expect(fixedPortGenerator.generatePort()).rejects.toThrowError(
+        "FixedPortGenerator has no more ports available"
+      );
     });
   });
 

--- a/packages/testcontainers/src/utils/port-generator.test.ts
+++ b/packages/testcontainers/src/utils/port-generator.test.ts
@@ -8,6 +8,13 @@ describe("PortGenerator", () => {
       await expect(fixedPortGenerator.generatePort()).resolves.toBe(1000);
       await expect(fixedPortGenerator.generatePort()).resolves.toBe(1001);
     });
+
+    it("should throw when no more ports are available", async () => {
+      const fixedPortGenerator = new FixedPortGenerator([1000]);
+
+      await expect(fixedPortGenerator.generatePort()).resolves.toBe(1000);
+      expect(() => fixedPortGenerator.generatePort()).toThrowError("FixedPortGenerator has no more ports available");
+    });
   });
 
   describe("RandomPortGenerator", () => {

--- a/packages/testcontainers/src/utils/port-generator.ts
+++ b/packages/testcontainers/src/utils/port-generator.ts
@@ -15,6 +15,9 @@ export class FixedPortGenerator implements PortGenerator {
   constructor(private readonly ports: number[]) {}
 
   public generatePort(): Promise<number> {
+    if (this.portIndex >= this.ports.length) {
+      throw new Error("FixedPortGenerator has no more ports available");
+    }
     return Promise.resolve(this.ports[this.portIndex++]);
   }
 }

--- a/packages/testcontainers/src/utils/port-generator.ts
+++ b/packages/testcontainers/src/utils/port-generator.ts
@@ -14,10 +14,10 @@ export class FixedPortGenerator implements PortGenerator {
 
   constructor(private readonly ports: number[]) {}
 
-  public generatePort(): Promise<number> {
+  public async generatePort(): Promise<number> {
     if (this.portIndex >= this.ports.length) {
       throw new Error("FixedPortGenerator has no more ports available");
     }
-    return Promise.resolve(this.ports[this.portIndex++]);
+    return this.ports[this.portIndex++];
   }
 }


### PR DESCRIPTION
## Summary
`FixedPortGenerator.generatePort()` returned `this.ports[this.portIndex++]` with no bounds check, yielding `undefined` (typed as `number`) once the pool was exhausted. It now throws a clear error so misuse fails fast.

## Verification
- Added a unit test asserting the first call returns the seeded port and the next throws (no Docker required).
- `npm ci` && `npx vitest run packages/testcontainers/src/utils/port-generator.test.ts` → **passed**
- `npm run check-compiles` → clean · `npm run lint` → clean

## Test results
New unit test passing.

## Not breaking
Adds a thrown error only on the previously-undefined exhaustion path (which returned a non-number). No change to valid usage or to `RandomPortGenerator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
