### PR TITLE
Pin Dependabot weekly schedule to Monday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
     cooldown:
       default-days: 7
     labels:
@@ -32,6 +33,7 @@ updates:
       - "/packages/modules/*"
     schedule:
       interval: "weekly"
+      day: "monday"
     labels:
       - "dependencies"
       - "docker"
@@ -44,6 +46,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
     labels:
       - "dependencies"
       - "github_actions"
@@ -56,6 +59,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
     labels:
       - "dependencies"
       - "devcontainers"
@@ -68,6 +72,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
     labels:
       - "dependencies"
       - "docker_compose"
@@ -80,6 +85,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
     labels:
       - "dependencies"
       - "pip"


### PR DESCRIPTION
Adds `day: "monday"` to every ecosystem's weekly schedule in `.github/dependabot.yml`.

Without an explicit `day`, Dependabot chooses a day on its own, so the weekly runs had drifted off Monday. This pins all six ecosystems (npm, docker, github-actions, devcontainers, docker-compose, pip) to Monday. Run time is left at the default (05:00 UTC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)