### PR TITLE
Fix intermittent Jest smoke test failures

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -142,7 +142,7 @@ jobs:
         env:
           DEBUG: "testcontainers*"
       - name: Run Jest CommonJS runtime smoke test
-        run: npm exec --yes --package jest@30.4.2 -- jest --testMatch "**/smoke-test.jest.js" --runInBand --no-cache
+        run: npm exec --yes --package jest@30.4.2 -- jest --testMatch "**/smoke-test.jest.js" --runInBand --transform "{}"
         env:
           DEBUG: "testcontainers*"
 


### PR DESCRIPTION
## Summary
The `Smoke tests` job intermittently fails with `SyntaxError: Invalid regular expression: missing /` inside `browserslist/node.js`, before any test runs (`Tests: 0 total`). Example: [run 28363763741](https://github.com/testcontainers/testcontainers-node/actions/runs/28363763741/job/84025457642).

## Root cause
The Jest CommonJS smoke test runs:
```
npm exec --yes --package jest@30.4.2 -- jest --testMatch "**/smoke-test.jest.js" --runInBand --no-cache
```
`npm exec --yes --package jest@30.4.2` installs jest and its **entire transitive tree** (including `@babel/core` and `browserslist`) into the lockfile-less npx cache on every run — no integrity pinning. Jest's default transform loads `babel-jest` → `@babel/core` → `@babel/helper-compilation-targets` → `browserslist`, so an occasional corrupted `browserslist` in that cache fails the whole suite at `require` time.

## Fix
`smoke-test.jest.js` is plain CommonJS (`require("./build/index")`) that Node runs natively, so no transformation is needed. Passing `--transform "{}"` overrides Jest's default `babel-jest` transform with an empty map, so `@babel/core`/`browserslist` are never loaded and a corrupted cache copy can no longer break the run.

The `--no-cache` flag is removed as redundant: it only governed the transform-output cache, which is moot once there are no transforms. `--runInBand` is kept (it runs the test in the main process rather than forking a worker).

## Scope
CI-only change; no source or test changes. The smoke test still verifies the same thing — that the built CommonJS package starts a container under the Jest runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)