### PR TITLE
Use default stale issue timings

### DIFF
--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -13,12 +13,10 @@ jobs:
     steps:
       - uses: actions/stale@v10
         with:
-          days-before-issue-stale: 90
-          days-before-issue-close: 30
           stale-issue-label: "stale"
           exempt-issue-labels: "never-stale"
-          stale-issue-message: "This issue is stale because it has been open for 90 days with no activity."
-          close-issue-message: "This issue was closed because it has been inactive for 30 days since being marked as stale."
+          stale-issue-message: "This issue is stale because it has had no recent activity."
+          close-issue-message: "This issue was closed because it has had no recent activity since being marked as stale."
           days-before-pr-stale: -1
           days-before-pr-close: -1
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- use the `actions/stale` defaults of 60 days before marking issues stale and 7 days before closing them
- make the issue messages independent of configured durations
- keep the existing labels, exemptions, schedule, and disabled PR handling

## Verification

- `npm run format`
- `npm run lint`
- `git diff --check`

## Semver impact

Patch. This only changes repository issue-maintenance automation and does not affect published package APIs or runtime behavior.
