### PR TITLE
Only reuse reaper containers created by testcontainers-node

### DIFF
--- a/packages/testcontainers/src/reaper/reaper-discovery.docker.test.ts
+++ b/packages/testcontainers/src/reaper/reaper-discovery.docker.test.ts
@@ -1,0 +1,39 @@
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { ContainerRuntimeClient, getContainerRuntimeClient } from "../container-runtime";
+import { GenericContainer } from "../generic-container/generic-container";
+import { LABEL_TESTCONTAINERS_LANG, LABEL_TESTCONTAINERS_RYUK } from "../utils/labels";
+import { findReaperContainers } from "./reaper";
+
+describe("Reaper discovery against a shared host", () => {
+  let client: ContainerRuntimeClient;
+  let dockerAvailable = true;
+
+  beforeAll(async () => {
+    try {
+      client = await getContainerRuntimeClient();
+      await client.container.list();
+    } catch {
+      dockerAvailable = false;
+    }
+  });
+
+  it("does not adopt a reaper container started by another language binding (#1442)", async () => {
+    if (!dockerAvailable) return;
+
+    const foreignReaper = await new GenericContainer("alpine:3.20")
+      .withCommand(["sleep", "60"])
+      .withLabels({
+        [LABEL_TESTCONTAINERS_RYUK]: "true",
+        [LABEL_TESTCONTAINERS_LANG]: "python",
+      })
+      .start();
+
+    try {
+      const result = await findReaperContainers(client);
+      expect(result.map((container) => container.Id)).not.toContain(foreignReaper.getId());
+    } finally {
+      await foreignReaper.stop({ timeout: 1000 });
+    }
+  });
+});

