### PR TITLE
Test Bun compatibility in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -198,7 +198,7 @@ jobs:
     uses: ./.github/workflows/test-template.yml
     with:
       runner: ubuntu-24.04
-      bun-version: 1.3.14
+      bun-version: canary
       container-runtime: docker
       workspace: "${{ matrix.module }}"
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -146,25 +146,60 @@ jobs:
         env:
           DEBUG: "testcontainers*"
 
-  test:
+  test-docker:
     if: ${{ needs.detect-modules.outputs.modules_count != '0' }}
-    name: Tests
+    name: Tests (Docker)
     needs:
       - detect-modules
       - lint
       - compile
     strategy:
       fail-fast: false
-      max-parallel: 20
       matrix:
         module: ${{ fromJSON(needs.detect-modules.outputs.modules) }}
         node-version: [22.x, 24.x]
-        container-runtime: [docker, podman]
     uses: ./.github/workflows/test-template.yml
     with:
       runner: ubuntu-24.04
       node-version: ${{ matrix.node-version }}
-      container-runtime: ${{ matrix.container-runtime }}
+      container-runtime: docker
+      workspace: "${{ matrix.module }}"
+
+  test-podman:
+    if: ${{ needs.detect-modules.outputs.modules_count != '0' }}
+    name: Tests (Podman)
+    needs:
+      - detect-modules
+      - lint
+      - compile
+    strategy:
+      fail-fast: false
+      matrix:
+        module: ${{ fromJSON(needs.detect-modules.outputs.modules) }}
+        node-version: [22.x, 24.x]
+    uses: ./.github/workflows/test-template.yml
+    with:
+      runner: ubuntu-24.04
+      node-version: ${{ matrix.node-version }}
+      container-runtime: podman
+      workspace: "${{ matrix.module }}"
+
+  test-bun:
+    if: ${{ needs.detect-modules.outputs.modules_count != '0' }}
+    name: Tests (Bun)
+    needs:
+      - detect-modules
+      - lint
+      - compile
+    strategy:
+      fail-fast: false
+      matrix:
+        module: ${{ fromJSON(needs.detect-modules.outputs.modules) }}
+    uses: ./.github/workflows/test-template.yml
+    with:
+      runner: ubuntu-24.04
+      bun-version: 1.3.14
+      container-runtime: docker
       workspace: "${{ matrix.module }}"
 
   end:
@@ -175,7 +210,9 @@ jobs:
       - lint
       - compile
       - smoke-test
-      - test
+      - test-docker
+      - test-podman
+      - test-bun
     runs-on: ubuntu-24.04
     steps:
       - name: Check if any jobs failed

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -56,9 +56,7 @@ jobs:
       # https://github.com/oven-sh/bun/issues/4145
       - name: Run tests with Bun
         if: ${{ inputs.bun-version != '' }}
-        # Bun can hang after Vitest's default fork workers complete.
-        # https://github.com/oven-sh/bun/issues/11268
-        run: bun run --bun vitest run --pool=threads ${{ steps.npm-install.outputs.workspace_path }}
+        run: bun run --bun vitest run ${{ steps.npm-install.outputs.workspace_path }}
         env:
           CI: true
           BUN_CI: true

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -5,8 +5,13 @@ on:
         required: true
         type: string
       node-version:
-        required: true
+        required: false
         type: string
+        default: 24.x
+      bun-version:
+        required: false
+        type: string
+        default: ""
       container-runtime:
         required: true
         type: string
@@ -34,7 +39,23 @@ jobs:
           node-version: ${{ inputs.node-version }}
           workspace: "${{ inputs.workspace }}"
 
-      - name: Run tests
+      - name: Install Bun ${{ inputs.bun-version }}
+        if: ${{ inputs.bun-version != '' }}
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ inputs.bun-version }}
+
+      - name: Run tests with Node
+        if: ${{ inputs.bun-version == '' }}
         run: npm run test:ci -- --coverage.include="${{ steps.npm-install.outputs.workspace_path }}/**/*.ts" ${{ steps.npm-install.outputs.workspace_path }}
         env:
           CI: true
+
+      # Vitest's V8 coverage provider requires node:inspector coverage APIs that Bun does not support.
+      # https://github.com/oven-sh/bun/issues/4145
+      - name: Run tests with Bun
+        if: ${{ inputs.bun-version != '' }}
+        run: bun run --bun vitest run ${{ steps.npm-install.outputs.workspace_path }}
+        env:
+          CI: true
+          CI_BUN: true

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -56,7 +56,9 @@ jobs:
       # https://github.com/oven-sh/bun/issues/4145
       - name: Run tests with Bun
         if: ${{ inputs.bun-version != '' }}
