### PR TITLE
Document review-comment style and approval gate in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,21 @@ When reviewing a PR (your own or someone else's), the review is not only about t
 - Check that labels (change type and semver impact) are present and correct.
 - Check that docs were updated alongside any public API change.
 
+Before posting any review feedback to GitHub, share the proposed comments with the user and get
+explicit approval (this is the review-specific case of PR Process step 6). Present the full set of
+comments for a quick sanity check first; do not post directly, even when explicitly asked to
+review a PR.
+
+When writing review comments, keep each one terse and actionable for the PR author:
+
+- State the problem, at most a sentence of context if it helps, and what to do instead. Skip
+  restated background, meta-commentary, and severity labels the author does not need.
+- Anchor comments inline on the relevant line rather than dumping everything in the review body.
+  Keep the summary body to the few must-address points plus any high-level design note.
+- Only claim something violates convention after checking the rest of the repo. Prefer scoping a
+  comment to a concrete inconsistency (for example "the other blocks in this file do X") over a
+  broad assertion that may be wrong.
+
 ## Labels
 
 ### Change type


### PR DESCRIPTION
## Summary

Adds guidance to the **PR Review** section of `AGENTS.md` so PR review feedback from contributors and coding agents is consistent and low-noise. Prompted by a review where comments were overly verbose and one made a repo-wide convention claim that wasn't accurate.

New guidance:

- **Approval gate** — get explicit user approval before posting any review feedback to GitHub, even when explicitly asked to review a PR. Clarifies that "review this PR" is not itself standing approval to post, and ties back to existing PR Process step 6.
- **Terse, actionable comments** — state the problem, at most a sentence of context, and what to do instead; skip restated background, meta-commentary, and severity labels.
- **Inline over body** — anchor comments on the relevant line; keep the summary body to must-address points plus any high-level design note.
- **Verify conventions first** — only claim a convention violation after checking the rest of the repo; prefer scoping to a concrete inconsistency over a broad assertion.

## Why

Review comments were verbose and not consistently actionable for the PR author, and a "no one does X" claim turned out to be wrong on closer inspection. Encoding these expectations in `AGENTS.md` keeps future reviews focused and prevents low-value or inaccurate comments.

## Changes

- `AGENTS.md` — docs-only addition to the `## PR Review` section.

## Verification

Docs-only change (no code, no public API). No build/test impact.

## Semver

Not breaking — documentation-only change to contributor guidance.
