### PR TITLE
Fall back to the host-side check on distroless images in HostPortWaitStrategy

### DIFF
--- a/packages/testcontainers/src/wait-strategies/utils/port-check.test.ts
+++ b/packages/testcontainers/src/wait-strategies/utils/port-check.test.ts
@@ -103,23 +103,25 @@ describe.sequential("PortCheck", () => {
       ]);
     });
 
-    it("should error log when the port-check will fail due to missing shells (distroless)", async () => {
+    it("should return true and debug log when the port-check has no shell to run (distroless)", async () => {
       mockContainerExec
         .mockReturnValueOnce(Promise.resolve({ output: "ERROR 1", exitCode: 126 }))
         .mockReturnValueOnce(Promise.resolve({ output: "ERROR 2", exitCode: 126 }))
         .mockReturnValueOnce(Promise.resolve({ output: "ERROR 2", exitCode: 126 }));
 
-      await portCheck.isBound(8080);
+      const result = await portCheck.isBound(8080);
 
-      expect(mockLogger.error.mock.calls).toEqual([
+      expect(result).toBe(true);
+      expect(mockLogger.debug.mock.calls).toEqual([
         [
-          "The HostPortWaitStrategy will not work on a distroless image, use an alternate wait strategy",
+          "No shell available in the container (distroless image) — deferring to the host port check",
           { containerId: "containerId" },
         ],
       ]);
+      expect(mockLogger.error).not.toHaveBeenCalled();
     });
 
-    it("should error log the distroless image once", async () => {
+    it("should debug log the distroless image once", async () => {
       mockContainerExec
         .mockReturnValueOnce(Promise.resolve({ output: "ERROR 1", exitCode: 126 }))
         .mockReturnValueOnce(Promise.resolve({ output: "ERROR 2", exitCode: 126 }))
@@ -128,18 +130,18 @@ describe.sequential("PortCheck", () => {
         .mockReturnValueOnce(Promise.resolve({ output: "ERROR 2", exitCode: 126 }))
         .mockReturnValueOnce(Promise.resolve({ output: "ERROR 2", exitCode: 126 }));
 
-      await portCheck.isBound(8080);
-      await portCheck.isBound(8080);
+      expect(await portCheck.isBound(8080)).toBe(true);
+      expect(await portCheck.isBound(8080)).toBe(true);
 
-      expect(mockLogger.error.mock.calls).toEqual([
+      expect(mockLogger.debug.mock.calls).toEqual([
         [
-          "The HostPortWaitStrategy will not work on a distroless image, use an alternate wait strategy",
+          "No shell available in the container (distroless image) — deferring to the host port check",
           { containerId: "containerId" },
         ],
       ]);
     });
 
-    it("should error log the distroless image once, regardless of logs enabled or not", async () => {
+    it("should debug log the distroless image once, regardless of logs enabled or not", async () => {
       // Make sure logging is disabled explicitly here
       mockLogger.enabled.mockImplementation(() => false);
 
@@ -151,27 +153,28 @@ describe.sequential("PortCheck", () => {
         .mockReturnValueOnce(Promise.resolve({ output: "ERROR 2", exitCode: 126 }))
         .mockReturnValueOnce(Promise.resolve({ output: "ERROR 2", exitCode: 126 }));
 
-      await portCheck.isBound(8080);
-      await portCheck.isBound(8080);
+      expect(await portCheck.isBound(8080)).toBe(true);
+      expect(await portCheck.isBound(8080)).toBe(true);
 
-      expect(mockLogger.error.mock.calls).toEqual([
+      expect(mockLogger.debug.mock.calls).toEqual([
         [
-          "The HostPortWaitStrategy will not work on a distroless image, use an alternate wait strategy",
+          "No shell available in the container (distroless image) — deferring to the host port check",
           { containerId: "containerId" },
         ],
       ]);
     });
 
-    it.for([126, 127])("should error log the distroless image when exit code is %i", async (code) => {
+    it.for([126, 127])("should return true and debug log when exit code is %i (no shell)", async (code) => {
       mockContainerExec.mockReturnValueOnce(Promise.resolve({ output: "ERROR 1", exitCode: code }));
       mockContainerExec.mockReturnValueOnce(Promise.resolve({ output: "ERROR 2", exitCode: code }));
       mockContainerExec.mockReturnValueOnce(Promise.resolve({ output: "ERROR 3", exitCode: code }));
 
-      await portCheck.isBound(8080);
+      const result = await portCheck.isBound(8080);
 
-      expect(mockLogger.error.mock.calls).toEqual([
+      expect(result).toBe(true);
+      expect(mockLogger.debug.mock.calls).toEqual([
         [
-          "The HostPortWaitStrategy will not work on a distroless image, use an alternate wait strategy",
+          "No shell available in the container (distroless image) — deferring to the host port check",
           { containerId: "containerId" },
         ],
       ]);

--- a/packages/testcontainers/src/wait-strategies/utils/port-check.ts
+++ b/packages/testcontainers/src/wait-strategies/utils/port-check.ts
@@ -71,11 +71,19 @@ export class InternalPortCheck implements PortCheck {
     // If a command is not found, the child process created to execute it returns a status of 127.
     // If a command is found but is not executable, the return status is 126.
     const shellExists = commandResults.some((result) => result.exitCode !== 126 && result.exitCode !== 127);
-    if (!isBound && !shellExists && !this.isDistroless) {
-      this.isDistroless = true;
-      log.error(`The HostPortWaitStrategy will not work on a distroless image, use an alternate wait strategy`, {
-        containerId: this.container.id,
-      });
+    if (!isBound && !shellExists) {
+      // No shell to run the probe commands (a distroless image) — this check can never observe the
+      // port as bound on its own. HostPortWaitStrategy runs this check in parallel with
+      // HostPortCheck (the host-side check, which needs no shell and already works against
+      // distroless images), so defer to it here instead of returning `false` and letting the
+      // caller's retry loop spin until it times out and rejects the whole wait.
+      if (!this.isDistroless) {
+        this.isDistroless = true;
+        log.debug(`No shell available in the container (distroless image) — deferring to the host port check`, {
+          containerId: this.container.id,
+        });
+      }
+      return true;
     }
 
     if (!isBound && log.enabled()) {


### PR DESCRIPTION
## What

`InternalPortCheck.isBound()` execs shell commands (`/bin/sh`, `nc`, `/bin/bash`) inside the container to check whether a port is bound. On a genuinely **distroless** image (no shell at all — e.g. a `-native` Quarkus/GraalVM build, or anything built `FROM gcr.io/distroless/*`), every one of those execs fails with exit 126/127, so `shellExists` is `false`. The current code detects this and logs an error, but still returns `isBound` — which in this branch is always `false` — so the caller keeps retrying.

That matters because `HostPortWaitStrategy.waitUntilReady()` runs `Promise.all([waitForHostPorts, waitForInternalPorts])`. `waitForInternalPorts` calls `waitForPort`, which retries `isBound()` until `startupTimeoutMs` and then **throws** `Port ${port} not bound after ${startupTimeoutMs}ms` — which rejects the whole `Promise.all`, even though `waitForHostPorts` (running concurrently, using `HostPortCheck`, which needs no shell) may already show the port open. So `Wait.forListeningPorts()` can never succeed against a distroless image, no matter how long you wait — the wait always dies with the internal check's timeout.

This PR makes `InternalPortCheck.isBound()` return `true` immediately once it detects it has no shell, deferring entirely to the host-side check (which already works without a shell — that's the parallel branch that was silently racing the doomed internal one). The "no shell" log line moves from `error` to `debug`, since it's no longer an unhandled/unrecoverable condition.

## Why

We hit this running [Microcks](https://microcks.io/)' native image (`microcks-uber:*-native`, distroless) via `DockerComposeEnvironment` under Testcontainers — `Wait.forListeningPorts()` against it always timed out and rejected, even though the container was demonstrably up and the port reachable from the host. Traced it to this method.

## Testing

- Updated `port-check.test.ts`'s existing distroless-branch tests (previously only asserted the `log.error` call, not the return value) to assert `isBound()` now returns `true`, and that the log line moved to `debug`.
- Ran the full `port-check.test.ts` suite locally (`vitest run`) — 10/10 passing.
- Verified end-to-end against the real motivating image (Microcks native, digest-pinned) in our own repo: `Wait.forListeningPorts()` against that image failed with `Port 8080/tcp not bound after 15000ms` on unpatched `11.7.2`, and passed (~10s) with this same fix applied via `bun patch`. Happy to share that reproduction if useful — it's a `GenericContainer(...).withWaitStrategy(Wait.forListeningPorts()).start()` against `quay.io/microcks/microcks-uber:1.15.0-native@sha256:b36c02f9e52bd6dfad939bbbd75dfd3f27c3196a046caa34fabd82e76924f670`.

No behavior change for shell-bearing images — `shellExists` is unaffected, so this branch only triggers when there truly is no shell to run the probe commands.