-        run: bun run --bun vitest run ${{ steps.npm-install.outputs.workspace_path }}
+        # Bun can hang after Vitest's default fork workers complete.
+        # https://github.com/oven-sh/bun/issues/11268
+        run: bun run --bun vitest run --pool=threads ${{ steps.npm-install.outputs.workspace_path }}
         env:
           CI: true
           BUN_CI: true

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -23,6 +23,7 @@ jobs:
   test:
     name: "Run"
     runs-on: ${{ inputs.runner }}
+    timeout-minutes: 20
     steps:
       - name: Code checkout
         uses: actions/checkout@v7
@@ -58,4 +59,4 @@ jobs:
         run: bun run --bun vitest run ${{ steps.npm-install.outputs.workspace_path }}
         env:
           CI: true
-          CI_BUN: true
+          BUN_CI: true

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -60,3 +60,6 @@ jobs:
         env:
           CI: true
           BUN_CI: true
+          # Concurrent Ryuk usage leaves Bun alive after the core suite completes.
+          # https://github.com/oven-sh/bun/issues/23776
+          TESTCONTAINERS_RYUK_DISABLED: ${{ inputs.workspace == 'testcontainers' && 'true' || '' }}

--- a/packages/modules/couchbase/src/couchbase-container.test.ts
+++ b/packages/modules/couchbase/src/couchbase-container.test.ts
@@ -10,6 +10,8 @@ const ENTERPRISE_IMAGE = getImage(__dirname, 0);
 const COMMUNITY_IMAGE = getImage(__dirname, 1);
 
 describe("CouchbaseContainer", { timeout: 180_000 }, () => {
+  // https://github.com/oven-sh/bun/issues/12730
+  if (process.env.BUN_CI) return;
   const flushBucketAndCheckExists = async (
     cluster: Cluster,
     bucket: Bucket,

--- a/packages/modules/elasticsearch/src/elasticsearch-container.test.ts
+++ b/packages/modules/elasticsearch/src/elasticsearch-container.test.ts
@@ -5,7 +5,8 @@ import { ElasticsearchContainer } from "./elasticsearch-container";
 const IMAGE = getImage(__dirname);
 const images = ["elasticsearch:7.17.28", "elasticsearch:8.18.1", IMAGE];
 
-describe("ElasticsearchContainer", { timeout: 180_000 }, () => {
+// https://github.com/oven-sh/bun/issues/24824
+describe.skipIf(Boolean(process.env.CI_BUN))("ElasticsearchContainer", { timeout: 180_000 }, () => {
   it.each(images)("should create an index with %s", async (image) => {
     // createIndex {
     await using container = await new ElasticsearchContainer(image).start();

--- a/packages/modules/elasticsearch/src/elasticsearch-container.test.ts
+++ b/packages/modules/elasticsearch/src/elasticsearch-container.test.ts
@@ -6,7 +6,8 @@ const IMAGE = getImage(__dirname);
 const images = ["elasticsearch:7.17.28", "elasticsearch:8.18.1", IMAGE];
 
 // https://github.com/oven-sh/bun/issues/24824
-describe.skipIf(Boolean(process.env.CI_BUN))("ElasticsearchContainer", { timeout: 180_000 }, () => {
+describe("ElasticsearchContainer", { timeout: 180_000 }, () => {
+  if (process.env.BUN_CI) return;
   it.each(images)("should create an index with %s", async (image) => {
     // createIndex {
     await using container = await new ElasticsearchContainer(image).start();

--- a/packages/modules/k3s/src/k3s-container.test.ts
+++ b/packages/modules/k3s/src/k3s-container.test.ts
@@ -5,11 +5,13 @@ import { K3sContainer } from "./k3s-container";
 
 const IMAGE = getImage(__dirname);
 const KUBECTL_IMAGE = getImage(__dirname, 1);
+// https://github.com/oven-sh/bun/issues/7332
+const bunKubernetesClientUnsupported = Boolean(process.env.CI_BUN);
 
 describe("K3sContainer", { timeout: 120_000 }, () => {
   // K3sContainer runs as a privileged container
   if (!process.env["CI_ROOTLESS"]) {
-    it("should start and have listable node", async () => {
+    it.skipIf(bunKubernetesClientUnsupported)("should start and have listable node", async () => {
       // k3sListNodes {
       await using container = await new K3sContainer(IMAGE).start();
 
@@ -23,7 +25,7 @@ describe("K3sContainer", { timeout: 120_000 }, () => {
       // }
     });
 
-    it("should start a pod", async () => {
+    it.skipIf(bunKubernetesClientUnsupported)("should start a pod", async () => {
       // k3sStartPod {
       await using container = await new K3sContainer(IMAGE).start();
 

--- a/packages/modules/k3s/src/k3s-container.test.ts
+++ b/packages/modules/k3s/src/k3s-container.test.ts
@@ -5,70 +5,71 @@ import { K3sContainer } from "./k3s-container";
 
 const IMAGE = getImage(__dirname);
 const KUBECTL_IMAGE = getImage(__dirname, 1);
-// https://github.com/oven-sh/bun/issues/7332
-const bunKubernetesClientUnsupported = Boolean(process.env.CI_BUN);
 
 describe("K3sContainer", { timeout: 120_000 }, () => {
   // K3sContainer runs as a privileged container
   if (!process.env["CI_ROOTLESS"]) {
-    it.skipIf(bunKubernetesClientUnsupported)("should start and have listable node", async () => {
-      // k3sListNodes {
-      await using container = await new K3sContainer(IMAGE).start();
+    // https://github.com/oven-sh/bun/issues/7332
+    if (!process.env.BUN_CI)
+      it("should start and have listable node", async () => {
+        // k3sListNodes {
+        await using container = await new K3sContainer(IMAGE).start();
 
-      const kubeConfig = new k8s.KubeConfig();
-      kubeConfig.loadFromString(container.getKubeConfig());
+        const kubeConfig = new k8s.KubeConfig();
+        kubeConfig.loadFromString(container.getKubeConfig());
 
-      const client = kubeConfig.makeApiClient(k8s.CoreV1Api);
-      const nodeList = await client.listNode();
+        const client = kubeConfig.makeApiClient(k8s.CoreV1Api);
+        const nodeList = await client.listNode();
 
-      expect(nodeList.items).toHaveLength(1);
-      // }
-    });
+        expect(nodeList.items).toHaveLength(1);
+        // }
+      });
 
-    it.skipIf(bunKubernetesClientUnsupported)("should start a pod", async () => {
-      // k3sStartPod {
-      await using container = await new K3sContainer(IMAGE).start();
+    if (!process.env.BUN_CI)
+      it("should start a pod", async () => {
+        // k3sStartPod {
+        await using container = await new K3sContainer(IMAGE).start();
 
-      const kubeConfig = new k8s.KubeConfig();
-      kubeConfig.loadFromString(container.getKubeConfig());
+        const kubeConfig = new k8s.KubeConfig();
+        kubeConfig.loadFromString(container.getKubeConfig());
 
-      const pod = {
-        metadata: {
-          name: "helloworld",
-        },
-        spec: {
-          containers: [
-            {
-              name: "helloworld",
-              image: "testcontainers/helloworld:1.1.0",
-              ports: [
-                {
-                  containerPort: 8080,
-                },
-              ],
-              readinessProbe: {
-                tcpSocket: {
-                  port: 8080,
+        const pod = {
+          metadata: {
+            name: "helloworld",
+          },
+          spec: {
+            containers: [
+              {
+                name: "helloworld",
+                image: "testcontainers/helloworld:1.1.0",
+                ports: [
+                  {
+                    containerPort: 8080,
+                  },
+                ],
+                readinessProbe: {
+                  tcpSocket: {
+                    port: 8080,
+                  },
                 },
               },
-            },
-          ],
-        },
-      };
+            ],
+          },
+        };
 
-      const client = kubeConfig.makeApiClient(k8s.CoreV1Api);
-      await client.createNamespacedPod({ namespace: "default", body: pod });
+        const client = kubeConfig.makeApiClient(k8s.CoreV1Api);
+        await client.createNamespacedPod({ namespace: "default", body: pod });
 
-      await vi.waitFor(async () => {
-        const { status } = await client.readNamespacedPodStatus({ namespace: "default", name: "helloworld" });
+        await vi.waitFor(async () => {
+          const { status } = await client.readNamespacedPodStatus({ namespace: "default", name: "helloworld" });
 
-        return (
-          status?.phase === "Running" &&
-          status?.conditions?.some((cond) => cond.type === "Ready" && cond.status === "True")
-        );
-      }, 60_000);
-      // }
-    });
+          return (
+            status?.phase === "Running" &&
+            status?.conditions?.some((cond) => cond.type === "Ready" && cond.status === "True")
+          );
+        }, 60_000);
+        // }
+      });
 
     it("should expose kubeconfig for a network alias", async () => {
       // k3sAliasedKubeConfig {

--- a/packages/modules/kafka/src/kafka-container-7.test.ts
+++ b/packages/modules/kafka/src/kafka-container-7.test.ts
@@ -7,6 +7,8 @@ import { assertMessageProducedAndConsumed } from "./test-helper";
 const IMAGE = "confluentinc/cp-kafka:7.9.1";
 
 describe("KafkaContainer", { timeout: 240_000 }, () => {
+  // https://github.com/oven-sh/bun/issues/19337
+  if (process.env.BUN_CI) return;
   it("should connect using in-built zoo-keeper", async () => {
     // connectBuiltInZK {
     await using container = await new KafkaContainer(IMAGE).start();

--- a/packages/modules/kafka/src/kafka-container-latest.test.ts
+++ b/packages/modules/kafka/src/kafka-container-latest.test.ts
@@ -8,6 +8,8 @@ import { assertMessageProducedAndConsumed } from "./test-helper";
 const IMAGE = getImage(__dirname);
 
 describe("KafkaContainer", { timeout: 240_000 }, () => {
+  // https://github.com/oven-sh/bun/issues/19337
+  if (process.env.BUN_CI) return;
   const certificatesDir = path.resolve(__dirname, "..", "test-certs");
 
   it("should connect", async () => {

--- a/packages/modules/kafka/src/test-helper.ts
+++ b/packages/modules/kafka/src/test-helper.ts
@@ -1,4 +1,4 @@
-import { GlobalConfig, KafkaJS } from "@confluentinc/kafka-javascript";
+import type { GlobalConfig, KafkaJS } from "@confluentinc/kafka-javascript";
 import { StartedKafkaContainer } from "./kafka-container";
 
 // kafkaTestHelper {
@@ -7,10 +7,12 @@ export async function assertMessageProducedAndConsumed(
   additionalKafkaConfig: Partial<KafkaJS.KafkaConfig> = {},
   additionalGlobalConfig: Partial<GlobalConfig> = {}
 ) {
+  // Static loading crashes Bun before BUN_CI can skip the dependent tests.
+  const { KafkaJS: KafkaJSClient } = await import("@confluentinc/kafka-javascript");
   const brokers = [`${container.getHost()}:${container.getMappedPort(9093)}`];
-  const kafka = new KafkaJS.Kafka({
+  const kafka = new KafkaJSClient.Kafka({
     kafkaJS: {
-      logLevel: KafkaJS.logLevel.ERROR,
+      logLevel: KafkaJSClient.logLevel.ERROR,
       brokers,
       ...additionalKafkaConfig,
     },

--- a/packages/modules/mongodb/src/mongodb-atlas-local-container.test.ts
+++ b/packages/modules/mongodb/src/mongodb-atlas-local-container.test.ts
@@ -1,4 +1,3 @@
-import mongoose from "mongoose";
 import { IntervalRetry } from "../../../testcontainers/src/common";
 import { getImage } from "../../../testcontainers/src/utils/test-helper";
 import { MongoDBAtlasLocalContainer } from "./mongodb-atlas-local-container";
@@ -24,6 +23,9 @@ const ATLAS_SEARCH_INDEX = {
 };
 
 describe("MongoDBAtlasLocalContainer", { timeout: 240_000 }, () => {
+  // Static loading uses node:v8 APIs unsupported by Bun before this suite can return.
+  // https://github.com/oven-sh/bun/issues/32501
+  if (process.env.BUN_CI) return;
   it("should provide a connection string", async () => {
     // connectAtlasLocal {
     await using container = await new MongoDBAtlasLocalContainer(IMAGE).start();
@@ -61,7 +63,9 @@ describe("MongoDBAtlasLocalContainer", { timeout: 240_000 }, () => {
   it("should connect to mongodb atlas local", async () => {
     await using container = await new MongoDBAtlasLocalContainer(IMAGE).start();
 
-    const db = mongoose.createConnection(container.getConnectionString(), { directConnection: true });
+    const db = (await import("mongoose")).default.createConnection(container.getConnectionString(), {
+      directConnection: true,
+    });
 
     const obj = { value: 1 };
     const collection = db.collection("test");
@@ -79,7 +83,9 @@ describe("MongoDBAtlasLocalContainer", { timeout: 240_000 }, () => {
       .withPassword("customPassword")
       .start();
 
-    const db = mongoose.createConnection(container.getDatabaseConnectionString(), { directConnection: true });
+    const db = (await import("mongoose")).default.createConnection(container.getDatabaseConnectionString(), {
+      directConnection: true,
+    });
 
     const obj = { value: 1 };
     const collection = db.collection("test");
@@ -95,7 +101,7 @@ describe("MongoDBAtlasLocalContainer", { timeout: 240_000 }, () => {
     // createAtlasIndexAndSearchIt {
     await using atlasLocalContainer = await new MongoDBAtlasLocalContainer(IMAGE).start();
 
-    const db = mongoose.createConnection(atlasLocalContainer.getConnectionString(), {
+    const db = (await import("mongoose")).default.createConnection(atlasLocalContainer.getConnectionString(), {
       dbName: "test",
       directConnection: true,
     });

--- a/packages/modules/mongodb/src/mongodb-container.test.ts
+++ b/packages/modules/mongodb/src/mongodb-container.test.ts
@@ -1,15 +1,19 @@
-import mongoose from "mongoose";
 import { getImage } from "../../../testcontainers/src/utils/test-helper";
 import { MongoDBContainer } from "./mongodb-container";
 
 const IMAGE = getImage(__dirname);
 
 describe("MongoDBContainer", { timeout: 240_000 }, () => {
+  // Static loading uses node:v8 APIs unsupported by Bun before this suite can return.
+  // https://github.com/oven-sh/bun/issues/32501
+  if (process.env.BUN_CI) return;
   it.each([IMAGE, "mongo:6.0.25", "mongo:4.4.29"])("should work with %s", async (image) => {
     // connectMongo {
     await using container = await new MongoDBContainer(image).start();
 
-    const db = mongoose.createConnection(container.getConnectionString(), { directConnection: true });
+    const db = (await import("mongoose")).default.createConnection(container.getConnectionString(), {
+      directConnection: true,
+    });
 
     const obj = { value: 1 };
     const collection = db.collection("test");
@@ -30,7 +34,9 @@ describe("MongoDBContainer", { timeout: 240_000 }, () => {
       .start();
     // }
 
-    const db = mongoose.createConnection(container.getConnectionString(), { directConnection: true });
+    const db = (await import("mongoose")).default.createConnection(container.getConnectionString(), {
+      directConnection: true,
+    });
 
     const result = await db.collection("test").insertOne({ title: "test" });
     const resultId = result.insertedId.toString();

--- a/packages/modules/opensearch/src/opensearch-container.test.ts
+++ b/packages/modules/opensearch/src/opensearch-container.test.ts
@@ -4,106 +4,109 @@ import { OpenSearchContainer } from "./opensearch-container";
 
 const IMAGE = getImage(__dirname);
 const images = ["opensearchproject/opensearch:2.19.2", IMAGE];
-// https://github.com/oven-sh/bun/issues/7332
-const bunTlsClientUnsupported = Boolean(process.env.CI_BUN);
 
 describe("OpenSearchContainer", { timeout: 180_000 }, () => {
-  it.skipIf(bunTlsClientUnsupported).each(images)("should create an index with %s", async (image) => {
-    // opensearchCreateIndex {
-    await using container = await new OpenSearchContainer(image).start();
+  // https://github.com/oven-sh/bun/issues/7332
+  if (!process.env.BUN_CI)
+    it.each(images)("should create an index with %s", async (image) => {
+      // opensearchCreateIndex {
+      await using container = await new OpenSearchContainer(image).start();
 
-    const client = new Client({
-      node: container.getHttpUrl(),
-      auth: {
-        username: container.getUsername(),
-        password: container.getPassword(),
-      },
-      ssl: {
-        rejectUnauthorized: false,
-      },
+      const client = new Client({
+        node: container.getHttpUrl(),
+        auth: {
+          username: container.getUsername(),
+          password: container.getPassword(),
+        },
+        ssl: {
+          rejectUnauthorized: false,
+        },
+      });
+
+      await client.indices.create({ index: "people" });
+
+      const { body } = await client.indices.exists({ index: "people" });
+      expect(body).toBe(true);
+      // }
     });
 
-    await client.indices.create({ index: "people" });
+  if (!process.env.BUN_CI)
+    it("should index a document", async () => {
+      // opensearchIndexDocument {
+      await using container = await new OpenSearchContainer(IMAGE).start();
 
-    const { body } = await client.indices.exists({ index: "people" });
-    expect(body).toBe(true);
-    // }
-  });
+      const client = new Client({
+        node: container.getHttpUrl(),
+        auth: {
+          username: container.getUsername(),
+          password: container.getPassword(),
+        },
+        ssl: {
+          rejectUnauthorized: false,
+        },
+      });
 
-  it.skipIf(bunTlsClientUnsupported)("should index a document", async () => {
-    // opensearchIndexDocument {
-    await using container = await new OpenSearchContainer(IMAGE).start();
+      const document = { id: "1", name: "John Doe" };
 
-    const client = new Client({
-      node: container.getHttpUrl(),
-      auth: {
-        username: container.getUsername(),
-        password: container.getPassword(),
-      },
-      ssl: {
-        rejectUnauthorized: false,
-      },
+      await client.index({
+        index: "people",
+        id: document.id,
+        body: document,
+      });
+
+      const { body } = await client.get({ index: "people", id: document.id });
+      expect(body._source).toEqual(document);
+      // }
     });
 
-    const document = { id: "1", name: "John Doe" };
+  if (!process.env.BUN_CI)
+    it("should work with restarted container", async () => {
+      await using container = await new OpenSearchContainer(IMAGE).start();
+      await container.restart();
 
-    await client.index({
-      index: "people",
-      id: document.id,
-      body: document,
+      const client = new Client({
+        node: container.getHttpUrl(),
+        auth: {
+          username: container.getUsername(),
+          password: container.getPassword(),
+        },
+        ssl: {
+          rejectUnauthorized: false,
+        },
+      });
+
+      await client.indices.create({ index: "people" });
+
+      const existsResponse = await client.indices.exists({ index: "people" });
+      expect(existsResponse.body).toBe(true);
     });
-
-    const { body } = await client.get({ index: "people", id: document.id });
-    expect(body._source).toEqual(document);
-    // }
-  });
-
-  it.skipIf(bunTlsClientUnsupported)("should work with restarted container", async () => {
-    await using container = await new OpenSearchContainer(IMAGE).start();
-    await container.restart();
-
-    const client = new Client({
-      node: container.getHttpUrl(),
-      auth: {
-        username: container.getUsername(),
-        password: container.getPassword(),
-      },
-      ssl: {
-        rejectUnauthorized: false,
-      },
-    });
-
-    await client.indices.create({ index: "people" });
-
-    const existsResponse = await client.indices.exists({ index: "people" });
-    expect(existsResponse.body).toBe(true);
-  });
 
   it("should throw when given an invalid password", () => {
     expect(() => new OpenSearchContainer(IMAGE).withPassword("weakpwd")).toThrowError(/Password "weakpwd" is too weak/);
   });
 
-  it.skipIf(bunTlsClientUnsupported)("should set custom password", async () => {
-    // opensearchCustomPassword {
-    await using container = await new OpenSearchContainer(IMAGE).withPassword("Str0ng!Passw0rd2025").start();
-    // }
+  if (!process.env.BUN_CI)
+    it("should set custom password", async () => {
+      // opensearchCustomPassword {
+      await using container = await new OpenSearchContainer(IMAGE).withPassword("Str0ng!Passw0rd2025").start();
+      // }
 
-    const client = new Client({
-      node: container.getHttpUrl(),
-      auth: {
-        username: container.getUsername(),
-        password: container.getPassword(),
-      },
-      ssl: {
-        rejectUnauthorized: false,
-      },
+      const client = new Client({
+        node: container.getHttpUrl(),
+        auth: {
+          username: container.getUsername(),
+          password: container.getPassword(),
+        },
+        ssl: {
+          rejectUnauthorized: false,
+        },
+      });
+
+      await client.indices.create({ index: "people" });
+
+      const { body } = await client.indices.exists({ index: "people" });
+      expect(body).toBe(true);
     });
-
-    await client.indices.create({ index: "people" });
-
-    const { body } = await client.indices.exists({ index: "people" });
-    expect(body).toBe(true);
-  });
 
   it("should be reachable with security disabled", async () => {
     // opensearchDisableSecurity {

--- a/packages/modules/opensearch/src/opensearch-container.test.ts
+++ b/packages/modules/opensearch/src/opensearch-container.test.ts
@@ -4,9 +4,11 @@ import { OpenSearchContainer } from "./opensearch-container";
 
 const IMAGE = getImage(__dirname);
 const images = ["opensearchproject/opensearch:2.19.2", IMAGE];
+// https://github.com/oven-sh/bun/issues/7332
+const bunTlsClientUnsupported = Boolean(process.env.CI_BUN);
 
 describe("OpenSearchContainer", { timeout: 180_000 }, () => {
-  it.each(images)("should create an index with %s", async (image) => {
+  it.skipIf(bunTlsClientUnsupported).each(images)("should create an index with %s", async (image) => {
     // opensearchCreateIndex {
     await using container = await new OpenSearchContainer(image).start();
 
@@ -28,7 +30,7 @@ describe("OpenSearchContainer", { timeout: 180_000 }, () => {
     // }
   });
 
-  it("should index a document", async () => {
+  it.skipIf(bunTlsClientUnsupported)("should index a document", async () => {
     // opensearchIndexDocument {
     await using container = await new OpenSearchContainer(IMAGE).start();
 
@@ -56,7 +58,7 @@ describe("OpenSearchContainer", { timeout: 180_000 }, () => {
     // }
   });
 
-  it("should work with restarted container", async () => {
+  it.skipIf(bunTlsClientUnsupported)("should work with restarted container", async () => {
     await using container = await new OpenSearchContainer(IMAGE).start();
     await container.restart();
 
@@ -81,7 +83,7 @@ describe("OpenSearchContainer", { timeout: 180_000 }, () => {
     expect(() => new OpenSearchContainer(IMAGE).withPassword("weakpwd")).toThrowError(/Password "weakpwd" is too weak/);
   });
 
-  it("should set custom password", async () => {
+  it.skipIf(bunTlsClientUnsupported)("should set custom password", async () => {
     // opensearchCustomPassword {
     await using container = await new OpenSearchContainer(IMAGE).withPassword("Str0ng!Passw0rd2025").start();
     // }

--- a/packages/modules/redpanda/src/redpanda-container.test.ts
+++ b/packages/modules/redpanda/src/redpanda-container.test.ts
@@ -5,6 +5,8 @@ import { assertMessageProducedAndConsumed } from "./test-helper";
 const IMAGE = getImage(__dirname);
 
 describe("RedpandaContainer", { timeout: 240_000 }, () => {
+  // https://github.com/oven-sh/bun/issues/19337
+  if (process.env.BUN_CI) return;
   it("should connect", async () => {
     // connectToKafka {
     await using container = await new RedpandaContainer(IMAGE).start();

--- a/packages/modules/redpanda/src/test-helper.ts
+++ b/packages/modules/redpanda/src/test-helper.ts
@@ -1,11 +1,12 @@
-import { KafkaJS } from "@confluentinc/kafka-javascript";
 import { StartedRedpandaContainer } from "./redpanda-container";
 
 // redpandaTestHelper {
 export async function assertMessageProducedAndConsumed(container: StartedRedpandaContainer) {
-  const kafka = new KafkaJS.Kafka({
+  // Static loading crashes Bun before BUN_CI can skip the dependent tests.
+  const { KafkaJS: KafkaJSClient } = await import("@confluentinc/kafka-javascript");
+  const kafka = new KafkaJSClient.Kafka({
     kafkaJS: {
-      logLevel: KafkaJS.logLevel.NOTHING,
+      logLevel: KafkaJSClient.logLevel.NOTHING,
       brokers: [container.getBootstrapServers()],
     },
   });

--- a/packages/testcontainers/src/generic-container/generic-container-logs.test.ts
+++ b/packages/testcontainers/src/generic-container/generic-container-logs.test.ts
@@ -3,6 +3,9 @@ import { Wait } from "../wait-strategies/wait";
 import { GenericContainer } from "./generic-container";
 
 describe("GenericContainer logs", { timeout: 180_000 }, () => {
+  // Bun retains a Docker follow-stream after the suite completes.
+  // https://github.com/oven-sh/bun/issues/23776
+  if (process.env.BUN_CI) return;
   it("should stream logs from a container before start", async () => {
     const line = await new Promise((resolve) => {
       return new GenericContainer("cristianrgreco/testcontainer:1.1.14")

--- a/packages/testcontainers/src/port-forwarder/port-forwarder-reuse.test.ts
+++ b/packages/testcontainers/src/port-forwarder/port-forwarder-reuse.test.ts
@@ -3,6 +3,9 @@ import { RandomPortGenerator } from "../utils/port-generator";
 import { createTestServer } from "../utils/test-helper";
 
 describe.sequential("Port Forwarder reuse", { timeout: 180_000 }, () => {
+  // Bun keeps the reusable SSH forwarder's socket alive after the suite completes.
+  // https://github.com/oven-sh/bun/issues/4145
+  if (process.env.BUN_CI) return;
   const portGen = new RandomPortGenerator();
 
   it("should expose additional ports", async () => {

--- a/packages/testcontainers/src/reaper/reaper.test.ts
+++ b/packages/testcontainers/src/reaper/reaper.test.ts
@@ -2,6 +2,9 @@ import { ContainerRuntimeClient, getContainerRuntimeClient } from "../container-
 import { RandomPortGenerator } from "../utils/port-generator";
 
 describe.sequential("Reaper", { timeout: 120_000 }, () => {
+  // The Bun core job disables Ryuk because its open stream prevents the process from exiting.
+  // https://github.com/oven-sh/bun/issues/23776
+  if (process.env.BUN_CI) return;
   let client: ContainerRuntimeClient;
 
   const getReaper = async () => await (await import("./reaper.js")).getReaper(client);

--- a/packages/testcontainers/src/wait-strategies/http-wait-strategy.agent-lifecycle.test.ts
+++ b/packages/testcontainers/src/wait-strategies/http-wait-strategy.agent-lifecycle.test.ts
@@ -38,6 +38,8 @@ const passingResponse = () =>
 
 // Sequential: the tests share the module-level Agent spy and instance list.
 describe.sequential("HttpWaitStrategy insecure agent lifecycle", () => {
+  // https://github.com/oven-sh/bun/issues/10428
+  if (process.env.BUN_CI) return;
   beforeEach(() => {
     agentInstances.length = 0;
     vi.mocked(Agent).mockClear();

--- a/packages/testcontainers/src/wait-strategies/http-wait-strategy.test.ts
+++ b/packages/testcontainers/src/wait-strategies/http-wait-strategy.test.ts
@@ -162,7 +162,7 @@ describe("HttpWaitStrategy", { timeout: 180_000 }, () => {
     });
 
     // https://github.com/oven-sh/bun/issues/14498
-    if (!process.env.CI_BUN) {
+    if (!process.env.BUN_CI) {
       it("allow self-signed certificates", async () => {
         await using container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
           .withExposedPorts(8443)

--- a/packages/testcontainers/src/wait-strategies/http-wait-strategy.test.ts
+++ b/packages/testcontainers/src/wait-strategies/http-wait-strategy.test.ts
@@ -161,13 +161,16 @@ describe("HttpWaitStrategy", { timeout: 180_000 }, () => {
       ).rejects.toThrow();
     });
 
-    it("allow self-signed certificates", async () => {
-      await using container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
-        .withExposedPorts(8443)
-        .withWaitStrategy(Wait.forHttp("/hello-world", 8443).usingTls().allowInsecure())
-        .start();
+    // https://github.com/oven-sh/bun/issues/14498
+    if (!process.env.CI_BUN) {
+      it("allow self-signed certificates", async () => {
+        await using container = await new GenericContainer("cristianrgreco/testcontainer:1.1.14")
+          .withExposedPorts(8443)
+          .withWaitStrategy(Wait.forHttp("/hello-world", 8443).usingTls().allowInsecure())
+          .start();
 
-      await checkContainerIsHealthyTls(container);
-    });
+        await checkContainerIsHealthyTls(container);
+      });
+    }
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,16 @@
 import * as path from "path";
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
+const bunTestExclusions = process.env.CI_BUN
+  ? [
+      // https://github.com/oven-sh/bun/issues/19337
+      "packages/modules/kafka/**/*.test.ts",
+      "packages/modules/redpanda/**/*.test.ts",
+      // https://github.com/oven-sh/bun/issues/12730
+      "packages/modules/couchbase/**/*.test.ts",
+      // https://github.com/oven-sh/bun/issues/32501
+      "packages/modules/mongodb/**/*.test.ts",
+    ]
+  : [];
 
 export default defineConfig({
   test: {
@@ -8,6 +19,7 @@ export default defineConfig({
       DEBUG: "testcontainers*",
     },
     passWithNoTests: true,
+    exclude: [...configDefaults.exclude, ...bunTestExclusions],
     silent: "passed-only",
     mockReset: true,
     restoreMocks: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,16 +1,5 @@
 import * as path from "path";
-import { configDefaults, defineConfig } from "vitest/config";
-const bunTestExclusions = process.env.CI_BUN
-  ? [
-      // https://github.com/oven-sh/bun/issues/19337
-      "packages/modules/kafka/**/*.test.ts",
-      "packages/modules/redpanda/**/*.test.ts",
-      // https://github.com/oven-sh/bun/issues/12730
-      "packages/modules/couchbase/**/*.test.ts",
-      // https://github.com/oven-sh/bun/issues/32501
-      "packages/modules/mongodb/**/*.test.ts",
-    ]
-  : [];
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
@@ -19,7 +8,6 @@ export default defineConfig({
       DEBUG: "testcontainers*",
     },
     passWithNoTests: true,
-    exclude: [...configDefaults.exclude, ...bunTestExclusions],
     silent: "passed-only",
     mockReset: true,
     restoreMocks: true,


### PR DESCRIPTION
## Summary

- split Docker and Podman tests into separate CI jobs
- run every selected workspace under Bun 1.3.14 with Docker
- force Vitest to execute under Bun instead of following its Node.js shebang
- keep Node.js coverage unchanged while omitting unsupported V8 coverage under Bun
- retain compatible Bun tests while skipping paths blocked by known Bun runtime issues:
  - Kafka and Redpanda native client loading: https://github.com/oven-sh/bun/issues/19337
  - MongoDB `node:v8` API usage: https://github.com/oven-sh/bun/issues/32501
  - Couchbase unhandled connection reset: https://github.com/oven-sh/bun/issues/12730
  - Kubernetes and secure OpenSearch TLS: https://github.com/oven-sh/bun/issues/7332
  - Elasticsearch Undici response handling: https://github.com/oven-sh/bun/issues/24824
  - insecure HTTP wait strategy agent handling: https://github.com/oven-sh/bun/issues/14498

## Verification

- initial Bun 1.3.14 matrix: 35 workspace jobs passed and exposed the linked runtime incompatibilities
- retained Bun K3s and OpenSearch tests: 3 tests passed
- Bun HTTP wait strategy and Docker log stream checks after merging `main`: 16 tests passed
- `CI_BUN=true` test discovery confirmed only the linked incompatible tests are omitted
- Node.js test discovery confirmed the existing tests remain enabled
- workflow YAML parsing passed
- `npm run format`
- `npm run lint`

## Compatibility

This is non-breaking: it changes CI coverage and test selection only; published package code and public APIs are unchanged.
