### PR TITLE
Apply `withStartupTimeout()` to the port-binding pre-wait

### DIFF
--- a/packages/testcontainers/src/generic-container/generic-container.ts
+++ b/packages/testcontainers/src/generic-container/generic-container.ts
@@ -160,7 +160,11 @@ export class GenericContainer implements TestContainer {
     if (!inspectResult.State.Running) {
       log.debug("Reused container is not running, attempting to start it");
       await client.container.start(container);
-      inspectResult = await inspectContainerUntilPortsExposed(() => client.container.inspect(container), container.id);
+      inspectResult = await inspectContainerUntilPortsExposed(
+        () => client.container.inspect(container),
+        container.id,
+        this.startupTimeoutMs
+      );
     }
 
     const mappedInspectResult = mapInspectResult(inspectResult);
@@ -217,7 +221,8 @@ export class GenericContainer implements TestContainer {
 
     const inspectResult = await inspectContainerUntilPortsExposed(
       () => client.container.inspect(container),
-      container.id
+      container.id,
+      this.startupTimeoutMs
     );
     const mappedInspectResult = mapInspectResult(inspectResult);
     const boundPorts = BoundPorts.fromInspectResult(client.info.containerRuntime.hostIps, mappedInspectResult).filter(


### PR DESCRIPTION
Fixes #1446.

`GenericContainer.start()` waits for host port bindings (`inspectContainerUntilPortsExposed`) before the wait strategy runs, but neither call site passes `this.startupTimeoutMs`, so that pre-wait is always capped at the util's 10 s default and `withStartupTimeout()` does not apply to it.

This passes `this.startupTimeoutMs` at both call sites (`reuseContainer` and `startContainer`). When no startup timeout was configured the argument is `undefined` and the existing 10 s default still applies, so behaviour only changes for callers who explicitly asked for a longer budget.

Measured (12.1.0, six `postgres:18-alpine` containers starting concurrently on a 2-vCPU GitHub runner): port binding took up to 16.7 s and failed at 10 s despite `withStartupTimeout(120_000)`; with this change the same suite passes.

Verified locally on the branch: `npm ci` → 0, `tsc -p packages/testcontainers/tsconfig.json --noEmit` → 0, eslint → 0, prettier → 0. The Docker-backed integration suite was not run here.
