### PR TITLE
Clarify branch naming and worktree setup in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,12 +54,13 @@ It captures practical rules that prevent avoidable CI and PR churn.
 ## PR Process
 
 1. Start from `main`.
-2. Create a branch prefixed with `codex/`.
+2. Create a branch prefixed with `<agent-name>/` (for example `claude/fix-exec-output-truncation`). The PR title must not carry such prefixes (see step 9).
 3. Implement scoped changes only.
 4. Run required checks: `npm run format`, `npm run lint`, `npm run check-compiles` when touching `packages/testcontainers` APIs consumed by modules, and targeted tests.
+   - When working in a fresh git worktree, dependencies are not installed (`node_modules` is absent), so verification commands (tests, `lint`, `format`, `check-compiles`) will fail with "Cannot find module" errors. Run `npm ci` once before verifying. `npm ci` only populates `node_modules` and must not modify `package-lock.json`; if it does, treat that as drift to investigate.
 5. Verify git diff only contains intended files.
 6. Never commit, push, or post on GitHub (issues, PRs, or comments) without first sharing the proposed diff/message and getting explicit user approval.
-7. Commit with focused message(s), using `git commit --no-verify`.
+7. Commit with focused message(s), using `git commit`.
    - Never bypass signing (for example, do not use `--no-gpg-sign`).
    - If signing fails (for example, passphrase/key issues), stop and ask the user to resolve signing, then retry.
 8. Push branch. Ask for explicit user permission before any force push.


### PR DESCRIPTION
## Summary
Documentation-only updates to `AGENTS.md`:

- Generalize the branch-naming rule from a hard-coded `codex/` prefix to `<agent-name>/` (e.g. `claude/fix-exec-output-truncation`), and note this is separate from the PR-title rule.
- Document that fresh git worktrees have no installed dependencies, so `npm ci` must be run once before verification commands (tests, `lint`, `format`, `check-compiles`) work — and that `npm ci` must not modify `package-lock.json`.
- Drop the now-moot `git commit --no-verify` guidance (the pre-commit hook was already removed).

## Verification
Docs-only; no code paths affected. `npm run format`/`lint` globs do not cover `.md` files.

## Not breaking
Documentation change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