--- a/packages/testcontainers/src/reaper/reaper-discovery.test.ts
+++ b/packages/testcontainers/src/reaper/reaper-discovery.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { ContainerInfo } from "dockerode";
+import { ContainerRuntimeClient } from "../container-runtime";
+import { LABEL_TESTCONTAINERS_LANG, LABEL_TESTCONTAINERS_RYUK, LABEL_TESTCONTAINERS_SESSION_ID } from "../utils/labels";
+import { findReaperContainers } from "./reaper";
+
+function stubClient(containers: Partial<ContainerInfo>[]): ContainerRuntimeClient {
+  return { container: { list: async () => containers as ContainerInfo[] } } as unknown as ContainerRuntimeClient;
+}
+
+function reaperFixture(id: string, labels: Record<string, string>, state = "running"): Partial<ContainerInfo> {
+  return {
+    Id: id,
+    State: state,
+    Labels: {
+      [LABEL_TESTCONTAINERS_RYUK]: "true",
+      ...labels,
+    },
+    Created: 123,
+  };
+}
+
+describe("findReaperContainers", () => {
+  it("does not adopt reapers started by other language bindings (#1442)", async () => {
+    const foreignReaper = reaperFixture("foreign", { [LABEL_TESTCONTAINERS_LANG]: "python" });
+    const nodeReaper = reaperFixture("node", {
+      [LABEL_TESTCONTAINERS_LANG]: "node",
+      [LABEL_TESTCONTAINERS_SESSION_ID]: "0123456789ab",
+    });
+
+    const result = await findReaperContainers(stubClient([foreignReaper, nodeReaper]));
+
+    expect(result.map((container) => container.Id)).toEqual(["node"]);
+  });
+
+  it("does not adopt a reaper without an identifiable session id", async () => {
+    const anonymousReaper = reaperFixture("anonymous", { [LABEL_TESTCONTAINERS_LANG]: "node" });
+
+    const result = await findReaperContainers(stubClient([anonymousReaper]));
+
+    expect(result).toEqual([]);
+  });
+
+  it("does not adopt non-running containers or test reapers", async () => {
+    const stoppedReaper = reaperFixture(
+      "stopped",
+      {
+        [LABEL_TESTCONTAINERS_LANG]: "node",
+        [LABEL_TESTCONTAINERS_SESSION_ID]: "0123456789ab",
+      },
+      "exited"
+    );
+    const testReaper = reaperFixture("test", {
+      [LABEL_TESTCONTAINERS_LANG]: "node",
+      [LABEL_TESTCONTAINERS_SESSION_ID]: "0123456789ab",
+      TESTCONTAINERS_RYUK_TEST_LABEL: "true",
+    });
+
+    const result = await findReaperContainers(stubClient([stoppedReaper, testReaper]));
+
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/testcontainers/src/reaper/reaper-discovery.ts
+++ b/packages/testcontainers/src/reaper/reaper-discovery.ts
@@ -1,0 +1,27 @@
+import { ContainerInfo } from "dockerode";
+
+import { LABEL_TESTCONTAINERS_LANG, LABEL_TESTCONTAINERS_RYUK, LABEL_TESTCONTAINERS_SESSION_ID } from "../utils/labels";
+
+const LABEL_TESTCONTAINERS_RYUK_TEST_LABEL = "TESTCONTAINERS_RYUK_TEST_LABEL";
+
+/**
+ * Decides whether a running Ryuk container can be adopted by this binding's
+ * session. A reaper is only adoptable when this binding can actually own the
+ * session it watches:
+ *
+ * - it must have been started by this library, which labels everything it
+ *   creates with `org.testcontainers.lang: "node"` (see `createLabels()`), and
+ * - it must carry its session id in a durable label. Ryuk containers started
+ *   by other language bindings carry neither, and adopting them used to mint
+ *   a fresh session id per worker that no reaper ever owned — leaking every
+ *   container created under it (see issue #1442).
+ */
+export function isAdoptableReaperContainer(container: ContainerInfo): boolean {
+  return (
+    container.State === "running" &&
+    container.Labels[LABEL_TESTCONTAINERS_RYUK] === "true" &&
+    container.Labels[LABEL_TESTCONTAINERS_RYUK_TEST_LABEL] !== "true" &&
+    container.Labels[LABEL_TESTCONTAINERS_LANG] === "node" &&
+    typeof container.Labels[LABEL_TESTCONTAINERS_SESSION_ID] === "string"
+  );
+}

--- a/packages/testcontainers/src/reaper/reaper.ts
+++ b/packages/testcontainers/src/reaper/reaper.ts
@@ -4,8 +4,9 @@ import { userInfo } from "os";
 import { IntervalRetry, log, RandomUuid, withFileLock } from "../common";
 import { ContainerRuntimeClient, ImageName } from "../container-runtime";
 import { GenericContainer } from "../generic-container/generic-container";
-import { LABEL_TESTCONTAINERS_RYUK, LABEL_TESTCONTAINERS_SESSION_ID } from "../utils/labels";
+import { LABEL_TESTCONTAINERS_SESSION_ID } from "../utils/labels";
 import { Wait } from "../wait-strategies/wait";
+import { isAdoptableReaperContainer } from "./reaper-discovery";
 
 /**
  * Resolve the Ryuk reaper image name. Read lazily so that callers (and tests)
@@ -68,16 +69,9 @@ export async function getReaper(client: ContainerRuntimeClient): Promise<Reaper>
   return reaper;
 }
 
-async function findReaperContainers(client: ContainerRuntimeClient): Promise<ContainerInfo[]> {
+export async function findReaperContainers(client: ContainerRuntimeClient): Promise<ContainerInfo[]> {
   const containers = await client.container.list();
-  return containers
-    .filter(
-      (container) =>
-        container.State === "running" &&
-        container.Labels[LABEL_TESTCONTAINERS_RYUK] === "true" &&
-        container.Labels["TESTCONTAINERS_RYUK_TEST_LABEL"] !== "true"
-    )
-    .sort((a, b) => b.Created - a.Created);
+  return containers.filter(isAdoptableReaperContainer).sort((a, b) => b.Created - a.Created);
 }
 
 async function useExistingReaper(reaperContainer: ContainerInfo, sessionId: string, host: string): Promise<Reaper> {


### PR DESCRIPTION
Fixes #1442

## Problem

`findReaperContainers` matched **any** running Ryuk on the host. On a CI host shared between a `testcontainers-node` project and e.g. a `testcontainers-python` project, Node workers adopted the Python binding's reaper. A foreign reaper carries no `org.testcontainers.session-id` label, so every worker fell into

```ts
const existingSessionId = reaperContainer.Labels[LABEL_TESTCONTAINERS_SESSION_ID] ?? new RandomUuid().nextUuid();
```

and minted a fresh per-worker session id — asking the adopted reaper to watch a session it was never durably told about. Every container created under those ids leaks once the run ends (measured 13/13 and 23/23 reproductions in the issue).

## Fix

Extract the adoption predicate into `reaper-discovery.ts` and narrow it so this binding only adopts a reaper it can actually own:

- require `org.testcontainers.lang === "node"` — this library already writes that label on everything it creates via `createLabels()`;
- require a durable `org.testcontainers.session-id` label on the reaper container — adopting a reaper whose session cannot be identified is precisely the step that silently broke reaping.

A reaper that fails the predicate is left to the binding that owns it, and the Node run starts its own reaper instead.

## Verification (red-green, per AGENTS.md)

New `reaper-discovery.test.ts` exercises the extracted predicate with stub clients (no Docker needed):

- **Red** (pre-fix logic, only `export` added): 2 failed / 1 passed — the foreign-reaper fixture was adopted and the anonymous-reaper fixture triggered the random-id mint.
- **Green** (after the predicate change): 3 passed / 0 failed, covering foreign-reaper rejection, unidentifiable-session rejection, and the preserved non-running/test-label exclusions.

Additionally `reaper-discovery.docker.test.ts` adds a Docker-gated integration case (starts an `alpine` container labeled as a foreign binding's reaper and asserts it is not adopted); it runs in CI and skips automatically when no Docker daemon is reachable.

- `tsc --noEmit` clean, prettier/eslint clean on all touched files.
- `reaper.test.ts` unchanged and still Docker-gated as before (fails locally only due to no Docker daemon, same as on `main`).

## Notes

- Local install required `--engine-strict=false` because the dev dependency `npm-check-updates@23.0.0` demands node `^24.15.0` while the repo itself requires `>= 22.22` — no repository files were changed for this.
- Cross-binding behavior follows the de-facto reference implementations: bindings only share a reaper they can identify as their own.