### PR TITLE
Document cross-language Testcontainers implementations in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,36 @@ It captures practical rules that prevent avoidable CI and PR churn.
   - Prefer asserting observable behavior instead of shared global mock state when possible.
   - If a test must depend on shared/global mock state, use `it.sequential(...)` or `describe.sequential(...)`.
 
+## Cross-language Implementations
+
+Testcontainers is a family of libraries that share the same concepts (containers, wait
+strategies, modules, Ryuk/reaper, networks, etc.) across many languages. When you are
+unsure how to design or implement something here, it is often worth checking how the more
+mature implementations solved the same problem. Their behavior is the de-facto reference,
+and aligning with it keeps this port consistent with the rest of the ecosystem.
+
+Use them as a sanity check in both directions:
+
+- If a feature or behavior exists elsewhere, see how it was implemented, what edge cases
+  it handles, and what defaults it chose before designing your own version.
+- If something is conspicuously absent, treat that as a signal. It may have been
+  deliberately omitted (unsupported by the Docker API, a footgun, deprecated, or
+  platform-specific). Investigate why before adding it here.
+
+Implementations, roughly in order of maturity (most mature first):
+
+- Java (the original reference implementation): https://github.com/testcontainers/testcontainers-java
+- Go: https://github.com/testcontainers/testcontainers-go
+- .NET: https://github.com/testcontainers/testcontainers-dotnet
+- Python: https://github.com/testcontainers/testcontainers-python
+- Node.js (this repository): https://github.com/testcontainers/testcontainers-node
+- Rust: https://github.com/testcontainers/testcontainers-rs
+- Ruby: https://github.com/testcontainers/testcontainers-ruby
+- Haskell: https://github.com/testcontainers/testcontainers-hs
+
+When you do borrow a decision from another implementation, note the source in the PR so
+reviewers can follow the reasoning.
+
 ## Permission and Escalation
 
 - `npm install` requires escalated permissions for outbound network access to npm registries.
@@ -65,6 +95,8 @@ It captures practical rules that prevent avoidable CI and PR churn.
    - If signing fails (for example, passphrase/key issues), stop and ask the user to resolve signing, then retry.
 8. Push branch. Ask for explicit user permission before any force push.
 9. Open PR against `main` using a human-readable title (no `feat(...)` / `fix(...)` prefixes, and no agent-identifying prefixes or suffixes).
+   - Phrase titles in the imperative mood to match existing history, for example `Add Mosquitto module`, not `Adding Mosquitto module` (gerund/`-ing`) or `Added Mosquitto module` (past tense).
+   - For new modules the established form is `Add <Name> module` (see prior PRs such as `Add CouchDB module`, `Add Oracle Free module`).
    - Default to a ready-for-review PR. Only open or keep a PR in draft when the user explicitly asks for a draft.
    - When using `gh` to create/edit PR descriptions, prefer `--body-file <path>` over inline `--body`; this avoids shell command substitution issues when the body contains backticks.
 10. Add labels for both change type and semantic version impact.
@@ -74,6 +106,16 @@ It captures practical rules that prevent avoidable CI and PR churn.
     - test results summary
     - if semver impact is not `major`, evidence that the change is not breaking
     - `Closes #<issue>` only when the PR is intended to close a specific issue
+
+## PR Review
+
+When reviewing a PR (your own or someone else's), the review is not only about the diff:
+
+- Check the PR title follows the conventions in step 9 of the PR Process: imperative mood,
+  no agent/`feat(...)`/`fix(...)` prefixes, and the `Add <Name> module` form for new
+  modules. Flag titles using the gerund (`Adding ...`) or past tense (`Added ...`).
+- Check that labels (change type and semver impact) are present and correct.
+- Check that docs were updated alongside any public API change.
 
 ## Labels
 


### PR DESCRIPTION
## Summary

Documentation-only update to `AGENTS.md`:

- **Cross-language Implementations** — new section explaining that Testcontainers is a multi-language family sharing the same concepts, and that the more mature ports are a de-facto reference. Lists the implementations ordered by maturity (Java → Go → .NET → Python → Node → Rust → Ruby → Haskell) and advises checking them when in doubt — including treating a feature's *absence* elsewhere as a signal worth investigating before adding it here.
- **PR title conventions** — clarifies in the PR Process that titles use the imperative mood, with `Add <Name> module` as the established form for new modules (e.g. `Add CouchDB module`), and explicitly flags gerund (`Adding ...`) and past-tense (`Added ...`) forms as wrong.
- **PR Review** — new section noting that a review should also check the PR title, labels, and docs updates, not just the diff.

## Verification

Docs-only change; no code, tests, or CI configuration touched, so there is nothing to run.

## Semver impact

Not breaking — documentation only (`documentation` + `patch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
